### PR TITLE
feat: Enhance URL state validation with input sanitization and valida…

### DIFF
--- a/src/app/store/searchStore.ts
+++ b/src/app/store/searchStore.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  sanitizeString,
+  validateStringArray,
+  isValidDifficulty,
+  isValidSortOption,
+  validateNumericRange,
+} from '@/utils/searchUtils';
 
 export type Difficulty = 'beginner' | 'intermediate' | 'advanced';
 export type SortOption = 'relevance' | 'newest' | 'rating' | 'price';
@@ -95,34 +102,43 @@ export const useSearchStore = create<SearchStore>()(
 
         const difficulty = params.get('difficulty');
         if (difficulty) {
-          newState.difficulty = difficulty.split(',') as Difficulty[];
+          const validated = difficulty
+            .split(',')
+            .map(sanitizeString)
+            .filter(isValidDifficulty);
+          if (validated.length) newState.difficulty = validated;
         }
 
         const duration = params.get('duration');
         if (duration) {
-          const [min, max] = duration.split(',').map(Number);
-          newState.duration = [min, max];
+          const parts = duration.split(',').map(Number);
+          const validated = validateNumericRange(parts[0], parts[1], 0, 100);
+          if (validated) newState.duration = validated;
         }
 
         const topics = params.get('topics');
         if (topics) {
-          newState.topics = topics.split(',');
+          const validated = validateStringArray(topics.split(','));
+          if (validated.length) newState.topics = validated;
         }
 
         const instructors = params.get('instructors');
         if (instructors) {
-          newState.instructors = instructors.split(',');
+          const validated = validateStringArray(instructors.split(','));
+          if (validated.length) newState.instructors = validated;
         }
 
         const sort = params.get('sort');
         if (sort) {
-          newState.sortBy = sort as SortOption;
+          const sanitized = sanitizeString(sort);
+          if (isValidSortOption(sanitized)) newState.sortBy = sanitized;
         }
 
         const price = params.get('price');
         if (price) {
-          const [min, max] = price.split(',').map(Number);
-          newState.price = [min, max];
+          const parts = price.split(',').map(Number);
+          const validated = validateNumericRange(parts[0], parts[1], 0, 10000);
+          if (validated) newState.price = validated;
         }
 
         set(newState);

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -2,6 +2,41 @@
  * Search Utilities for Advanced Search Interface
  */
 
+const VALID_DIFFICULTIES = ['beginner', 'intermediate', 'advanced'] as const;
+const VALID_SORT_OPTIONS = ['relevance', 'newest', 'rating', 'price'] as const;
+const MAX_STRING_LENGTH = 100;
+const MAX_ARRAY_SIZE = 50;
+
+export const sanitizeString = (value: string): string =>
+  value
+    .trim()
+    .replace(/[\x00-\x1F\x7F]/g, '')
+    .slice(0, MAX_STRING_LENGTH);
+
+export const validateStringArray = (values: string[]): string[] =>
+  values.map(sanitizeString).filter(Boolean).slice(0, MAX_ARRAY_SIZE);
+
+export const isValidDifficulty = (
+  v: string,
+): v is 'beginner' | 'intermediate' | 'advanced' =>
+  (VALID_DIFFICULTIES as readonly string[]).includes(v);
+
+export const isValidSortOption = (
+  v: string,
+): v is 'relevance' | 'newest' | 'rating' | 'price' =>
+  (VALID_SORT_OPTIONS as readonly string[]).includes(v);
+
+export const validateNumericRange = (
+  rawMin: number,
+  rawMax: number,
+  lowerBound: number,
+  upperBound: number,
+): [number, number] | null => {
+  if (!Number.isFinite(rawMin) || !Number.isFinite(rawMax)) return null;
+  if (rawMin < lowerBound || rawMax > upperBound || rawMin > rawMax) return null;
+  return [rawMin, rawMax];
+};
+
 export type SearchContentType = 'all' | 'post' | 'profile' | 'topic' | 'course' | 'tutorial';
 
 export interface SearchResult {
@@ -61,7 +96,9 @@ export const parseAdvancedQuery = (query: string) => {
 
   parts.forEach((part) => {
     if (part.includes(':')) {
-      const [key, value] = part.split(':');
+      const colonIdx = part.indexOf(':');
+      const key = part.slice(0, colonIdx);
+      const value = part.slice(colonIdx + 1);
       switch (key.toLowerCase()) {
         case 'author':
           result.author = value;


### PR DESCRIPTION
Summary
Added validation utilities (sanitizeString, validateStringArray, isValidDifficulty, isValidSortOption, validateNumericRange) to searchUtils.ts
Updated updateFromUrl in searchStore.ts to validate and sanitize all URL params before applying them to store state
Fixed parseAdvancedQuery edge case where values containing colons (e.g. author:john:doe) were silently truncated
What was broken
updateFromUrl applied URL params directly to the store with no validation:

difficulty and sortBy were cast with as Type — any arbitrary string was accepted
duration and price used Number() with no NaN or range checks, allowing the store to hold [NaN, NaN]
topics and instructors accepted empty strings and unbounded input
How it's fixed
Invalid or malformed params now fall through silently — the store falls back to initialState defaults instead of being corrupted. String values are trimmed, stripped of control characters, and length-capped before use.

Test plan
 Valid params (e.g. ?difficulty=beginner,advanced&sort=newest) load correctly
 Unknown difficulty values (e.g. ?difficulty=expert) are ignored, store stays at default
 Malformed numeric ranges (e.g. ?price=abc,xyz or ?duration=100,-5) are rejected
 Empty/blank array values (e.g. ?topics=,,) are filtered out
 Unknown sort values (e.g. ?sort=random) fall back to relevance
Closes #178 

