### PR TITLE
feat: Implement input sanitization for XSS protection in MediaEmbedde…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "validate": "npm run validate:ui && npm run validate:web3",
     "check-locales": "node scripts/check-locales.mjs",
     "prebuild": "npm run check-locales && npm run check-i18n"
-    "validate": "npm run validate:ui && npm run validate:web3"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -59,6 +58,7 @@
     "tailwind-merge": "^2.6.0",
     "web-vitals": "^4.2.4",
     "workbox-webpack-plugin": "^7.0.0",
+    "dompurify": "^3.2.4",
     "zod": "^3.25.75",
     "zustand": "^5.0.10"
   },
@@ -72,6 +72,7 @@
     "@types/chai": "^5.2.3",
     "@types/d3-array": "^3.2.2",
     "@types/d3-color": "^3.1.3",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^18.3.27",
     "@types/react-dom": "^18.3.7",

--- a/src/components/editor/MediaEmbedder.tsx
+++ b/src/components/editor/MediaEmbedder.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Image as ImageIcon, Youtube as YoutubeIcon, Link as LinkIcon } from 'lucide-react';
+import { sanitizeUrl } from '@/utils/sanitize';
 
 interface MediaEmbedderProps {
   onAddImage: (url: string) => void;
@@ -10,13 +11,20 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
   const [isOpen, setIsOpen] = useState(false);
   const [url, setUrl] = useState('');
   const [type, setType] = useState<'image' | 'youtube'>('image');
+  const [urlError, setUrlError] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const safeUrl = sanitizeUrl(url);
+    if (!safeUrl) {
+      setUrlError('Only http and https URLs are allowed.');
+      return;
+    }
+    setUrlError('');
     if (type === 'image') {
-      onAddImage(url);
+      onAddImage(safeUrl);
     } else {
-      onAddYoutube(url);
+      onAddYoutube(safeUrl);
     }
     setUrl('');
     setIsOpen(false);
@@ -59,11 +67,12 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
           <input
             type="url"
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            onChange={(e) => { setUrl(e.target.value); setUrlError(''); }}
             placeholder={`Enter ${type} URL...`}
-            className="w-full p-2 border rounded mb-4 dark:bg-gray-700 dark:border-gray-600"
+            className="w-full p-2 border rounded mb-1 dark:bg-gray-700 dark:border-gray-600"
             required
           />
+          <p className="text-red-500 text-sm mb-3 min-h-[1.25rem]">{urlError}</p>
           <div className="flex justify-end gap-2">
             <button
               type="button"

--- a/src/hooks/useContentEditor.tsx
+++ b/src/hooks/useContentEditor.tsx
@@ -5,6 +5,7 @@ import Youtube from '@tiptap/extension-youtube';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import { useState, useCallback } from 'react';
+import { sanitizeHtml, sanitizeUrl } from '@/utils/sanitize';
 
 interface UseContentEditorProps {
   initialContent?: string;
@@ -33,9 +34,9 @@ export const useContentEditor = ({
       }),
     ],
     immediatelyRender: false,
-    content: initialContent,
+    content: sanitizeHtml(initialContent),
     onUpdate: ({ editor }) => {
-      const html = editor.getHTML();
+      const html = sanitizeHtml(editor.getHTML());
       if (onUpdate) {
         onUpdate(html);
       }
@@ -51,8 +52,9 @@ export const useContentEditor = ({
 
   const addImage = useCallback(
     (url: string) => {
-      if (url && editor) {
-        editor.chain().focus().setImage({ src: url }).run();
+      const safeUrl = sanitizeUrl(url);
+      if (safeUrl && editor) {
+        editor.chain().focus().setImage({ src: safeUrl }).run();
       }
     },
     [editor],
@@ -60,9 +62,10 @@ export const useContentEditor = ({
 
   const addYoutubeVideo = useCallback(
     (url: string) => {
-      if (url && editor) {
+      const safeUrl = sanitizeUrl(url);
+      if (safeUrl && editor) {
         editor.commands.setYoutubeVideo({
-          src: url,
+          src: safeUrl,
           width: 640,
           height: 480,
         });

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,22 @@
+import DOMPurify from 'dompurify';
+
+const SAFE_URL_SCHEMES = ['http:', 'https:'];
+
+export const sanitizeHtml = (html: string): string => {
+  if (typeof window === 'undefined') return html;
+  return DOMPurify.sanitize(html, {
+    ADD_TAGS: ['iframe'],
+    ADD_ATTR: ['allowfullscreen', 'frameborder', 'data-youtube-video'],
+  });
+};
+
+export const sanitizeUrl = (url: string): string | null => {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    return SAFE_URL_SCHEMES.includes(parsed.protocol) ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
Summary
Added sanitizeHtml and sanitizeUrl utilities in src/utils/sanitize.ts using DOMPurify
Sanitized initialContent on load and getHTML() output on every editor update in useContentEditor
Validated image and YouTube URLs against an http/https allowlist before inserting into the editor
Added URL validation with user-facing error message in MediaEmbedder form handler
Fixed pre-existing malformed package.json (missing comma + duplicate script key) that was breaking all npm commands
What was vulnerable
initialContent was loaded into TipTap without sanitization — a stored XSS payload would be parsed directly into the editor
editor.getHTML() was passed unsanitized to the onUpdate consumer and from there to storage/display
addImage and addYoutubeVideo accepted any URL, including javascript: and data: schemes, and set them as src attributes
MediaEmbedder submitted raw user-typed URLs directly to the editor commands with no validation
How it's fixed
All HTML content passes through DOMPurify before it enters or leaves the editor. URLs are parsed and rejected at the point of entry if they don't use http: or https:. The MediaEmbedder surfaces a clear error to the user instead of silently accepting a bad URL.

Test plan
 Paste <script>alert(1)</script> into initialContent — editor loads without executing
 Type <img src=x onerror=alert(1)> in the editor — onUpdate output is stripped clean
 Enter javascript:alert(1) as an image URL in MediaEmbedder — form shows error and does not embed
 Enter data:text/html,<script>alert(1)</script> as a YouTube URL — rejected at hook level
 Valid https:// image and YouTube URLs embed correctly as before
Closes #164 

