### PR TITLE
refactor: simplify question components by removing isReviewMode prop …

### DIFF
--- a/src/app/components/quizzes/QuestionCard.tsx
+++ b/src/app/components/quizzes/QuestionCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Question, useQuizStore } from '@/app/store/quizStore';
+import { Question } from '@/app/store/quizStore';
 import MultipleChoiceQuestion from './question-types/MultipleChoiceQuestion';
 import TrueFalseQuestion from './question-types/TrueFalseQuestion';
 import dynamic from 'next/dynamic';
@@ -15,16 +15,14 @@ interface QuestionCardProps {
 }
 
 export default function QuestionCard({ question }: QuestionCardProps) {
-  const { isReviewMode } = useQuizStore();
-
   const renderQuestion = () => {
     switch (question.type) {
       case 'multiple-choice':
-        return <MultipleChoiceQuestion question={question} isReviewMode={isReviewMode} />;
+        return <MultipleChoiceQuestion question={question} />;
       case 'true-false':
-        return <TrueFalseQuestion question={question} isReviewMode={isReviewMode} />;
+        return <TrueFalseQuestion question={question} />;
       case 'code-challenge':
-        return <CodeChallengeQuestion question={question} isReviewMode={isReviewMode} />;
+        return <CodeChallengeQuestion question={question} />;
       default:
         return <div>Unsupported question type</div>;
     }

--- a/src/app/components/quizzes/question-types/CodeChallengeQuestion.tsx
+++ b/src/app/components/quizzes/question-types/CodeChallengeQuestion.tsx
@@ -7,14 +7,10 @@ import { FaCheck, FaTimes, FaPlay } from 'react-icons/fa';
 
 interface CodeChallengeQuestionProps {
   question: Question;
-  isReviewMode: boolean;
 }
 
-export default function CodeChallengeQuestion({
-  question,
-  isReviewMode,
-}: CodeChallengeQuestionProps) {
-  const { answers, setAnswer } = useQuizStore();
+export default function CodeChallengeQuestion({ question }: CodeChallengeQuestionProps) {
+  const { answers, setAnswer, isReviewMode } = useQuizStore();
   const [code, setCode] = useState(answers[question.id] || question.codeTemplate || '');
   const [testResults, setTestResults] = useState<boolean[]>([]);
   const [isRunning, setIsRunning] = useState(false);

--- a/src/app/components/quizzes/question-types/MultipleChoiceQuestion.tsx
+++ b/src/app/components/quizzes/question-types/MultipleChoiceQuestion.tsx
@@ -5,14 +5,10 @@ import { FaCheck, FaTimes } from 'react-icons/fa';
 
 interface MultipleChoiceQuestionProps {
   question: Question;
-  isReviewMode: boolean;
 }
 
-export default function MultipleChoiceQuestion({
-  question,
-  isReviewMode,
-}: MultipleChoiceQuestionProps) {
-  const { answers, setAnswer } = useQuizStore();
+export default function MultipleChoiceQuestion({ question }: MultipleChoiceQuestionProps) {
+  const { answers, setAnswer, isReviewMode } = useQuizStore();
   const selectedAnswer = answers[question.id];
   const handleOptionSelect = (optionId: string) => {
     if (!isReviewMode) {

--- a/src/app/components/quizzes/question-types/TrueFalseQuestion.tsx
+++ b/src/app/components/quizzes/question-types/TrueFalseQuestion.tsx
@@ -5,11 +5,10 @@ import { FaCheck, FaTimes } from 'react-icons/fa';
 
 interface TrueFalseQuestionProps {
   question: Question;
-  isReviewMode: boolean;
 }
 
-export default function TrueFalseQuestion({ question, isReviewMode }: TrueFalseQuestionProps) {
-  const { answers, setAnswer } = useQuizStore();
+export default function TrueFalseQuestion({ question }: TrueFalseQuestionProps) {
+  const { answers, setAnswer, isReviewMode } = useQuizStore();
   const selectedAnswer = answers[question.id];
   const correctAnswer = question.correctAnswer;
 

--- a/src/app/components/video/AdvancedVideoPlayer.tsx
+++ b/src/app/components/video/AdvancedVideoPlayer.tsx
@@ -25,6 +25,7 @@ import { VideoBookmarks } from './VideoBookmarks';
 import { TranscriptView } from './TranscriptView';
 import { clamp, formatTime } from '@/utils/videoUtils';
 import { usePlaybackAnalytics } from './PlaybackAnalytics';
+import { VideoPlayerContext } from './VideoPlayerContext';
 
 export type VideoQualityOption = {
   label: string;
@@ -351,7 +352,27 @@ export function AdvancedVideoPlayer(props: AdvancedVideoPlayerProps) {
   const seekBarCurrentWidth = duration > 0 ? `${(currentTime / duration) * 100}%` : '0%';
   const seekBarBufferedWidth = duration > 0 ? `${(buffered / duration) * 100}%` : '0%';
 
+  const videoPlayerContextValue = {
+    lessonId,
+    userId,
+    transcript,
+    currentTime,
+    duration,
+    playbackRate,
+    autoQuality,
+    selectedQualityValue,
+    qualitiesForControls,
+    seekToLearning,
+    setPlaybackRateLearning,
+    setQualityLearning,
+    setAutoQualityLearning,
+    onBookmark: (b: { time: number; title: string; note?: string }) =>
+      analytics.registerBookmarkAdded(b.time),
+    onNote: (n: { time: number; text: string }) => analytics.registerNoteAdded(n.time),
+  };
+
   return (
+    <VideoPlayerContext.Provider value={videoPlayerContextValue}>
     <div
       ref={containerRef}
       className={`relative bg-black rounded-lg overflow-hidden group ${className}`}
@@ -562,17 +583,7 @@ export function AdvancedVideoPlayer(props: AdvancedVideoPlayerProps) {
               </div>
             </div>
 
-            <PlaybackControls
-              playbackRate={playbackRate}
-              onPlaybackRateChange={setPlaybackRateLearning}
-              qualities={qualitiesForControls}
-              quality={
-                qualitiesForControls ? (autoQuality ? undefined : selectedQualityValue) : undefined
-              }
-              autoQuality={autoQuality}
-              onAutoQualityChange={qualitiesForControls ? setAutoQualityLearning : undefined}
-              onQualityChange={qualitiesForControls ? setQualityLearning : undefined}
-            />
+            <PlaybackControls />
 
             <div className="mt-2 text-xs text-white/80 flex items-center justify-between">
               <span>Watched: {Math.round(analytics.snapshot.watchSeconds)}s</span>
@@ -592,14 +603,7 @@ export function AdvancedVideoPlayer(props: AdvancedVideoPlayerProps) {
               exit={{ x: 300 }}
               className="w-80 bg-white shadow-lg"
             >
-              <VideoBookmarks
-                currentTime={currentTime}
-                duration={duration}
-                lessonId={lessonId}
-                userId={userId}
-                onSeek={seekToLearning}
-                onBookmark={(b) => analytics.registerBookmarkAdded(b.time)}
-              />
+              <VideoBookmarks />
             </motion.div>
           )}
         </AnimatePresence>
@@ -612,11 +616,7 @@ export function AdvancedVideoPlayer(props: AdvancedVideoPlayerProps) {
               exit={{ x: 300 }}
               className="w-80 bg-white shadow-lg"
             >
-              <TranscriptView
-                transcript={transcript}
-                currentTime={currentTime}
-                onSeek={seekToLearning}
-              />
+              <TranscriptView />
             </motion.div>
           )}
         </AnimatePresence>
@@ -629,16 +629,12 @@ export function AdvancedVideoPlayer(props: AdvancedVideoPlayerProps) {
               exit={{ x: 300 }}
               className="w-80 bg-white shadow-lg"
             >
-              <VideoNotes
-                currentTime={currentTime}
-                lessonId={lessonId}
-                userId={userId}
-                onNote={(n) => analytics.registerNoteAdded(n.time)}
-              />
+              <VideoNotes />
             </motion.div>
           )}
         </AnimatePresence>
       </div>
     </div>
+    </VideoPlayerContext.Provider>
   );
 }

--- a/src/app/components/video/PlaybackControls.tsx
+++ b/src/app/components/video/PlaybackControls.tsx
@@ -1,40 +1,30 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Settings, ChevronDown } from 'lucide-react';
+import { useVideoPlayerContext } from './VideoPlayerContext';
 
-interface QualityOption {
-  label: string;
-  value: string;
-  width?: number;
-  height?: number;
-  bitrate?: number;
-}
+const DEFAULT_QUALITIES = [
+  { label: 'Auto', value: 'auto', width: 0, height: 0 },
+  { label: '1080p', value: '1080p', width: 1920, height: 1080, bitrate: 5000 },
+  { label: '720p', value: '720p', width: 1280, height: 720, bitrate: 2500 },
+  { label: '480p', value: '480p', width: 854, height: 480, bitrate: 1000 },
+  { label: '360p', value: '360p', width: 640, height: 360, bitrate: 500 },
+];
 
-interface PlaybackControlsProps {
-  playbackRate: number;
-  onPlaybackRateChange: (rate: number) => void;
-  quality?: string;
-  onQualityChange?: (quality: string) => void;
-  qualities?: QualityOption[];
-  autoQuality?: boolean;
-  onAutoQualityChange?: (auto: boolean) => void;
-}
+export const PlaybackControls: React.FC = () => {
+  const {
+    playbackRate,
+    setPlaybackRateLearning: onPlaybackRateChange,
+    autoQuality,
+    selectedQualityValue,
+    qualitiesForControls,
+    setQualityLearning: onQualityChange,
+    setAutoQualityLearning: onAutoQualityChange,
+  } = useVideoPlayerContext();
 
-export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
-  playbackRate,
-  onPlaybackRateChange,
-  quality,
-  onQualityChange,
-  qualities = [
-    { label: 'Auto', value: 'auto', width: 0, height: 0 },
-    { label: '1080p', value: '1080p', width: 1920, height: 1080, bitrate: 5000 },
-    { label: '720p', value: '720p', width: 1280, height: 720, bitrate: 2500 },
-    { label: '480p', value: '480p', width: 854, height: 480, bitrate: 1000 },
-    { label: '360p', value: '360p', width: 640, height: 360, bitrate: 500 },
-  ],
-  autoQuality = true,
-  onAutoQualityChange,
-}) => {
+  const qualities = qualitiesForControls ?? DEFAULT_QUALITIES;
+  const quality = autoQuality ? undefined : selectedQualityValue;
+
   const [showSpeedMenu, setShowSpeedMenu] = useState(false);
   const [showQualityMenu, setShowQualityMenu] = useState(false);
 
@@ -82,7 +72,7 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
       </div>
 
       {/* Quality Control */}
-      {onQualityChange && (
+      {qualitiesForControls && (
         <div className="relative">
           <div className="flex items-center space-x-2">
             <button

--- a/src/app/components/video/TranscriptView.tsx
+++ b/src/app/components/video/TranscriptView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
+import { useVideoPlayerContext } from './VideoPlayerContext';
 
 // Inline SVG Icons to replace lucide-react
 const ClockIcon = ({ size = 24, className = '' }) => (
@@ -41,14 +42,8 @@ interface TranscriptEntry {
   speaker?: string;
 }
 
-interface TranscriptViewProps {
-  transcript: TranscriptEntry[];
-  currentTime: number;
-  onSeek: (time: number) => void;
-}
-
-export const TranscriptView: React.FC<TranscriptViewProps> = React.memo(
-  ({ transcript, currentTime, onSeek }) => {
+export const TranscriptView: React.FC = React.memo(() => {
+  const { transcript, currentTime, seekToLearning: onSeek } = useVideoPlayerContext();
     const containerRef = useRef<HTMLDivElement>(null);
     const activeEntryRef = useRef<HTMLDivElement>(null);
 
@@ -161,7 +156,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = React.memo(
                             e.stopPropagation();
                             onSeek(entry.time);
                           }}
-                          className={`flex-shrink-0 p-1 rounded-full transition-colors self-start mt-1 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500 ${
+                          className={`shrink-0 p-1 rounded-full transition-colors self-start mt-1 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500 ${
                             isActive
                               ? 'bg-blue-500 text-white'
                               : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
@@ -207,7 +202,6 @@ export const TranscriptView: React.FC<TranscriptViewProps> = React.memo(
           </div>
         </div>
       </div>
-    );
-  },
-);
+  );
+});
 TranscriptView.displayName = 'TranscriptView';

--- a/src/app/components/video/VideoBookmarks.tsx
+++ b/src/app/components/video/VideoBookmarks.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Bookmark, Clock, Edit2, Trash2, Plus } from 'lucide-react';
 import { apiClient } from '@/lib/api';
 import { formatTime, generateId, getVideoStorageKey } from '@/utils/videoUtils';
+import { useVideoPlayerContext } from './VideoPlayerContext';
 
 type PersistedVideoBookmark = {
   id: string;
@@ -15,15 +16,15 @@ type PersistedVideoBookmark = {
   updatedAt: string; // ISO
 };
 
-export function VideoBookmarks(props: {
-  lessonId: string;
-  userId?: string;
-  currentTime: number;
-  duration: number;
-  onSeek: (time: number) => void;
-  onBookmark?: (bookmark: { time: number; title: string; note?: string }) => void;
-}) {
-  const { lessonId, userId, currentTime, duration, onSeek, onBookmark } = props;
+export function VideoBookmarks() {
+  const {
+    lessonId,
+    userId,
+    currentTime,
+    duration,
+    seekToLearning: onSeek,
+    onBookmark,
+  } = useVideoPlayerContext();
 
   const storageKey = useMemo(
     () => getVideoStorageKey({ kind: 'bookmarks', userId, lessonId }),

--- a/src/app/components/video/VideoNotes.tsx
+++ b/src/app/components/video/VideoNotes.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Clock, MessageSquare, Edit2, Trash2, Save } from 'lucide-react';
 import { apiClient } from '@/lib/api';
 import { formatTime, generateId, getVideoStorageKey } from '@/utils/videoUtils';
+import { useVideoPlayerContext } from './VideoPlayerContext';
 
 type PersistedVideoNote = {
   id: string;
@@ -14,13 +15,8 @@ type PersistedVideoNote = {
   updatedAt: string; // ISO
 };
 
-export function VideoNotes(props: {
-  lessonId: string;
-  userId?: string;
-  currentTime: number;
-  onNote?: (note: { time: number; text: string }) => void;
-}) {
-  const { lessonId, userId, currentTime, onNote } = props;
+export function VideoNotes() {
+  const { lessonId, userId, currentTime, onNote } = useVideoPlayerContext();
 
   const storageKey = useMemo(
     () => getVideoStorageKey({ kind: 'notes', userId, lessonId }),

--- a/src/app/components/video/VideoPlayerContext.tsx
+++ b/src/app/components/video/VideoPlayerContext.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export interface VideoQualityControlOption {
+  label: string;
+  value: string;
+  width?: number;
+  height?: number;
+  bitrate?: number;
+}
+
+export interface VideoPlayerContextValue {
+  lessonId: string;
+  userId?: string;
+  transcript: Array<{ time: number; text: string; speaker?: string }>;
+  currentTime: number;
+  duration: number;
+  playbackRate: number;
+  autoQuality: boolean;
+  selectedQualityValue: string;
+  qualitiesForControls?: VideoQualityControlOption[];
+  seekToLearning: (time: number) => void;
+  setPlaybackRateLearning: (rate: number) => void;
+  setQualityLearning: (value: string) => void;
+  setAutoQualityLearning: (auto: boolean) => void;
+  onBookmark: (bookmark: { time: number; title: string; note?: string }) => void;
+  onNote: (note: { time: number; text: string }) => void;
+}
+
+export const VideoPlayerContext = createContext<VideoPlayerContextValue | null>(null);
+
+export const useVideoPlayerContext = (): VideoPlayerContextValue => {
+  const ctx = useContext(VideoPlayerContext);
+  if (!ctx) throw new Error('useVideoPlayerContext must be used within AdvancedVideoPlayer');
+  return ctx;
+};


### PR DESCRIPTION
Summary
Created VideoPlayerContext to share video player state across panel components, eliminating 20 drilled props across 4 components
Removed isReviewMode prop from all three question type components — they now read it directly from useQuizStore which they were already calling
Net result: -34 lines across 9 modified files, zero-prop signatures on all video panel components
What was wrong
Quiz flow:
QuestionCard read isReviewMode from useQuizStore() and passed it as a prop to MultipleChoiceQuestion, TrueFalseQuestion, and CodeChallengeQuestion — all three of which already called useQuizStore() themselves for answers and setAnswer. The prop was unnecessary.

Video player:
AdvancedVideoPlayer was forwarding 20 props total into its four side-panel children (PlaybackControls, VideoBookmarks, TranscriptView, VideoNotes):

currentTime, duration, lessonId, userId — state that belongs to the player, not the panels
onSeek, onBookmark, onNote — callbacks wrapping analytics calls
playbackRate, autoQuality, selectedQualityValue, qualitiesForControls + quality/rate setters
Every new panel or deeper child would have required threading these props further down.

How it's fixed
A VideoPlayerContext is provided at the AdvancedVideoPlayer root. Each panel component calls useVideoPlayerContext() and reads only what it needs. Adding new panels in the future requires no changes to the parent.

The quiz fix is simpler — isReviewMode is already in the store the components are consuming; the drilled prop was just removed.

Test plan
 Quiz: answer selection and review feedback still work correctly for all three question types (multiple choice, true/false, code challenge)
 Quiz: completing a quiz and entering review mode still highlights correct/incorrect answers
 Video: playback speed control changes rate correctly
 Video: quality selector switches source and respects auto-quality toggle
 Video: bookmarks panel shows current time, seek-to works, add/edit/delete persist
 Video: transcript panel highlights the active entry and seek-on-click works
 Video: notes panel saves and deletes notes at the correct timestamp
 Using VideoPlayerContext outside AdvancedVideoPlayer throws a clear error
Closes #172 