### PR TITLE
Feat/169 mobile gesture fix

### DIFF
--- a/src/components/mobile/GestureHandler.tsx
+++ b/src/components/mobile/GestureHandler.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useState, useEffect } from 'react';
 import { useMobileGestures } from '../../hooks/useMobileGestures';
 
 interface GestureHandlerProps extends HTMLAttributes<HTMLDivElement> {
@@ -25,7 +25,34 @@ export const GestureHandler: React.FC<GestureHandlerProps> = ({
   children,
   ...props
 }) => {
-  const gestureProps = useMobileGestures({
+  const [isIOS, setIsIOS] = useState(false);
+  const [gesturesEnabled, setGesturesEnabled] = useState(true);
+
+  useEffect(() => {
+    // Detect iOS devices (iPhone, iPad, iPod) and iPadOS (MacIntel with touch)
+    const checkIOS = () => {
+      const userAgent = window.navigator.userAgent.toLowerCase();
+      const isIOSDevice = /iphone|ipad|ipod/.test(userAgent) || 
+                          (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      return isIOSDevice;
+    };
+    
+    const isIOSBrowser = checkIOS();
+    setIsIOS(isIOSBrowser);
+    
+    // Disable custom gestures by default on iOS to prevent conflicts with native swipe-to-go-back
+    if (isIOSBrowser) {
+      setGesturesEnabled(false);
+    }
+  }, []);
+
+  const toggleGestures = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setGesturesEnabled(prev => !prev);
+  };
+
+  const activeGestures = gesturesEnabled ? {
     onSwipeLeft,
     onSwipeRight,
     onSwipeUp,
@@ -34,10 +61,27 @@ export const GestureHandler: React.FC<GestureHandlerProps> = ({
     onPinchOut,
     onTap,
     swipeThreshold,
-  });
+  } : { swipeThreshold };
+
+  const gestureProps = useMobileGestures(activeGestures);
+
+  const touchActionStyle = gesturesEnabled ? 'pan-y' : 'auto';
 
   return (
-    <div {...gestureProps} {...props} style={{ touchAction: 'pan-y', ...props.style }}>
+    <div {...gestureProps} {...props} style={{ touchAction: touchActionStyle, position: 'relative', ...props.style }}>
+      {isIOS && (
+        <div className="absolute top-2 right-2 z-50 pointer-events-auto">
+          <button
+            onClick={toggleGestures}
+            className="bg-gray-800 text-white text-xs px-3 py-1.5 rounded-full shadow-lg opacity-70 hover:opacity-100 transition-opacity border border-gray-600 flex items-center gap-2"
+            title={gesturesEnabled ? "Disable Custom Gestures" : "Enable Custom Gestures"}
+            type="button"
+          >
+            <div className={`w-2 h-2 rounded-full ${gesturesEnabled ? 'bg-green-400' : 'bg-red-400'}`}></div>
+            {gesturesEnabled ? "Gestures On" : "Gestures Off"}
+          </button>
+        </div>
+      )}
       {children}
     </div>
   );

--- a/src/components/mobile/GestureHandler.tsx
+++ b/src/components/mobile/GestureHandler.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes, useState, useEffect } from 'react';
 import { useMobileGestures } from '../../hooks/useMobileGestures';
+import { ToggleLeft, ToggleRight } from 'lucide-react';
 
 interface GestureHandlerProps extends HTMLAttributes<HTMLDivElement> {
   onSwipeLeft?: () => void;
@@ -77,7 +78,7 @@ export const GestureHandler: React.FC<GestureHandlerProps> = ({
             title={gesturesEnabled ? "Disable Custom Gestures" : "Enable Custom Gestures"}
             type="button"
           >
-            <div className={`w-2 h-2 rounded-full ${gesturesEnabled ? 'bg-green-400' : 'bg-red-400'}`}></div>
+            {gesturesEnabled ? <ToggleRight size={16} className="text-green-400" /> : <ToggleLeft size={16} className="text-red-400" />}
             {gesturesEnabled ? "Gestures On" : "Gestures Off"}
           </button>
         </div>


### PR DESCRIPTION
#closes #169 


Description This PR resolves the ongoing gesture conflicts between our custom mobile swipe handlers and native iOS browser navigation gestures (e.g., swipe-to-go-back/forward in Safari).

It introduces browser detection for iOS devices and automatically defaults to disabling custom swipe gestures on those devices, thereby preserving native browser navigation. Additionally, a dynamic toggle UI powered by lucide-react icons has been implemented, granting users explicit control to enable or disable custom gestures when needed.

Changes Included

Added browser user-agent detection to accurately identify iOS and iPadOS environments.
Automatically disabled custom useMobileGestures default behavior for iOS devices to prevent native swipe-to-navigate conflict.
Implemented a floating, intuitive toggle button (using Tailwind CSS) allowing users to switch custom gestures on or off.
Used ToggleLeft and ToggleRight from lucide-react within the toggle button to adhere to design consistency rules.
Set touchAction to dynamically switch between pan-y and auto based on the gesture enablement state.


Checklist:

 Feature aligns with roadmap/issue description.
 UI is working as expected with no console errors.
 Used lucide-react icons for consistent usage throughout the app.
 Styled utilizing Tailwind CSS with a responsive/accessible design.
 Tested locally via iOS simulation.
Testing Instructions for Reviewers:

Checkout this branch and run npm run dev.
Open the application using an iOS device, or emulate an iOS device using Chrome DevTools (ensure you refresh the page after toggling device emulation).
Verify that the "Gestures Off" toggle is visible in the top right corner of gesture-enabled areas.
Try a left-to-right swipe along the edge. The native browser back action should trigger without conflict.
Tap the toggle to switch to "Gestures On". Swiping should now successfully fire the app's custom gesture events instead of the native action.

#closes