### PR TITLE
fix: add missing cleanup for event listeners and debounce timer

### DIFF
--- a/src/hooks/usePWA.tsx
+++ b/src/hooks/usePWA.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -17,6 +17,7 @@ export const usePWA = () => {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null);
   const [isOffline, setIsOffline] = useState(false);
+  const updateFoundHandlerRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     // Check if app is already installed
@@ -41,15 +42,17 @@ export const usePWA = () => {
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
 
     // Track installation
-    window.addEventListener('appinstalled', () => {
+    const handleAppInstalled = () => {
       setIsInstalled(true);
       setInstallPrompt(null);
-    });
+    };
+    window.addEventListener('appinstalled', handleAppInstalled);
 
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
       window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
     };
   }, []);
 
@@ -59,7 +62,7 @@ export const usePWA = () => {
         const reg = await navigator.serviceWorker.register('/serviceWorker.js');
         setRegistration(reg);
 
-        reg.addEventListener('updatefound', () => {
+        const handleUpdateFound = () => {
           const newWorker = reg.installing;
           if (newWorker) {
             newWorker.addEventListener('statechange', () => {
@@ -68,12 +71,22 @@ export const usePWA = () => {
               }
             });
           }
-        });
+        };
+        updateFoundHandlerRef.current = handleUpdateFound;
+        reg.addEventListener('updatefound', handleUpdateFound);
       } catch (error) {
         console.error('Service worker registration failed:', error);
       }
     }
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (registration && updateFoundHandlerRef.current) {
+        registration.removeEventListener('updatefound', updateFoundHandlerRef.current);
+      }
+    };
+  }, [registration]);
 
   const installApp = async () => {
     if (!installPrompt) return;

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 export interface SearchResult {
   id: string;
@@ -73,6 +73,12 @@ export function useSearch<T extends SearchResult>(
     setNextCursor(undefined);
     setHasMore(false);
     setError(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
   }, []);
 
   return { query, updateQuery, results, isLoading, error, hasMore, loadMore, reset };


### PR DESCRIPTION
## Summary

- **`usePWA`**: Named the `appinstalled` inline handler so it can be passed to `removeEventListener` in the effect cleanup
- **`usePWA`**: Stored the `updatefound` handler in a ref (`updateFoundHandlerRef`) and added a `useEffect` that removes the listener from the `ServiceWorkerRegistration` on unmount
- **`useSearch`**: Added a `useEffect` cleanup that clears the pending debounce timer on unmount, preventing a state update on an unmounted component

## Test plan

- [ ] Mount/unmount a component using `usePWA` — no `appinstalled` or `updatefound` listeners should remain attached
- [ ] Type in a search field then unmount quickly — no state-update-on-unmounted-component warning in the console

Closes #190