### PR TITLE
feat(css): add print stylesheets for clean page printing

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       {/* Header */}
-      <header className="bg-white dark:bg-gray-900 shadow-sm border-b dark:border-gray-800">
+      <header className="no-print bg-white dark:bg-gray-900 shadow-sm border-b dark:border-gray-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,11 @@
 @import 'tailwindcss';
+@import '../styles/print.css';
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+}
 
 :root {
   --background: #ffffff;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ export const Header: React.FC = () => {
   };
 
   return (
-    <header className="bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 sticky top-0 z-40 transition-colors duration-200">
+    <header className="no-print bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 sticky top-0 z-40 transition-colors duration-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 gap-4">
           {/* Logo */}
@@ -73,6 +73,13 @@ export const Header: React.FC = () => {
             >
               {t('navigation.dashboard')}
             </Link>
+            <button
+              onClick={() => window.print()}
+              className="no-print px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-sm"
+              aria-label="Print this page"
+            >
+              Print
+            </button>
           </nav>
 
           {/* Theme Toggle, Language Switcher and Mobile Menu Button */}

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,105 @@
+@media print {
+  /* ── Hide screen-only elements ─────────────────────────────────────── */
+  nav,
+  header,
+  footer,
+  aside,
+  button,
+  dialog,
+  [role='dialog'],
+  [role='tooltip'],
+  [data-radix-popper-content-wrapper],
+  [data-print='false'],
+  [class*='no-print'],
+  .no-print {
+    display: none !important;
+  }
+
+  /* ── Page setup ────────────────────────────────────────────────────── */
+  @page {
+    margin: 1.5cm;
+  }
+
+  /* ── Reset layout ──────────────────────────────────────────────────── */
+  *,
+  *::before,
+  *::after {
+    background: #fff !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    gap: 0 !important;
+  }
+
+  html,
+  body {
+    width: 100%;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    font-size: 12pt;
+    line-height: 1.5;
+  }
+
+  body > *,
+  main,
+  article,
+  section,
+  .container,
+  [class*='max-w-'],
+  [class*='mx-auto'] {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    float: none !important;
+  }
+
+  /* ── Page-break rules ──────────────────────────────────────────────── */
+  h1,
+  h2,
+  h3,
+  tr {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  h1,
+  h2,
+  h3 {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  img,
+  table,
+  figure {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* ── Show link URLs ────────────────────────────────────────────────── */
+  a[href]::after {
+    content: ' (' attr(href) ')';
+    font-size: 10pt;
+    color: #444 !important;
+  }
+
+  /* Don't expand internal/anchor links or javascript: links */
+  a[href^='#']::after,
+  a[href^='javascript:']::after {
+    content: '';
+  }
+
+  /* ── Tables ────────────────────────────────────────────────────────── */
+  table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  th,
+  td {
+    border: 1px solid #999 !important;
+    padding: 4pt 6pt;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
Closes #275  

## Description
Brief description of changes

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed

Implements issue #275 — Print Stylesheets.
  
  Adds a dedicated print stylesheet so pages render cleanly when printed or saved as PDF, with no screen-only chrome visible.
  
  ## Changes
  
  - **`src/styles/print.css`** — New `@media print` stylesheet:
    - Hides `nav`, `header`, `footer`, `aside`, `button`, `dialog`, tooltips, and any element with `.no-print` or `data-print="false"`
    - Resets layout to single-column, full-width, no flex/grid gaps
    - Sets font to serif, 12pt, `#000` on `#fff`
    - Prevents page breaks inside `h1`, `h2`, `h3`, `tr`
    - Appends link URLs after anchor text via `a[href]::after`
    - Removes `box-shadow` and `border-radius` from all elements
    - Sets `@page` margins to 1.5cm
  
  - **`src/app/globals.css`** — Imports `print.css`; adds `.no-print { display: none !important }` utility under `@media print`
  
  - **`src/components/layout/Header.tsx`** — Added `no-print` class to `<header>`; added Print button (`window.print()`) styled as a secondary action
  button in the desktop nav
  
  - **`src/app/dashboard/page.tsx`** — Added `no-print` class to the inline `<header>`
  
  ## No logic changes
  
  Only CSS additions and className updates. No component logic was modified.
  
