### PR TITLE
feat: implement responsive images (#255)

### DIFF
--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Image, { type ImageProps } from 'next/image';
+import { useState } from 'react';
+import { SIZES, type CDNProvider, type ImageOptimizerOptions, getOptimizedUrl } from '@/lib/image-optimizer';
+
+export interface ResponsiveImageProps
+  extends Omit<ImageProps, 'src' | 'onError'> {
+  src: string;
+  fallbackSrc?: string;
+  /** CDN provider for URL transformation (default: 'next') */
+  provider?: CDNProvider;
+  /** Optimizer options forwarded to the CDN builder */
+  optimizerOptions?: ImageOptimizerOptions;
+  /** Predefined sizes shorthand or a custom sizes string */
+  responsiveSizes?: keyof typeof SIZES | string;
+  /** Wrapper className */
+  containerClassName?: string;
+}
+
+/**
+ * ResponsiveImage — wraps next/image with:
+ * - Automatic WebP/AVIF via Next.js image optimization
+ * - Optional Cloudinary / Imgix CDN URL building
+ * - Native lazy loading (loading="lazy" by default)
+ * - Graceful fallback on error
+ * - Accessible alt text enforcement
+ */
+export function ResponsiveImage({
+  src,
+  fallbackSrc = '/images/placeholder.png',
+  provider = 'next',
+  optimizerOptions,
+  responsiveSizes,
+  containerClassName,
+  alt,
+  sizes,
+  priority = false,
+  className,
+  ...props
+}: ResponsiveImageProps) {
+  const [imgSrc, setImgSrc] = useState(() =>
+    provider !== 'next' ? getOptimizedUrl(src, optimizerOptions, provider) : src
+  );
+
+  const resolvedSizes =
+    sizes ??
+    (responsiveSizes
+      ? (SIZES[responsiveSizes as keyof typeof SIZES] ?? responsiveSizes)
+      : SIZES.full);
+
+  return (
+    <div className={containerClassName}>
+      <Image
+        {...props}
+        src={imgSrc}
+        alt={alt}
+        sizes={resolvedSizes}
+        priority={priority}
+        loading={priority ? undefined : 'lazy'}
+        className={className}
+        onError={() => setImgSrc(fallbackSrc)}
+      />
+    </div>
+  );
+}
+
+export default ResponsiveImage;

--- a/src/lib/image-optimizer/index.ts
+++ b/src/lib/image-optimizer/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Image optimizer utilities for responsive image delivery.
+ * Supports Next.js built-in optimization, Cloudinary, and Imgix CDNs.
+ */
+
+export type ImageFormat = 'auto' | 'webp' | 'avif' | 'jpg' | 'png';
+
+export interface ImageOptimizerOptions {
+  width?: number;
+  height?: number;
+  quality?: number;
+  format?: ImageFormat;
+}
+
+export type CDNProvider = 'next' | 'cloudinary' | 'imgix';
+
+const DEFAULT_QUALITY = 75;
+
+/**
+ * Build a Cloudinary URL with transformation parameters.
+ * Requires NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME env var.
+ */
+function buildCloudinaryUrl(src: string, opts: ImageOptimizerOptions): string {
+  const cloudName = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+  if (!cloudName) return src;
+
+  const transforms: string[] = ['f_auto', 'q_auto'];
+  if (opts.width) transforms.push(`w_${opts.width}`);
+  if (opts.height) transforms.push(`h_${opts.height}`);
+  if (opts.quality) transforms.push(`q_${opts.quality}`);
+
+  return `https://res.cloudinary.com/${cloudName}/image/fetch/${transforms.join(',')}/${src}`;
+}
+
+/**
+ * Build an Imgix URL with transformation parameters.
+ * Requires NEXT_PUBLIC_IMGIX_DOMAIN env var.
+ */
+function buildImgixUrl(src: string, opts: ImageOptimizerOptions): string {
+  const domain = process.env.NEXT_PUBLIC_IMGIX_DOMAIN;
+  if (!domain) return src;
+
+  const params = new URLSearchParams({ auto: 'format,compress' });
+  if (opts.width) params.set('w', String(opts.width));
+  if (opts.height) params.set('h', String(opts.height));
+  if (opts.quality) params.set('q', String(opts.quality));
+
+  const path = src.startsWith('http') ? encodeURIComponent(src) : src;
+  return `https://${domain}/${path}?${params.toString()}`;
+}
+
+/**
+ * Returns an optimized image URL for the given CDN provider.
+ * Falls back to the original src when no CDN is configured.
+ */
+export function getOptimizedUrl(
+  src: string,
+  opts: ImageOptimizerOptions = {},
+  provider: CDNProvider = 'next'
+): string {
+  const options = { quality: DEFAULT_QUALITY, ...opts };
+
+  switch (provider) {
+    case 'cloudinary':
+      return buildCloudinaryUrl(src, options);
+    case 'imgix':
+      return buildImgixUrl(src, options);
+    default:
+      return src; // Next.js handles optimization natively via <Image>
+  }
+}
+
+/**
+ * Generate a srcset string for a given set of widths.
+ */
+export function buildSrcSet(
+  src: string,
+  widths: number[],
+  opts: Omit<ImageOptimizerOptions, 'width'> = {},
+  provider: CDNProvider = 'next'
+): string {
+  return widths
+    .map((w) => `${getOptimizedUrl(src, { ...opts, width: w }, provider)} ${w}w`)
+    .join(', ');
+}
+
+/** Common responsive sizes attribute values */
+export const SIZES = {
+  full: '100vw',
+  half: '(min-width: 768px) 50vw, 100vw',
+  third: '(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw',
+  avatar: '(min-width: 768px) 96px, 64px',
+} as const;


### PR DESCRIPTION
## Summary

Closes #255

Implements responsive image support to fix oversized images being served to mobile users.

## Changes

### `src/lib/image-optimizer/index.ts`
- `getOptimizedUrl()` — builds CDN-transformed URLs for Cloudinary and Imgix; falls back to original src for Next.js native optimization
- `buildSrcSet()` — generates a `srcset` string for a given set of widths
- `SIZES` — predefined responsive `sizes` attribute values (full, half, third, avatar)

### `src/components/ResponsiveImage.tsx`
- Wraps `next/image` (which handles WebP/AVIF automatically via `next.config.ts`)
- Native lazy loading (`loading="lazy"`) by default; disabled when `priority` is set
- Optional Cloudinary / Imgix CDN URL building via `provider` prop
- Graceful `fallbackSrc` on image load error
- Accessible: enforces `alt` prop

## How to use

```tsx
// Basic (Next.js native optimization)
<ResponsiveImage src="/hero.jpg" alt="Hero" width={1200} height={600} />

// With predefined sizes
<ResponsiveImage src="/card.jpg" alt="Card" width={400} height={300} responsiveSizes="half" />

// With Cloudinary CDN
<ResponsiveImage
  src="https://example.com/photo.jpg"
  alt="Photo"
  width={800}
  height={600}
  provider="cloudinary"
  optimizerOptions={{ quality: 80 }}
/>
```

## Acceptance Criteria
- [x] Images serve appropriate size for device (via `srcset` + `sizes`)
- [x] Lazy loading enabled by default
- [x] WebP/AVIF format support (Next.js `image.formats` already configured)
- [x] CDN integration (Cloudinary, Imgix)
- [x] No console errors — graceful fallback on broken images