### PR TITLE
chore: improve screen reader support for input fields

### DIFF
--- a/src/app/components/accessibility/README.md
+++ b/src/app/components/accessibility/README.md
@@ -286,6 +286,14 @@ console.log(issues);
 9. **Test with real assistive technologies**
 10. **Include focus indicators** for all interactive elements
 
+### Form Input Screen Reader Support
+
+- Use the shared `FormInput` components for new text fields, selects, and textareas where possible.
+- Pass visible `label` text so the component can create an explicit `label`/`id` relationship.
+- Pass `helperText` for persistent instructions; validation errors are linked to fields automatically.
+- Use `required` for required fields so both browser validation and `aria-required` stay in sync.
+- Keep decorative icons non-interactive; password visibility controls expose their current state to assistive technology.
+
 ## Browser Support
 
 - Chrome/Edge 90+

--- a/src/app/components/auth/FormInput.tsx
+++ b/src/app/components/auth/FormInput.tsx
@@ -2,13 +2,14 @@
 
 import { motion } from 'framer-motion';
 import { Eye, EyeOff } from 'lucide-react';
-import { useState, InputHTMLAttributes, forwardRef } from 'react';
+import { useId, useState, InputHTMLAttributes, forwardRef } from 'react';
 import { FieldError } from '../../../components/forms/FormError';
 
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   error?: string;
   icon?: React.ReactNode;
+  helperText?: React.ReactNode;
 }
 
 export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
@@ -18,6 +19,10 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
       error,
       icon,
       type,
+      id,
+      required,
+      helperText,
+      'aria-describedby': ariaDescribedBy,
       onDrag,
       onDragStart,
       onDragEnd,
@@ -32,10 +37,16 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
     void onDragEnd;
     void onAnimationStart;
     void onAnimationEnd;
+    const generatedId = useId();
     const [showPassword, setShowPassword] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
 
     const inputType = type === 'password' && showPassword ? 'text' : type;
+    const inputId = id ?? `auth-input-${generatedId}`;
+    const helperTextId = helperText ? `${inputId}-helper` : undefined;
+    const errorId = error ? `${inputId}-error` : undefined;
+    const describedBy =
+      [ariaDescribedBy, helperTextId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
       <motion.div
@@ -44,16 +55,29 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
         transition={{ duration: 0.3 }}
         className="w-full"
       >
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
           {label}
         </label>
         <div className="relative">
           {icon && (
-            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">{icon}</div>
+            <div
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+              aria-hidden="true"
+            >
+              {icon}
+            </div>
           )}
           <motion.input
             ref={ref}
+            id={inputId}
             type={inputType}
+            required={required}
+            aria-invalid={!!error}
+            aria-required={required}
+            aria-describedby={describedBy}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             animate={{
@@ -72,13 +96,25 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
             <button
               type="button"
               onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? `Hide ${label}` : `Show ${label}`}
+              aria-pressed={showPassword}
+              aria-controls={inputId}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             >
-              {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+              {showPassword ? (
+                <EyeOff size={20} aria-hidden="true" />
+              ) : (
+                <Eye size={20} aria-hidden="true" />
+              )}
             </button>
           )}
         </div>
-        <FieldError error={error} />
+        {helperText && (
+          <p id={helperTextId} className="mt-1.5 text-sm text-gray-500 dark:text-gray-400 ml-1">
+            {helperText}
+          </p>
+        )}
+        <FieldError error={error} id={errorId} />
       </motion.div>
     );
   },

--- a/src/app/components/auth/__tests__/FormInput.test.tsx
+++ b/src/app/components/auth/__tests__/FormInput.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FormInput } from '../FormInput';
+
+describe('Auth FormInput', () => {
+  it('associates label, helper text, and required state with the input', () => {
+    render(
+      <FormInput
+        label="Email"
+        name="email"
+        type="email"
+        required
+        helperText="Use the email connected to your account."
+      />,
+    );
+
+    const input = screen.getByRole('textbox', {
+      name: 'Email',
+      description: 'Use the email connected to your account.',
+    });
+
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute('aria-required', 'true');
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('links validation errors to the input for screen readers', () => {
+    render(
+      <FormInput
+        label="Email"
+        name="email"
+        type="email"
+        error="Enter a valid email address."
+        helperText="Use the email connected to your account."
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Email' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid email address.');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAccessibleDescription(
+      'Use the email connected to your account. Enter a valid email address.',
+    );
+  });
+
+  it('exposes password visibility controls with name, state, and controlled input', () => {
+    render(<FormInput label="Password" name="password" type="password" />);
+
+    const input = screen.getByLabelText('Password');
+    const toggle = screen.getByRole('button', { name: 'Show Password' });
+
+    expect(input).toHaveAttribute('type', 'password');
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', input.id);
+
+    fireEvent.click(toggle);
+
+    expect(input).toHaveAttribute('type', 'text');
+    expect(screen.getByRole('button', { name: 'Hide Password' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+});

--- a/src/components/forms/FormInput.tsx
+++ b/src/components/forms/FormInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useId } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { LucideIcon } from 'lucide-react';
 
@@ -12,6 +12,7 @@ interface FormInputProps
   as?: 'input' | 'textarea' | 'select';
   children?: React.ReactNode; // For select options
   rows?: number; // Explicitly add rows for textarea
+  helperText?: React.ReactNode;
 }
 
 /**
@@ -25,8 +26,13 @@ export const FormInput: React.FC<FormInputProps> = ({
   children,
   className = '',
   rows,
+  id,
+  required,
+  helperText,
+  'aria-describedby': ariaDescribedBy,
   ...props
 }) => {
+  const generatedId = useId();
   const {
     register,
     formState: { errors },
@@ -34,6 +40,11 @@ export const FormInput: React.FC<FormInputProps> = ({
 
   const error = errors[name];
   const isError = !!error;
+  const inputId = id ?? `${name}-${generatedId}`;
+  const helperTextId = helperText ? `${inputId}-helper` : undefined;
+  const errorId = isError ? `${inputId}-error` : undefined;
+  const describedBy =
+    [ariaDescribedBy, helperTextId, errorId].filter(Boolean).join(' ') || undefined;
 
   const baseStyles = `
     w-full pl-${Icon ? '10' : '4'} pr-4 py-2.5 
@@ -46,12 +57,18 @@ export const FormInput: React.FC<FormInputProps> = ({
 
   return (
     <div className="space-y-2">
-      <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
+      <label
+        htmlFor={inputId}
+        className="block text-sm font-semibold text-gray-700 dark:text-gray-300"
+      >
         {label}
       </label>
       <div className="relative group">
         {Icon && (
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <div
+            className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
+            aria-hidden="true"
+          >
             <Icon
               className={`h-5 w-5 ${
                 isError ? 'text-red-400' : 'text-gray-400 group-focus-within:text-blue-500'
@@ -63,25 +80,52 @@ export const FormInput: React.FC<FormInputProps> = ({
         {as === 'textarea' ? (
           <textarea
             {...(register(name) as any)}
+            id={inputId}
+            aria-invalid={isError}
+            aria-required={required}
+            aria-describedby={describedBy}
             className={`${baseStyles} resize-none ${className}`}
             rows={rows}
+            required={required}
             {...(props as any)}
           />
         ) : as === 'select' ? (
           <select
             {...(register(name) as any)}
+            id={inputId}
+            aria-invalid={isError}
+            aria-required={required}
+            aria-describedby={describedBy}
             className={`${baseStyles} ${className}`}
+            required={required}
             {...(props as any)}
           >
             {children}
           </select>
         ) : (
-          <input {...register(name)} className={`${baseStyles} ${className}`} {...(props as any)} />
+          <input
+            {...register(name)}
+            id={inputId}
+            aria-invalid={isError}
+            aria-required={required}
+            aria-describedby={describedBy}
+            className={`${baseStyles} ${className}`}
+            required={required}
+            {...(props as any)}
+          />
         )}
       </div>
 
+      {helperText && (
+        <p id={helperTextId} className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-1">
+          {helperText}
+        </p>
+      )}
+
       {isError && (
-        <p className="text-red-500 text-xs mt-1 ml-1 font-medium">{error.message as string}</p>
+        <p id={errorId} className="text-red-500 text-xs mt-1 ml-1 font-medium" role="alert">
+          {error.message as string}
+        </p>
       )}
     </div>
   );

--- a/src/components/forms/__tests__/FormInput.test.tsx
+++ b/src/components/forms/__tests__/FormInput.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+import { FormInput } from '../FormInput';
+
+function renderWithForm(ui: React.ReactNode, options: { error?: string } = {}) {
+  function Wrapper() {
+    const methods = useForm({ defaultValues: { email: '', bio: '', role: '' } });
+
+    useEffect(() => {
+      if (options.error) {
+        methods.setError('email', { type: 'manual', message: options.error });
+      }
+    }, [methods, options.error]);
+
+    return <FormProvider {...methods}>{ui}</FormProvider>;
+  }
+
+  return render(<Wrapper />);
+}
+
+describe('FormInput', () => {
+  it('associates the visible label and helper text with text inputs', () => {
+    renderWithForm(
+      <FormInput
+        name="email"
+        label="Email address"
+        type="email"
+        required
+        helperText="Use your school email address."
+      />,
+    );
+
+    const input = screen.getByRole('textbox', {
+      name: 'Email address',
+      description: 'Use your school email address.',
+    });
+
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute('aria-required', 'true');
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('announces validation errors through aria-describedby and alert role', async () => {
+    renderWithForm(
+      <FormInput
+        name="email"
+        label="Email address"
+        type="email"
+        helperText="Use your school email address."
+      />,
+      { error: 'Email address is required.' },
+    );
+
+    const error = await screen.findByRole('alert');
+    const input = screen.getByRole('textbox', { name: 'Email address' });
+
+    expect(error).toHaveTextContent('Email address is required.');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAccessibleDescription(
+      'Use your school email address. Email address is required.',
+    );
+  });
+
+  it('supports textarea and select fields with accessible names', () => {
+    renderWithForm(
+      <>
+        <FormInput name="bio" label="Biography" as="textarea" helperText="Keep it brief." />
+        <FormInput name="role" label="Role" as="select">
+          <option value="">Choose a role</option>
+          <option value="teacher">Teacher</option>
+        </FormInput>
+      </>,
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Biography' })).toHaveAccessibleDescription(
+      'Keep it brief.',
+    );
+    expect(screen.getByRole('combobox', { name: 'Role' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #523 

Changes made:
- Added explicit label/id, aria-describedby, aria-invalid, aria-required, helper text, and alert-linked errors in src/components/forms/FormInput.tsx:35.
- Added the same accessible wiring for auth inputs, plus labelled/stateful password visibility controls in src/app/components/auth/FormInput.tsx:40.
- Added regression tests covering labels, helper text, errors, textarea/select support, and password toggle semantics in src/components/forms/__tests__/FormInput.test.tsx:23 and src/app/components/auth/__tests__/FormInput.test.tsx:5.
- Documented usage guidance in src/app/components/accessibility/README.md:289.


Validation:
- Passed: pnpm exec vitest run src/components/forms/__tests__/FormInput.test.tsx src/app/components/auth/__tests__/FormInput.test.tsx
- Passed: Prettier check on touched files
- Blocked: pnpm run type-check fails on pre-existing syntax errors in src/components/assessment/AdaptiveTesting.tsx:43, src/components/assessment/QuestionTypes.tsx:97, and src/lib/api.ts:216.