### PR TITLE
Add dashboard analytics internationalization

### DIFF
--- a/scripts/validate-ui.cjs
+++ b/scripts/validate-ui.cjs
@@ -2,32 +2,24 @@
 
 /**
  * UI Validation Script
- * Checks for consistent icon usage and responsive Tailwind classes
+ * Checks for consistent icon usage and responsive Tailwind classes.
  * Exit code 0 = pass, 1 = fail
  */
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 const SRC_DIR = path.join(__dirname, '../src');
 const COMPONENT_DIRS = ['components', 'app', 'pages'];
 
-// Disallowed icon libraries (should use lucide-react)
 const DISALLOWED_ICONS = [
   { pattern: /from ['"]@heroicons\/react/g, name: '@heroicons/react' },
   { pattern: /from ['"]@fortawesome/g, name: '@fortawesome' },
   { pattern: /from ['"]react-feather/g, name: 'react-feather' },
 ];
 
-// Required responsive breakpoints for key layout patterns
-const RESPONSIVE_PATTERNS = [
-  { pattern: /\bflex\b/, shouldHave: ['sm:', 'md:', 'lg:'], context: 'flex layouts' },
-  { pattern: /\bgrid\b/, shouldHave: ['sm:', 'md:', 'lg:'], context: 'grid layouts' },
-];
-
-let errors = [];
-let warnings = [];
+const warnings = [];
+const errors = [];
 
 function getAllFiles(dir, extensions = ['.tsx', '.jsx', '.ts', '.js']) {
   let files = [];
@@ -42,7 +34,10 @@ function getAllFiles(dir, extensions = ['.tsx', '.jsx', '.ts', '.js']) {
 
     if (stat.isDirectory() && !item.startsWith('.') && item !== 'node_modules') {
       files = files.concat(getAllFiles(fullPath, extensions));
-    } else if (stat.isFile() && extensions.some((ext) => item.endsWith(ext))) {
+      continue;
+    }
+
+    if (stat.isFile() && extensions.some((ext) => item.endsWith(ext))) {
       files.push(fullPath);
     }
   }
@@ -57,21 +52,12 @@ function checkIconUsage(content, filePath) {
     }
   }
 
-  // Check for react-icons usage (warning, not error)
   if (/from ['"]react-icons/g.test(content)) {
     warnings.push(`[ICON] ${filePath}: Uses react-icons - prefer lucide-react for consistency`);
   }
 }
 
 function checkResponsiveTailwind(content, filePath) {
-  // Only check component files that have className
-  if (!content.includes('className')) return;
-
-  // Check for common layout patterns without responsive variants
-  const lines = content.split('\n');
-
-  lines.forEach((line, index) => {
-    // Check for grid/flex without any responsive classes
   if (!content.includes('className')) return;
 
   const lines = content.split('\n');
@@ -89,7 +75,6 @@ function checkResponsiveTailwind(content, filePath) {
 }
 
 function checkForConsoleStatements(content, filePath) {
-  // Allow console.warn and console.error, flag console.log
   const matches = content.match(/console\.log\(/g);
   if (matches && matches.length > 0) {
     warnings.push(`[CONSOLE] ${filePath}: Contains ${matches.length} console.log statement(s)`);
@@ -97,7 +82,7 @@ function checkForConsoleStatements(content, filePath) {
 }
 
 function validateFiles() {
-  console.log('🔍 Running UI validation checks...\n');
+  console.log('Running UI validation checks...\n');
 
   for (const dir of COMPONENT_DIRS) {
     const fullDir = path.join(SRC_DIR, dir);
@@ -116,35 +101,20 @@ function validateFiles() {
 
 function printResults() {
   if (warnings.length > 0) {
-    console.log('⚠️  Warnings:\n');
-    warnings.forEach((w) => console.log(`  ${w}`));
+    console.log('Warnings:\n');
+    warnings.forEach((warning) => console.log(`  ${warning}`));
     console.log('');
   }
 
   if (errors.length > 0) {
-    console.log('❌ Errors:\n');
-    errors.forEach((e) => console.log(`  ${e}`));
+    console.log('Errors:\n');
+    errors.forEach((error) => console.log(`  ${error}`));
     console.log('');
-    console.log(`\n❌ UI validation failed with ${errors.length} error(s)`);
+    console.log(`UI validation failed with ${errors.length} error(s)`);
     process.exit(1);
   }
 
-  console.log(`✅ UI validation passed (${warnings.length} warning(s))`);
-  process.exit(0);
-}
-
-// Run validation
-    console.log('\n[WARN] UI Validation Warnings:');
-    warnings.forEach((warning) => console.warn(`  - ${warning}`));
-  }
-
-  if (errors.length > 0) {
-    console.error('\n[ERROR] UI Validation Errors:');
-    errors.forEach((error) => console.error(`  - ${error}`));
-    process.exit(1);
-  }
-
-  console.log('\n[OK] UI validation passed');
+  console.log(`UI validation passed (${warnings.length} warning(s))`);
   process.exit(0);
 }
 

--- a/scripts/validate-web3.cjs
+++ b/scripts/validate-web3.cjs
@@ -2,7 +2,7 @@
 
 /**
  * Web3 Validation Script
- * Validates wallet provider setup and environment configuration
+ * Validates wallet provider setup and environment configuration.
  * Exit code 0 = pass, 1 = fail
  */
 
@@ -11,59 +11,51 @@ const path = require('path');
 
 const SRC_DIR = path.join(__dirname, '../src');
 
-let errors = [];
-let warnings = [];
+const warnings = [];
+const errors = [];
 
 function checkWalletProviderExists() {
   const providerPath = path.join(SRC_DIR, 'providers/WalletProvider.tsx');
 
   if (!fs.existsSync(providerPath)) {
     errors.push('[WEB3] WalletProvider.tsx not found in src/providers/');
-    return false;
+    return;
   }
 
   const content = fs.readFileSync(providerPath, 'utf-8');
 
-  // Check for error handling
   if (!content.includes('try') || !content.includes('catch')) {
     errors.push('[WEB3] WalletProvider should have try-catch error handling');
   }
 
-  // Check for SSR safety
   if (!content.includes('typeof window')) {
     warnings.push('[WEB3] WalletProvider should check for SSR (typeof window)');
   }
 
-  // Check for graceful fallback
   if (!content.includes('useContext') || !content.includes('null')) {
     warnings.push('[WEB3] useWallet hook should handle missing provider gracefully');
   }
-
-  return true;
 }
 
 function checkWeb3Utils() {
   const utilsPath = path.join(SRC_DIR, 'utils/web3/index.ts');
+  const envValidationPath = path.join(SRC_DIR, 'utils/web3/envValidation.ts');
 
   if (!fs.existsSync(utilsPath)) {
     errors.push('[WEB3] utils/web3/index.ts not found');
-    return false;
+    return;
   }
 
-  const envValidationPath = path.join(SRC_DIR, 'utils/web3/envValidation.ts');
   if (!fs.existsSync(envValidationPath)) {
     errors.push('[WEB3] utils/web3/envValidation.ts not found');
-    return false;
+    return;
   }
 
   const content = fs.readFileSync(envValidationPath, 'utf-8');
 
-  // Check for network validation
   if (!content.includes('NEXT_PUBLIC_STARKNET')) {
     warnings.push('[WEB3] Environment validation should check NEXT_PUBLIC_STARKNET_* vars');
   }
-
-  return true;
 }
 
 function checkEnvExample() {
@@ -76,42 +68,27 @@ function checkEnvExample() {
 }
 
 function printResults() {
-  console.log('🔍 Running Web3 validation checks...\n');
+  console.log('Running Web3 validation checks...\n');
 
   checkWalletProviderExists();
   checkWeb3Utils();
   checkEnvExample();
 
   if (warnings.length > 0) {
-    console.log('⚠️  Warnings:\n');
-    warnings.forEach((w) => console.log(`  ${w}`));
+    console.log('Warnings:\n');
+    warnings.forEach((warning) => console.log(`  ${warning}`));
     console.log('');
   }
 
   if (errors.length > 0) {
-    console.log('❌ Errors:\n');
-    errors.forEach((e) => console.log(`  ${e}`));
+    console.log('Errors:\n');
+    errors.forEach((error) => console.log(`  ${error}`));
     console.log('');
-    console.log(`\n❌ Web3 validation failed with ${errors.length} error(s)`);
+    console.log(`Web3 validation failed with ${errors.length} error(s)`);
     process.exit(1);
   }
 
-  console.log(`✅ Web3 validation passed (${warnings.length} warning(s))`);
-  process.exit(0);
-}
-
-// Run validation
-    console.log('\n[WARN] Web3 Validation Warnings:');
-    warnings.forEach((warning) => console.warn(`  - ${warning}`));
-  }
-
-  if (errors.length > 0) {
-    console.error('\n[ERROR] Web3 Validation Errors:');
-    errors.forEach((error) => console.error(`  - ${error}`));
-    process.exit(1);
-  }
-
-  console.log(`[OK] Web3 validation passed (${warnings.length} warning(s))`);
+  console.log(`Web3 validation passed (${warnings.length} warning(s))`);
   process.exit(0);
 }
 

--- a/src/components/dashboard/DashboardFilters.tsx
+++ b/src/components/dashboard/DashboardFilters.tsx
@@ -10,6 +10,14 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { Filter, X, RotateCcw } from 'lucide-react';
 import { TimeRange, AggregationType, CHART_COLOR_PALETTE } from '@/utils/visualizationUtils';
 import type { DashboardFiltersState } from '@/hooks/useDashboardData';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import {
+  getDashboardAggregationLabel,
+  getDashboardCategoryLabel,
+  getDashboardMetricLabel,
+  getDashboardTimeRangeLabel,
+  translateWithFallback,
+} from './dashboardI18n';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -24,21 +32,9 @@ export interface DashboardFiltersProps {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
-  { value: '7d', label: 'Last 7 Days' },
-  { value: '30d', label: 'Last 30 Days' },
-  { value: '90d', label: 'Last 90 Days' },
-  { value: '1y', label: 'Last Year' },
-  { value: 'all', label: 'All Time' },
-];
+const TIME_RANGE_OPTIONS: TimeRange[] = ['7d', '30d', '90d', '1y', 'all'];
 
-const AGGREGATION_OPTIONS: { value: AggregationType; label: string }[] = [
-  { value: 'sum', label: 'Sum' },
-  { value: 'average', label: 'Average' },
-  { value: 'count', label: 'Count' },
-  { value: 'min', label: 'Min' },
-  { value: 'max', label: 'Max' },
-];
+const AGGREGATION_OPTIONS: AggregationType[] = ['sum', 'average', 'count', 'min', 'max'];
 
 const DEFAULT_CATEGORIES = ['Web Dev', 'Data Science', 'Design', 'Marketing', 'Mobile'];
 const DEFAULT_METRICS = ['enrollments', 'revenue', 'completions', 'views'];
@@ -54,7 +50,29 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
     metrics = DEFAULT_METRICS,
     className = '',
   }) => {
+    const { t } = useInternationalization();
     const [isOpen, setIsOpen] = useState(false);
+
+    const timeRangeOptions = useMemo(
+      () =>
+        TIME_RANGE_OPTIONS.map((value) => ({
+          value,
+          label: getDashboardTimeRangeLabel(value, t),
+        })),
+      [t],
+    );
+
+    const aggregationOptions = useMemo(
+      () =>
+        AGGREGATION_OPTIONS.map((value) => ({
+          value,
+          label: getDashboardAggregationLabel(value, t),
+        })),
+      [t],
+    );
+
+    const getCategoryLabel = useCallback((category: string) => getDashboardCategoryLabel(category, t), [t]);
+    const getMetricLabel = useCallback((metric: string) => getDashboardMetricLabel(metric, t), [t]);
 
     const toggleCategory = useCallback(
       (cat: string) => {
@@ -97,7 +115,13 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
             >
               <Filter className="w-4 h-4" aria-hidden="true" />
               <span className="text-sm font-medium">
-                {isOpen ? 'Hide Filters' : 'Show Filters'}
+                {translateWithFallback(
+                  t,
+                  isOpen
+                    ? 'dashboard.analytics.filters.hide'
+                    : 'dashboard.analytics.filters.show',
+                  isOpen ? 'Hide Filters' : 'Show Filters',
+                )}
               </span>
               {activeFilterCount > 0 && (
                 <span className="ml-1 px-1.5 py-0.5 text-xs bg-blue-600 text-white rounded-full">
@@ -107,16 +131,28 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
             </button>
 
             {/* Active filter badges */}
-            <div className="flex flex-wrap gap-2" role="list" aria-label="Active filters">
+            <div
+              className="flex flex-wrap gap-2"
+              role="list"
+              aria-label={translateWithFallback(
+                t,
+                'dashboard.analytics.filters.activeFilters',
+                'Active filters',
+              )}
+            >
               {filters.timeRange !== '30d' && (
                 <span
                   role="listitem"
                   className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
                 >
-                  {TIME_RANGE_OPTIONS.find((o) => o.value === filters.timeRange)?.label}
+                  {timeRangeOptions.find((option) => option.value === filters.timeRange)?.label}
                   <button
                     onClick={() => onFiltersChange({ timeRange: '30d' })}
-                    aria-label="Remove time range filter"
+                    aria-label={translateWithFallback(
+                      t,
+                      'dashboard.analytics.filters.removeTimeRange',
+                      'Remove time range filter',
+                    )}
                     className="hover:text-red-500 transition-colors"
                   >
                     <X className="w-3 h-3" />
@@ -130,10 +166,15 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                   className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full text-white"
                   style={{ backgroundColor: CHART_COLOR_PALETTE[i % CHART_COLOR_PALETTE.length] }}
                 >
-                  {cat}
+                  {getCategoryLabel(cat)}
                   <button
                     onClick={() => removeCategory(cat)}
-                    aria-label={`Remove ${cat} filter`}
+                    aria-label={translateWithFallback(
+                      t,
+                      'dashboard.analytics.filters.removeCategory',
+                      `Remove ${getCategoryLabel(cat)} filter`,
+                      { category: getCategoryLabel(cat) },
+                    )}
                     className="hover:opacity-75 transition-opacity"
                   >
                     <X className="w-3 h-3" />
@@ -146,11 +187,15 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
           {activeFilterCount > 0 && (
             <button
               onClick={onReset}
-              aria-label="Reset all filters"
+              aria-label={translateWithFallback(
+                t,
+                'dashboard.analytics.filters.resetAllAria',
+                'Reset all filters',
+              )}
               className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 rounded-lg"
             >
               <RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
-              Reset All
+              {translateWithFallback(t, 'dashboard.analytics.filters.resetAll', 'Reset All')}
             </button>
           )}
         </div>
@@ -167,7 +212,11 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                 htmlFor="filter-time-range"
                 className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2"
               >
-                Time Range
+                {translateWithFallback(
+                  t,
+                  'dashboard.analytics.filters.timeRange',
+                  'Time Range',
+                )}
               </label>
               <select
                 id="filter-time-range"
@@ -175,9 +224,9 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                 onChange={(e) => onFiltersChange({ timeRange: e.target.value as TimeRange })}
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
               >
-                {TIME_RANGE_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
+                {timeRangeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
                   </option>
                 ))}
               </select>
@@ -189,7 +238,11 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                 htmlFor="filter-aggregation"
                 className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2"
               >
-                Aggregation
+                {translateWithFallback(
+                  t,
+                  'dashboard.analytics.filters.aggregation',
+                  'Aggregation',
+                )}
               </label>
               <select
                 id="filter-aggregation"
@@ -199,9 +252,9 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                 }
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
               >
-                {AGGREGATION_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
+                {aggregationOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
                   </option>
                 ))}
               </select>
@@ -210,9 +263,17 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
             {/* Metric */}
             <fieldset>
               <legend className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
-                Metric
+                {translateWithFallback(t, 'dashboard.analytics.filters.metric', 'Metric')}
               </legend>
-              <div className="flex flex-col gap-1.5" role="radiogroup" aria-label="Metric">
+              <div
+                className="flex flex-col gap-1.5"
+                role="radiogroup"
+                aria-label={translateWithFallback(
+                  t,
+                  'dashboard.analytics.filters.metric',
+                  'Metric',
+                )}
+              >
                 {metrics.map((m) => (
                   <label key={m} className="flex items-center gap-2 cursor-pointer">
                     <input
@@ -223,7 +284,9 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                       onChange={() => onFiltersChange({ metric: m })}
                       className="accent-blue-600"
                     />
-                    <span className="text-sm text-gray-700 dark:text-gray-300 capitalize">{m}</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      {getMetricLabel(m)}
+                    </span>
                   </label>
                 ))}
               </div>
@@ -232,9 +295,21 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
             {/* Categories */}
             <div>
               <span className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
-                Categories
+                {translateWithFallback(
+                  t,
+                  'dashboard.analytics.filters.categories',
+                  'Categories',
+                )}
               </span>
-              <div className="flex flex-wrap gap-2" role="group" aria-label="Category filters">
+              <div
+                className="flex flex-wrap gap-2"
+                role="group"
+                aria-label={translateWithFallback(
+                  t,
+                  'dashboard.analytics.filters.categoryFilters',
+                  'Category filters',
+                )}
+              >
                 {categories.map((cat, i) => {
                   const isActive = filters.categories.includes(cat);
                   return (
@@ -253,7 +328,7 @@ export const DashboardFilters = React.memo<DashboardFiltersProps>(
                           : { borderColor: '#d1d5db', color: '#374151' }
                       }
                     >
-                      {cat}
+                      {getCategoryLabel(cat)}
                     </button>
                   );
                 })}

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { BarChart2, Download, Share2, CheckCheck } from 'lucide-react';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { translateWithFallback } from './dashboardI18n';
 
 interface DashboardHeaderProps {
   onExportAll: () => void;
@@ -12,6 +14,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   onShare,
   shareSuccess,
 }) => {
+  const { t } = useInternationalization();
+
   return (
     <div className="flex items-center justify-between mb-6 flex-wrap gap-4">
       <div className="flex items-center gap-3">
@@ -19,9 +23,19 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           <BarChart2 className="w-6 h-6" aria-hidden="true" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Analytics Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            {translateWithFallback(
+              t,
+              'dashboard.analytics.title',
+              'Analytics Dashboard',
+            )}
+          </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Interactive data visualization &amp; real-time insights
+            {translateWithFallback(
+              t,
+              'dashboard.analytics.subtitle',
+              'Interactive data visualization and real-time insights',
+            )}
           </p>
         </div>
       </div>
@@ -30,28 +44,36 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         {/* Export all */}
         <button
           onClick={onExportAll}
-          aria-label="Export all panels as CSV"
+          aria-label={translateWithFallback(
+            t,
+            'dashboard.analytics.actions.exportAllAria',
+            'Export all panels as CSV',
+          )}
           className="flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           <Download className="w-4 h-4" aria-hidden="true" />
-          Export All
+          {translateWithFallback(t, 'dashboard.analytics.actions.exportAll', 'Export All')}
         </button>
 
         {/* Share */}
         <button
           onClick={onShare}
-          aria-label="Copy shareable dashboard link"
+          aria-label={translateWithFallback(
+            t,
+            'dashboard.analytics.actions.shareAria',
+            'Copy shareable dashboard link',
+          )}
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         >
           {shareSuccess ? (
             <>
               <CheckCheck className="w-4 h-4" aria-hidden="true" />
-              Copied!
+              {translateWithFallback(t, 'dashboard.analytics.actions.copied', 'Copied!')}
             </>
           ) : (
             <>
               <Share2 className="w-4 h-4" aria-hidden="true" />
-              Share
+              {translateWithFallback(t, 'dashboard.analytics.actions.share', 'Share')}
             </>
           )}
         </button>

--- a/src/components/dashboard/DashboardPanelCard.tsx
+++ b/src/components/dashboard/DashboardPanelCard.tsx
@@ -5,6 +5,8 @@ import { DashboardPanel } from '@/hooks/useDashboardData';
 import { ChartType } from '@/utils/visualizationUtils';
 import { InteractiveCharts } from './InteractiveCharts';
 import { RealTimeUpdater } from './RealTimeUpdater';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { translateWithFallback } from './dashboardI18n';
 
 interface DashboardPanelCardProps {
   panel: DashboardPanel;
@@ -23,6 +25,8 @@ export const DashboardPanelCard: React.FC<DashboardPanelCardProps> = ({
   onDrillDown,
   onClearDrillDown,
 }) => {
+  const { t } = useInternationalization();
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
@@ -36,7 +40,12 @@ export const DashboardPanelCard: React.FC<DashboardPanelCardProps> = ({
         <h2 className="text-base font-semibold text-gray-900 dark:text-white">{panel.title}</h2>
         <button
           onClick={() => onExport(panel.id, 'csv')}
-          aria-label={`Export ${panel.title} as CSV`}
+          aria-label={translateWithFallback(
+            t,
+            'dashboard.analytics.actions.exportPanel',
+            `Export ${panel.title} as CSV`,
+            { panel: panel.title },
+          )}
           className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
         >
           <Download className="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/components/dashboard/InteractiveCharts.tsx
+++ b/src/components/dashboard/InteractiveCharts.tsx
@@ -21,8 +21,8 @@ import {
 import { InteractiveChartLibrary } from '@/components/visualization/InteractiveChartLibrary';
 import { getDrillDownData } from '@/utils/chartUtils';
 import type { ChartData, ChartType } from '@/utils/visualizationUtils';
-
-// ─── Types ────────────────────────────────────────────────────────────────────
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { getDashboardChartTypeLabel, translateWithFallback } from './dashboardI18n';
 
 export interface InteractiveChartsProps {
   panelId: string;
@@ -36,18 +36,14 @@ export interface InteractiveChartsProps {
   className?: string;
 }
 
-// ─── Chart type toolbar config ────────────────────────────────────────────────
-
-const CHART_TYPE_BUTTONS: { type: ChartType; Icon: React.ElementType; label: string }[] = [
-  { type: 'line', Icon: TrendingUp, label: 'Line chart' },
-  { type: 'bar', Icon: BarChart3, label: 'Bar chart' },
-  { type: 'area', Icon: AreaChart, label: 'Area chart' },
-  { type: 'pie', Icon: PieChart, label: 'Pie chart' },
-  { type: 'scatter', Icon: ScatterChart, label: 'Scatter chart' },
-  { type: 'radar', Icon: Radar, label: 'Radar chart' },
+const CHART_TYPE_BUTTONS: { type: ChartType; Icon: React.ElementType }[] = [
+  { type: 'line', Icon: TrendingUp },
+  { type: 'bar', Icon: BarChart3 },
+  { type: 'area', Icon: AreaChart },
+  { type: 'pie', Icon: PieChart },
+  { type: 'scatter', Icon: ScatterChart },
+  { type: 'radar', Icon: Radar },
 ];
-
-// ─── Component ────────────────────────────────────────────────────────────────
 
 export const InteractiveCharts = React.memo<InteractiveChartsProps>(
   ({
@@ -61,23 +57,31 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
     onClearDrillDown,
     className = '',
   }) => {
+    const { t } = useInternationalization();
     const isDrillDown = drillDownIndex !== null;
     const drillDownData = isDrillDown ? getDrillDownData(data, drillDownIndex) : null;
-    const drillDownLabel = isDrillDown ? data.labels[drillDownIndex] ?? 'Selected' : null;
+    const drillDownLabel =
+      isDrillDown
+        ? data.labels[drillDownIndex] ??
+          translateWithFallback(t, 'dashboard.analytics.drillDown.selected', 'Selected')
+        : null;
 
     return (
       <div className={`flex flex-col gap-4 ${className}`}>
-        {/* Chart type toolbar */}
         <div
           className="flex items-center gap-1 flex-wrap"
           role="toolbar"
-          aria-label="Chart type selector"
+          aria-label={translateWithFallback(
+            t,
+            'dashboard.analytics.chartTypeSelector',
+            'Chart type selector',
+          )}
         >
-          {CHART_TYPE_BUTTONS.map(({ type, Icon, label }) => (
+          {CHART_TYPE_BUTTONS.map(({ type, Icon }) => (
             <button
               key={type}
               onClick={() => onChartTypeChange(type)}
-              aria-label={label}
+              aria-label={getDashboardChartTypeLabel(type, t)}
               aria-pressed={chartType === type}
               className={`p-2 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 chartType === type
@@ -90,7 +94,6 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
           ))}
         </div>
 
-        {/* Main chart */}
         <AnimatePresence mode="wait">
           {!isDrillDown ? (
             <motion.div
@@ -108,8 +111,8 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
                 showLegend
                 showGrid
                 animated
-                onDataPointClick={(data: any) =>
-                  onDrillDown(data?.activeTooltipIndex ?? data?.index ?? 0)
+                onDataPointClick={(clickedPoint: any) =>
+                  onDrillDown(clickedPoint?.activeTooltipIndex ?? clickedPoint?.index ?? 0)
                 }
               />
             </motion.div>
@@ -122,14 +125,17 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
               transition={{ duration: 0.2 }}
               className="flex flex-col gap-3"
             >
-              {/* Breadcrumb */}
               <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
                 <button
                   onClick={onClearDrillDown}
                   className="text-blue-600 dark:text-blue-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
-                  aria-label="Back to all data"
+                  aria-label={translateWithFallback(
+                    t,
+                    'dashboard.analytics.drillDown.backToAllDataAria',
+                    'Back to all data',
+                  )}
                 >
-                  All Data
+                  {translateWithFallback(t, 'dashboard.analytics.drillDown.allData', 'All Data')}
                 </button>
                 <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" />
                 <span className="font-medium text-gray-700 dark:text-gray-200">
@@ -137,12 +143,16 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
                 </span>
               </div>
 
-              {/* Drill-down chart */}
               {drillDownData && (
                 <InteractiveChartLibrary
                   data={drillDownData}
                   chartType="bar"
-                  title={`Detail — ${drillDownLabel}`}
+                  title={translateWithFallback(
+                    t,
+                    'dashboard.analytics.drillDown.detailTitle',
+                    `Detail - ${drillDownLabel}`,
+                    { label: drillDownLabel ?? '' },
+                  )}
                   height={280}
                   showLegend
                   showGrid
@@ -150,14 +160,21 @@ export const InteractiveCharts = React.memo<InteractiveChartsProps>(
                 />
               )}
 
-              {/* Back button */}
               <button
                 onClick={onClearDrillDown}
                 className="self-start flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                aria-label="Back to overview"
+                aria-label={translateWithFallback(
+                  t,
+                  'dashboard.analytics.drillDown.backToOverview',
+                  'Back to overview',
+                )}
               >
                 <ArrowLeft className="w-4 h-4" aria-hidden="true" />
-                Back to overview
+                {translateWithFallback(
+                  t,
+                  'dashboard.analytics.drillDown.backToOverview',
+                  'Back to overview',
+                )}
               </button>
             </motion.div>
           )}

--- a/src/components/dashboard/RealTimeUpdater.tsx
+++ b/src/components/dashboard/RealTimeUpdater.tsx
@@ -11,8 +11,8 @@ import { Wifi, WifiOff, Activity, Pause, Play, RefreshCw } from 'lucide-react';
 import { InteractiveChartLibrary } from '@/components/visualization/InteractiveChartLibrary';
 import { useDataVisualization } from '@/hooks/useDataVisualization';
 import type { ChartType } from '@/utils/visualizationUtils';
-
-// ─── Types ────────────────────────────────────────────────────────────────────
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { translateWithFallback } from './dashboardI18n';
 
 export interface RealTimeUpdaterProps {
   title?: string;
@@ -30,20 +30,27 @@ const SPEED_OPTIONS = [
   { label: '5s', value: 5000 },
 ];
 
-// ─── Component ────────────────────────────────────────────────────────────────
-
 export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
   ({
-    title = 'Live Activity',
+    title,
     chartType = 'line',
     websocketUrl,
     updateInterval: initialInterval = 2000,
     maxDataPoints = 20,
     className = '',
   }) => {
+    const { language, t, formatNumber, formatPercentage } = useInternationalization();
     const [isPaused, setIsPaused] = useState(false);
     const [interval, setIntervalValue] = useState(initialInterval);
     const simulationEnabled = !websocketUrl;
+    const resolvedTitle =
+      title ??
+      translateWithFallback(t, 'dashboard.analytics.panels.realtime.title', 'Live Activity');
+    const liveDataLabel = translateWithFallback(
+      t,
+      'dashboard.analytics.datasets.realtime',
+      'Live Data',
+    );
 
     const {
       data,
@@ -59,7 +66,7 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
         labels: [],
         datasets: [
           {
-            label: 'Live Data',
+            label: liveDataLabel,
             data: [],
             borderColor: '#3b82f6',
             backgroundColor: 'rgba(59,130,246,0.1)',
@@ -77,38 +84,36 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
       websocketUrl,
     });
 
-    // Simulate real-time data when no WebSocket URL provided
     useEffect(() => {
       if (!simulationEnabled || isPaused) return;
 
       const timer = setInterval(() => {
-        const timeLabel = new Date().toLocaleTimeString();
+        const timeLabel = new Date().toLocaleTimeString(language);
         const value = Math.floor(Math.random() * 100);
         addDataPoint(0, value, timeLabel);
 
         if (data && data.labels.length > maxDataPoints) {
           updateData({
             labels: data.labels.slice(-maxDataPoints),
-            datasets: data.datasets.map((ds) => ({
-              ...ds,
-              data: ds.data.slice(-maxDataPoints),
+            datasets: data.datasets.map((dataset) => ({
+              ...dataset,
+              data: dataset.data.slice(-maxDataPoints),
             })),
           });
         }
       }, interval);
 
       return () => clearInterval(timer);
-    }, [simulationEnabled, isPaused, interval, maxDataPoints, addDataPoint, data, updateData]);
+    }, [addDataPoint, data, interval, isPaused, language, maxDataPoints, simulationEnabled, updateData]);
 
     const stats = calculateStats();
-
-    const statusText = isPaused
-      ? 'Paused'
+    const statusKey = isPaused
+      ? 'paused'
       : isConnected
-      ? 'Connected'
+      ? 'connected'
       : simulationEnabled
-      ? 'Simulating'
-      : 'Disconnected';
+      ? 'simulating'
+      : 'disconnected';
 
     const statusColor = isPaused
       ? 'text-yellow-600 dark:text-yellow-400'
@@ -121,7 +126,7 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
         labels: [],
         datasets: [
           {
-            label: 'Live Data',
+            label: liveDataLabel,
             data: [],
             borderColor: '#3b82f6',
             backgroundColor: 'rgba(59,130,246,0.1)',
@@ -129,56 +134,77 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
           },
         ],
       });
-    }, [updateData]);
+    }, [liveDataLabel, updateData]);
 
     return (
       <div className={`flex flex-col gap-4 ${className}`}>
-        {/* Status bar */}
         <div className="flex items-center justify-between flex-wrap gap-2">
           <div className="flex items-center gap-3">
-            {/* Connection status */}
             <div className="flex items-center gap-1.5">
               {(isConnected || simulationEnabled) && !isPaused ? (
                 <Wifi className="w-4 h-4 text-green-500" aria-hidden="true" />
               ) : (
                 <WifiOff className="w-4 h-4 text-gray-400" aria-hidden="true" />
               )}
-              <span className={`text-sm font-medium ${statusColor}`}>{statusText}</span>
+              <span className={`text-sm font-medium ${statusColor}`}>
+                {translateWithFallback(
+                  t,
+                  `dashboard.analytics.realtime.status.${statusKey}`,
+                  statusKey,
+                )}
+              </span>
             </div>
 
-            {/* Data point count */}
             {data && data.labels.length > 0 && (
               <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
                 <Activity className="w-4 h-4" aria-hidden="true" />
-                <span>{data.labels.length} pts</span>
+                <span>
+                  {translateWithFallback(
+                    t,
+                    'dashboard.analytics.realtime.pointsCount',
+                    `${formatNumber(data.labels.length)} pts`,
+                    { count: formatNumber(data.labels.length) },
+                  )}
+                </span>
               </div>
             )}
           </div>
 
-          {/* Controls */}
           <div className="flex items-center gap-2">
-            {/* Speed selector */}
             <label htmlFor="rt-speed" className="sr-only">
-              Update speed
+              {translateWithFallback(
+                t,
+                'dashboard.analytics.realtime.updateSpeed',
+                'Update speed',
+              )}
             </label>
             <select
               id="rt-speed"
               value={interval}
-              onChange={(e) => setIntervalValue(Number(e.target.value))}
+              onChange={(event) => setIntervalValue(Number(event.target.value))}
               className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-              aria-label="Update speed"
+              aria-label={translateWithFallback(
+                t,
+                'dashboard.analytics.realtime.updateSpeed',
+                'Update speed',
+              )}
             >
-              {SPEED_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
+              {SPEED_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </select>
 
-            {/* Pause / Resume */}
             <button
-              onClick={() => setIsPaused((v) => !v)}
-              aria-label={isPaused ? 'Resume live updates' : 'Pause live updates'}
+              onClick={() => setIsPaused((value) => !value)}
+              aria-label={translateWithFallback(
+                t,
+                isPaused
+                  ? 'dashboard.analytics.realtime.resume'
+                  : 'dashboard.analytics.realtime.pause',
+                isPaused ? 'Resume live updates' : 'Pause live updates',
+              )}
               className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               {isPaused ? (
@@ -188,10 +214,13 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
               )}
             </button>
 
-            {/* Reset */}
             <button
               onClick={handleReset}
-              aria-label="Reset data"
+              aria-label={translateWithFallback(
+                t,
+                'dashboard.analytics.realtime.reset',
+                'Reset data',
+              )}
               className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               <RefreshCw className="w-4 h-4" aria-hidden="true" />
@@ -199,30 +228,44 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
           </div>
         </div>
 
-        {/* Error */}
         {error && (
           <p className="text-sm text-red-600 dark:text-red-400" role="alert">
             {error}
           </p>
         )}
 
-        {/* Stats bar */}
         {stats && (
           <div className="grid grid-cols-3 gap-3">
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Mean</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                {translateWithFallback(t, 'dashboard.analytics.realtime.stats.mean', 'Mean')}
+              </div>
               <div className="text-lg font-semibold text-gray-900 dark:text-white">
-                {stats.mean.toFixed(1)}
+                {formatNumber(stats.mean, {
+                  minimumFractionDigits: 1,
+                  maximumFractionDigits: 1,
+                })}
               </div>
             </div>
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Median</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                {translateWithFallback(
+                  t,
+                  'dashboard.analytics.realtime.stats.median',
+                  'Median',
+                )}
+              </div>
               <div className="text-lg font-semibold text-gray-900 dark:text-white">
-                {stats.median.toFixed(1)}
+                {formatNumber(stats.median, {
+                  minimumFractionDigits: 1,
+                  maximumFractionDigits: 1,
+                })}
               </div>
             </div>
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Trend</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                {translateWithFallback(t, 'dashboard.analytics.realtime.stats.trend', 'Trend')}
+              </div>
               <div
                 className={`text-lg font-semibold ${
                   stats.trend.direction === 'up'
@@ -232,23 +275,22 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
                     : 'text-gray-600 dark:text-gray-400'
                 }`}
               >
-                {stats.trend.direction === 'up'
-                  ? '↑'
-                  : stats.trend.direction === 'down'
-                  ? '↓'
-                  : '→'}
-                {stats.trend.percentage.toFixed(1)}%
+                {translateWithFallback(
+                  t,
+                  `dashboard.analytics.realtime.trendDirections.${stats.trend.direction}`,
+                  stats.trend.direction,
+                )}{' '}
+                {formatPercentage(stats.trend.percentage, 1)}
               </div>
             </div>
           </div>
         )}
 
-        {/* Chart or empty state */}
         {data && data.labels.length > 0 ? (
           <InteractiveChartLibrary
             data={data}
             chartType={chartType}
-            title={title}
+            title={resolvedTitle}
             height={280}
             showLegend={config.showLegend}
             showGrid={config.showGrid}
@@ -257,7 +299,19 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
         ) : (
           <div className="flex flex-col items-center justify-center py-12 text-gray-400 dark:text-gray-500">
             <Activity className="w-10 h-10 mb-3 opacity-50" aria-hidden="true" />
-            <p className="text-sm">{isLoading ? 'Loading data…' : 'Waiting for data…'}</p>
+            <p className="text-sm">
+              {isLoading
+                ? translateWithFallback(
+                    t,
+                    'dashboard.analytics.realtime.loadingData',
+                    'Loading data...',
+                  )
+                : translateWithFallback(
+                    t,
+                    'dashboard.analytics.realtime.waitingForData',
+                    'Waiting for data...',
+                  )}
+            </p>
           </div>
         )}
       </div>

--- a/src/components/dashboard/__tests__/AdvancedDashboard.test.tsx
+++ b/src/components/dashboard/__tests__/AdvancedDashboard.test.tsx
@@ -4,6 +4,44 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AdvancedDashboard } from '../AdvancedDashboard';
 
+vi.mock('@/hooks/useInternationalization', async () => {
+  const translations = (await import('@/locales/en.json')).default;
+  const read = (key: string) =>
+    key.split('.').reduce<unknown>((value, part) => {
+      if (value && typeof value === 'object' && part in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[part];
+      }
+      return key;
+    }, translations);
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const value = read(key);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => String(params[paramKey] ?? ''));
+  };
+
+  return {
+    useInternationalization: () => ({
+      language: 'en',
+      t,
+      formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+        new Intl.NumberFormat('en-US', options).format(value),
+      formatPercentage: (value: number, decimals = 0) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'percent',
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(value / 100),
+    }),
+  };
+});
+
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 global.ResizeObserver = class {

--- a/src/components/dashboard/__tests__/DashboardFilters.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardFilters.test.tsx
@@ -5,6 +5,44 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { DashboardFilters } from '../DashboardFilters';
 import type { DashboardFiltersState } from '@/hooks/useDashboardData';
 
+vi.mock('@/hooks/useInternationalization', async () => {
+  const translations = (await import('@/locales/en.json')).default;
+  const read = (key: string) =>
+    key.split('.').reduce<unknown>((value, part) => {
+      if (value && typeof value === 'object' && part in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[part];
+      }
+      return key;
+    }, translations);
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const value = read(key);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => String(params[paramKey] ?? ''));
+  };
+
+  return {
+    useInternationalization: () => ({
+      language: 'en',
+      t,
+      formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+        new Intl.NumberFormat('en-US', options).format(value),
+      formatPercentage: (value: number, decimals = 0) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'percent',
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(value / 100),
+    }),
+  };
+});
+
 // ─── Default props ────────────────────────────────────────────────────────────
 
 const defaultFilters: DashboardFiltersState = {

--- a/src/components/dashboard/__tests__/InteractiveCharts.test.tsx
+++ b/src/components/dashboard/__tests__/InteractiveCharts.test.tsx
@@ -5,6 +5,44 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { InteractiveCharts } from '../InteractiveCharts';
 import type { ChartData } from '@/utils/visualizationUtils';
 
+vi.mock('@/hooks/useInternationalization', async () => {
+  const translations = (await import('@/locales/en.json')).default;
+  const read = (key: string) =>
+    key.split('.').reduce<unknown>((value, part) => {
+      if (value && typeof value === 'object' && part in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[part];
+      }
+      return key;
+    }, translations);
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const value = read(key);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => String(params[paramKey] ?? ''));
+  };
+
+  return {
+    useInternationalization: () => ({
+      language: 'en',
+      t,
+      formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+        new Intl.NumberFormat('en-US', options).format(value),
+      formatPercentage: (value: number, decimals = 0) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'percent',
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(value / 100),
+    }),
+  };
+});
+
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 // Recharts uses ResizeObserver; provide a minimal stub

--- a/src/components/dashboard/__tests__/RealTimeUpdater.test.tsx
+++ b/src/components/dashboard/__tests__/RealTimeUpdater.test.tsx
@@ -4,6 +4,44 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { RealTimeUpdater } from '../RealTimeUpdater';
 
+vi.mock('@/hooks/useInternationalization', async () => {
+  const translations = (await import('@/locales/en.json')).default;
+  const read = (key: string) =>
+    key.split('.').reduce<unknown>((value, part) => {
+      if (value && typeof value === 'object' && part in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[part];
+      }
+      return key;
+    }, translations);
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const value = read(key);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => String(params[paramKey] ?? ''));
+  };
+
+  return {
+    useInternationalization: () => ({
+      language: 'en',
+      t,
+      formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+        new Intl.NumberFormat('en-US', options).format(value),
+      formatPercentage: (value: number, decimals = 0) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'percent',
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(value / 100),
+    }),
+  };
+});
+
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 global.ResizeObserver = class {

--- a/src/components/dashboard/dashboardI18n.ts
+++ b/src/components/dashboard/dashboardI18n.ts
@@ -1,0 +1,151 @@
+import type { AggregationType, ChartType, TimeRange } from '@/utils/visualizationUtils';
+
+type TranslateFn = (key: string, params?: Record<string, string | number>) => string;
+
+const PANEL_TITLE_FALLBACKS: Record<string, string> = {
+  enrollments: 'Course Enrollments',
+  revenue: 'Revenue',
+  completions: 'Completions',
+  realtime: 'Live Activity',
+};
+
+const PANEL_DATASET_FALLBACKS: Record<string, string> = {
+  enrollments: 'Course Enrollments',
+  revenue: 'Revenue',
+  completions: 'Completions',
+  realtime: 'Live Data',
+  views: 'Course Views',
+};
+
+const TIME_RANGE_FALLBACKS: Record<TimeRange, string> = {
+  '7d': 'Last 7 Days',
+  '30d': 'Last 30 Days',
+  '90d': 'Last 90 Days',
+  '1y': 'Last Year',
+  all: 'All Time',
+};
+
+const AGGREGATION_FALLBACKS: Record<AggregationType, string> = {
+  sum: 'Sum',
+  average: 'Average',
+  count: 'Count',
+  min: 'Min',
+  max: 'Max',
+};
+
+const METRIC_FALLBACKS: Record<string, string> = {
+  enrollments: 'Enrollments',
+  revenue: 'Revenue',
+  completions: 'Completions',
+  views: 'Views',
+};
+
+const METRIC_KEY_MAP: Record<string, string> = {
+  enrollments: 'enrollments',
+  revenue: 'revenue',
+  completions: 'completions',
+  views: 'views',
+};
+
+const CATEGORY_FALLBACKS: Record<string, string> = {
+  'Web Dev': 'Web Dev',
+  'Data Science': 'Data Science',
+  Design: 'Design',
+  Marketing: 'Marketing',
+  Mobile: 'Mobile',
+};
+
+const CATEGORY_KEY_MAP: Record<string, string> = {
+  'Web Dev': 'webDev',
+  'Data Science': 'dataScience',
+  Design: 'design',
+  Marketing: 'marketing',
+  Mobile: 'mobile',
+};
+
+const CHART_TYPE_FALLBACKS: Record<ChartType, string> = {
+  line: 'Line chart',
+  bar: 'Bar chart',
+  pie: 'Pie chart',
+  doughnut: 'Doughnut chart',
+  area: 'Area chart',
+  scatter: 'Scatter chart',
+  radar: 'Radar chart',
+  heatmap: 'Heatmap chart',
+};
+
+export function translateWithFallback(
+  t: TranslateFn,
+  key: string,
+  fallback: string,
+  params?: Record<string, string | number>,
+): string {
+  const translated = t(key, params);
+  return translated === key ? fallback : translated;
+}
+
+export function getDashboardPanelTitle(panelId: string, t: TranslateFn): string {
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.panels.${panelId}.title`,
+    PANEL_TITLE_FALLBACKS[panelId] ?? panelId,
+  );
+}
+
+export function getDashboardDatasetLabel(panelId: string, t: TranslateFn): string {
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.datasets.${panelId}`,
+    PANEL_DATASET_FALLBACKS[panelId] ?? 'Metric',
+  );
+}
+
+export function getDashboardTimeRangeLabel(value: TimeRange, t: TranslateFn): string {
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.filters.timeRangeOptions.${value}`,
+    TIME_RANGE_FALLBACKS[value],
+  );
+}
+
+export function getDashboardAggregationLabel(value: AggregationType, t: TranslateFn): string {
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.filters.aggregationOptions.${value}`,
+    AGGREGATION_FALLBACKS[value],
+  );
+}
+
+export function getDashboardMetricLabel(metric: string, t: TranslateFn): string {
+  const metricKey = METRIC_KEY_MAP[metric];
+  if (!metricKey) {
+    return metric;
+  }
+
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.filters.metrics.${metricKey}`,
+    METRIC_FALLBACKS[metric],
+  );
+}
+
+export function getDashboardCategoryLabel(category: string, t: TranslateFn): string {
+  const categoryKey = CATEGORY_KEY_MAP[category];
+  if (!categoryKey) {
+    return category;
+  }
+
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.filters.categoriesOptions.${categoryKey}`,
+    CATEGORY_FALLBACKS[category],
+  );
+}
+
+export function getDashboardChartTypeLabel(type: ChartType, t: TranslateFn): string {
+  return translateWithFallback(
+    t,
+    `dashboard.analytics.chartTypes.${type}`,
+    CHART_TYPE_FALLBACKS[type],
+  );
+}

--- a/src/hooks/useDashboardControls.ts
+++ b/src/hooks/useDashboardControls.ts
@@ -3,6 +3,8 @@ import { useSensor, useSensors, PointerSensor, KeyboardSensor, DragEndEvent } fr
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import toast from 'react-hot-toast';
 import { DashboardPanel } from '@/hooks/useDashboardData';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { translateWithFallback } from '@/components/dashboard/dashboardI18n';
 
 interface UseDashboardControlsProps {
   panels: DashboardPanel[];
@@ -17,6 +19,7 @@ export const useDashboardControls = ({
   generateShareURL,
   exportPanel,
 }: UseDashboardControlsProps) => {
+  const { t } = useInternationalization();
   const [shareSuccess, setShareSuccess] = useState(false);
 
   // DnD sensors
@@ -48,12 +51,25 @@ export const useDashboardControls = ({
     try {
       await navigator.clipboard.writeText(url);
       setShareSuccess(true);
-      toast.success('Dashboard link copied to clipboard!', { duration: 2500 });
+      toast.success(
+        translateWithFallback(
+          t,
+          'dashboard.analytics.toasts.shareSuccess',
+          'Dashboard link copied to clipboard!',
+        ),
+        { duration: 2500 },
+      );
       setTimeout(() => setShareSuccess(false), 2500);
     } catch {
-      toast.error('Could not copy to clipboard');
+      toast.error(
+        translateWithFallback(
+          t,
+          'dashboard.analytics.toasts.shareError',
+          'Could not copy to clipboard',
+        ),
+      );
     }
-  }, [generateShareURL]);
+  }, [generateShareURL, t]);
 
   const handleExportAll = useCallback(() => {
     panels.forEach((panel) => {
@@ -61,8 +77,14 @@ export const useDashboardControls = ({
         exportPanel(panel.id, 'csv');
       }
     });
-    toast.success('Panels exported as CSV');
-  }, [panels, exportPanel]);
+    toast.success(
+      translateWithFallback(
+        t,
+        'dashboard.analytics.toasts.exportAllSuccess',
+        'Panels exported as CSV',
+      ),
+    );
+  }, [exportPanel, panels, t]);
 
   return {
     sensors,

--- a/src/hooks/useDashboardData.tsx
+++ b/src/hooks/useDashboardData.tsx
@@ -13,6 +13,12 @@ import {
   DashboardShareConfig,
 } from '@/utils/chartUtils';
 import type { ChartData } from '@/utils/visualizationUtils';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import {
+  getDashboardDatasetLabel,
+  getDashboardPanelTitle,
+  translateWithFallback,
+} from '@/components/dashboard/dashboardI18n';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -56,34 +62,47 @@ const DEFAULT_FILTERS: DashboardFiltersState = {
   aggregation: 'sum',
 };
 
-const buildDefaultPanels = (timeRange: TimeRange): DashboardPanel[] => [
+const buildDefaultPanels = (
+  timeRange: TimeRange,
+  locale: string,
+  t: (key: string, params?: Record<string, string | number>) => string,
+): DashboardPanel[] => [
   {
     id: 'enrollments',
-    title: 'Course Enrollments',
+    title: getDashboardPanelTitle('enrollments', t),
     chartType: 'line',
-    data: generateDashboardSampleData('enrollments', timeRange),
+    data: generateDashboardSampleData('enrollments', timeRange, {
+      locale,
+      datasetLabel: getDashboardDatasetLabel('enrollments', t),
+    }),
     drillDownIndex: null,
     position: 0,
   },
   {
     id: 'revenue',
-    title: 'Revenue',
+    title: getDashboardPanelTitle('revenue', t),
     chartType: 'bar',
-    data: generateDashboardSampleData('revenue', timeRange),
+    data: generateDashboardSampleData('revenue', timeRange, {
+      locale,
+      datasetLabel: getDashboardDatasetLabel('revenue', t),
+    }),
     drillDownIndex: null,
     position: 1,
   },
   {
     id: 'completions',
-    title: 'Completions',
+    title: getDashboardPanelTitle('completions', t),
     chartType: 'area',
-    data: generateDashboardSampleData('completions', timeRange),
+    data: generateDashboardSampleData('completions', timeRange, {
+      locale,
+      datasetLabel: getDashboardDatasetLabel('completions', t),
+    }),
     drillDownIndex: null,
     position: 2,
   },
   {
     id: 'realtime',
-    title: 'Live Activity',
+    title: getDashboardPanelTitle('realtime', t),
     chartType: 'line',
     data: { labels: [], datasets: [] },
     drillDownIndex: null,
@@ -94,6 +113,7 @@ const buildDefaultPanels = (timeRange: TimeRange): DashboardPanel[] => [
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 export const useDashboardData = (): UseDashboardDataReturn => {
+  const { language, t } = useInternationalization();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -110,12 +130,46 @@ export const useDashboardData = (): UseDashboardDataReturn => {
   });
 
   const [panels, setPanels] = useState<DashboardPanel[]>(() =>
-    buildDefaultPanels(filters.timeRange),
+    buildDefaultPanels(filters.timeRange, language, t),
   );
 
   const [shareURL, setShareURL] = useState<string | null>(null);
 
   const sortedPanels = useMemo(() => [...panels].sort((a, b) => a.position - b.position), [panels]);
+
+  useEffect(() => {
+    setPanels((prevPanels) =>
+      prevPanels.map((panel) => {
+        if (panel.id === 'realtime') {
+          return {
+            ...panel,
+            title: getDashboardPanelTitle(panel.id, t),
+          };
+        }
+
+        const localizedLabels = generateDashboardSampleData(panel.id, filters.timeRange, {
+          locale: language,
+        }).labels;
+
+        return {
+          ...panel,
+          title: getDashboardPanelTitle(panel.id, t),
+          data: {
+            ...panel.data,
+            labels: localizedLabels,
+            datasets: panel.data.datasets.map((dataset, index) =>
+              index === 0
+                ? {
+                    ...dataset,
+                    label: getDashboardDatasetLabel(panel.id, t),
+                  }
+                : dataset,
+            ),
+          },
+        };
+      }),
+    );
+  }, [filters.timeRange, language, t]);
 
   // Update filters and regenerate data for non-realtime panels
   const setFilters = useCallback((partial: Partial<DashboardFiltersState>) => {
@@ -128,7 +182,10 @@ export const useDashboardData = (): UseDashboardDataReturn => {
               ? panel
               : {
                   ...panel,
-                  data: generateDashboardSampleData(panel.id, next.timeRange),
+                  data: generateDashboardSampleData(panel.id, next.timeRange, {
+                    locale: language,
+                    datasetLabel: getDashboardDatasetLabel(panel.id, t),
+                  }),
                   drillDownIndex: null,
                 },
           ),
@@ -136,13 +193,13 @@ export const useDashboardData = (): UseDashboardDataReturn => {
       }
       return next;
     });
-  }, []);
+  }, [language, t]);
 
   const resetFilters = useCallback(() => {
     setFiltersState(DEFAULT_FILTERS);
-    setPanels(buildDefaultPanels(DEFAULT_FILTERS.timeRange));
+    setPanels(buildDefaultPanels(DEFAULT_FILTERS.timeRange, language, t));
     setShareURL(null);
-  }, []);
+  }, [language, t]);
 
   const setPanelChartType = useCallback((id: string, chartType: ChartType) => {
     setPanels((prev) => prev.map((p) => (p.id === id ? { ...p, chartType } : p)));
@@ -184,12 +241,16 @@ export const useDashboardData = (): UseDashboardDataReturn => {
       if (!panel) return;
       const filename = `${panel.title.replace(/\s+/g, '-').toLowerCase()}-${Date.now()}`;
       if (format === 'csv') {
-        exportToCSV(panel.data, filename);
+        exportToCSV(
+          panel.data,
+          filename,
+          translateWithFallback(t, 'dashboard.analytics.exports.labelColumn', 'Label'),
+        );
       } else {
         exportToJSON(panel.data, filename);
       }
     },
-    [panels],
+    [panels, t],
   );
 
   return {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "loading": "جاري التحميل...",
+    "loading": "جار التحميل...",
     "error": "خطأ",
     "success": "نجاح",
     "cancel": "إلغاء",
@@ -67,7 +67,130 @@
     "downloadedCourse": "تم تنزيل الدورة",
     "activityEntry": "{{course}} • {{time}}",
     "timeHoursAgo": "قبل {{count}} ساعات",
-    "timeDayAgo": "قبل {{count}} يوم"
+    "timeDayAgo": "قبل {{count}} يوم",
+    "analytics": {
+      "title": "لوحة التحليلات",
+      "subtitle": "تصور تفاعلي للبيانات ورؤى في الوقت الحقيقي",
+      "chartTypeSelector": "محدد نوع المخطط",
+      "actions": {
+        "exportAll": "تصدير الكل",
+        "exportAllAria": "تصدير جميع اللوحات كملف CSV",
+        "share": "مشاركة",
+        "shareAria": "نسخ رابط لوحة التحكم القابل للمشاركة",
+        "copied": "تم النسخ",
+        "exportPanel": "تصدير {{panel}} كملف CSV"
+      },
+      "toasts": {
+        "shareSuccess": "تم نسخ رابط لوحة التحكم إلى الحافظة",
+        "shareError": "تعذر النسخ إلى الحافظة",
+        "exportAllSuccess": "تم تصدير اللوحات كملف CSV"
+      },
+      "exports": {
+        "labelColumn": "التسمية"
+      },
+      "filters": {
+        "show": "إظهار المرشحات",
+        "hide": "إخفاء المرشحات",
+        "activeFilters": "المرشحات النشطة",
+        "removeTimeRange": "إزالة مرشح نطاق الوقت",
+        "removeCategory": "إزالة مرشح {{category}}",
+        "resetAll": "إعادة تعيين الكل",
+        "resetAllAria": "إعادة تعيين جميع المرشحات",
+        "timeRange": "نطاق الوقت",
+        "aggregation": "التجميع",
+        "metric": "المقياس",
+        "categories": "الفئات",
+        "categoryFilters": "مرشحات الفئات",
+        "timeRangeOptions": {
+          "7d": "آخر 7 أيام",
+          "30d": "آخر 30 يوما",
+          "90d": "آخر 90 يوما",
+          "1y": "العام الماضي",
+          "all": "كل الوقت"
+        },
+        "aggregationOptions": {
+          "sum": "المجموع",
+          "average": "المتوسط",
+          "count": "العدد",
+          "min": "الأدنى",
+          "max": "الأقصى"
+        },
+        "metrics": {
+          "enrollments": "التسجيلات",
+          "revenue": "الإيرادات",
+          "completions": "الإكمالات",
+          "views": "المشاهدات"
+        },
+        "categoriesOptions": {
+          "webDev": "تطوير الويب",
+          "dataScience": "علم البيانات",
+          "design": "التصميم",
+          "marketing": "التسويق",
+          "mobile": "الجوال"
+        }
+      },
+      "panels": {
+        "enrollments": {
+          "title": "تسجيلات الدورات"
+        },
+        "revenue": {
+          "title": "الإيرادات"
+        },
+        "completions": {
+          "title": "الإكمالات"
+        },
+        "realtime": {
+          "title": "النشاط المباشر"
+        }
+      },
+      "datasets": {
+        "enrollments": "تسجيلات الدورات",
+        "revenue": "الإيرادات",
+        "completions": "الإكمالات",
+        "realtime": "بيانات حية",
+        "views": "مشاهدات الدورة"
+      },
+      "chartTypes": {
+        "line": "مخطط خطي",
+        "bar": "مخطط أعمدة",
+        "area": "مخطط مساحة",
+        "pie": "مخطط دائري",
+        "scatter": "مخطط تبعثر",
+        "radar": "مخطط رادار"
+      },
+      "drillDown": {
+        "selected": "العنصر المحدد",
+        "allData": "كل البيانات",
+        "backToAllDataAria": "العودة إلى كل البيانات",
+        "detailTitle": "تفاصيل - {{label}}",
+        "backToOverview": "العودة إلى النظرة العامة"
+      },
+      "realtime": {
+        "status": {
+          "paused": "متوقف",
+          "connected": "متصل",
+          "simulating": "محاكاة",
+          "disconnected": "غير متصل"
+        },
+        "pointsCount": "{{count}} نقطة",
+        "updateSpeed": "سرعة التحديث",
+        "pause": "إيقاف التحديثات المباشرة",
+        "resume": "استئناف التحديثات المباشرة",
+        "reset": "إعادة ضبط البيانات",
+        "loadingData": "جار تحميل البيانات...",
+        "waitingForData": "بانتظار البيانات...",
+        "stats": {
+          "mean": "المتوسط",
+          "median": "الوسيط",
+          "trend": "الاتجاه"
+        },
+        "trendDirections": {
+          "up": "ارتفاع",
+          "down": "انخفاض",
+          "neutral": "ثابت"
+        }
+      }
+    }
   },
   "profile": {
     "editProfile": "تعديل الملف الشخصي",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,7 +67,130 @@
     "downloadedCourse": "Downloaded course",
     "activityEntry": "{{course}} • {{time}}",
     "timeHoursAgo": "{{count}} hours ago",
-    "timeDayAgo": "{{count}} day ago"
+    "timeDayAgo": "{{count}} day ago",
+    "analytics": {
+      "title": "Analytics Dashboard",
+      "subtitle": "Interactive data visualization and real-time insights",
+      "chartTypeSelector": "Chart type selector",
+      "actions": {
+        "exportAll": "Export All",
+        "exportAllAria": "Export all panels as CSV",
+        "share": "Share",
+        "shareAria": "Copy shareable dashboard link",
+        "copied": "Copied!",
+        "exportPanel": "Export {{panel}} as CSV"
+      },
+      "toasts": {
+        "shareSuccess": "Dashboard link copied to clipboard!",
+        "shareError": "Could not copy to clipboard",
+        "exportAllSuccess": "Panels exported as CSV"
+      },
+      "exports": {
+        "labelColumn": "Label"
+      },
+      "filters": {
+        "show": "Show Filters",
+        "hide": "Hide Filters",
+        "activeFilters": "Active filters",
+        "removeTimeRange": "Remove time range filter",
+        "removeCategory": "Remove {{category}} filter",
+        "resetAll": "Reset All",
+        "resetAllAria": "Reset all filters",
+        "timeRange": "Time Range",
+        "aggregation": "Aggregation",
+        "metric": "Metric",
+        "categories": "Categories",
+        "categoryFilters": "Category filters",
+        "timeRangeOptions": {
+          "7d": "Last 7 Days",
+          "30d": "Last 30 Days",
+          "90d": "Last 90 Days",
+          "1y": "Last Year",
+          "all": "All Time"
+        },
+        "aggregationOptions": {
+          "sum": "Sum",
+          "average": "Average",
+          "count": "Count",
+          "min": "Min",
+          "max": "Max"
+        },
+        "metrics": {
+          "enrollments": "Enrollments",
+          "revenue": "Revenue",
+          "completions": "Completions",
+          "views": "Views"
+        },
+        "categoriesOptions": {
+          "webDev": "Web Dev",
+          "dataScience": "Data Science",
+          "design": "Design",
+          "marketing": "Marketing",
+          "mobile": "Mobile"
+        }
+      },
+      "panels": {
+        "enrollments": {
+          "title": "Course Enrollments"
+        },
+        "revenue": {
+          "title": "Revenue"
+        },
+        "completions": {
+          "title": "Completions"
+        },
+        "realtime": {
+          "title": "Live Activity"
+        }
+      },
+      "datasets": {
+        "enrollments": "Course Enrollments",
+        "revenue": "Revenue",
+        "completions": "Completions",
+        "realtime": "Live Data",
+        "views": "Course Views"
+      },
+      "chartTypes": {
+        "line": "Line chart",
+        "bar": "Bar chart",
+        "area": "Area chart",
+        "pie": "Pie chart",
+        "scatter": "Scatter chart",
+        "radar": "Radar chart"
+      },
+      "drillDown": {
+        "selected": "Selected",
+        "allData": "All Data",
+        "backToAllDataAria": "Back to all data",
+        "detailTitle": "Detail - {{label}}",
+        "backToOverview": "Back to overview"
+      },
+      "realtime": {
+        "status": {
+          "paused": "Paused",
+          "connected": "Connected",
+          "simulating": "Simulating",
+          "disconnected": "Disconnected"
+        },
+        "pointsCount": "{{count}} pts",
+        "updateSpeed": "Update speed",
+        "pause": "Pause live updates",
+        "resume": "Resume live updates",
+        "reset": "Reset data",
+        "loadingData": "Loading data...",
+        "waitingForData": "Waiting for data...",
+        "stats": {
+          "mean": "Mean",
+          "median": "Median",
+          "trend": "Trend"
+        },
+        "trendDirections": {
+          "up": "Up",
+          "down": "Down",
+          "neutral": "Flat"
+        }
+      }
+    }
   },
   "profile": {
     "editProfile": "Edit Profile",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -67,7 +67,130 @@
     "downloadedCourse": "[MISSING TRANSLATION] Downloaded course",
     "activityEntry": "[MISSING TRANSLATION] {{course}} • {{time}}",
     "timeHoursAgo": "[MISSING TRANSLATION] {{count}} hours ago",
-    "timeDayAgo": "[MISSING TRANSLATION] {{count}} day ago"
+    "timeDayAgo": "[MISSING TRANSLATION] {{count}} day ago",
+    "analytics": {
+      "title": "Panel de analiticas",
+      "subtitle": "Visualizacion interactiva de datos e informacion en tiempo real",
+      "chartTypeSelector": "Selector de tipo de grafico",
+      "actions": {
+        "exportAll": "Exportar todo",
+        "exportAllAria": "Exportar todos los paneles como CSV",
+        "share": "Compartir",
+        "shareAria": "Copiar enlace compartible del panel",
+        "copied": "Copiado",
+        "exportPanel": "Exportar {{panel}} como CSV"
+      },
+      "toasts": {
+        "shareSuccess": "Enlace del panel copiado al portapapeles",
+        "shareError": "No se pudo copiar al portapapeles",
+        "exportAllSuccess": "Paneles exportados como CSV"
+      },
+      "exports": {
+        "labelColumn": "Etiqueta"
+      },
+      "filters": {
+        "show": "Mostrar filtros",
+        "hide": "Ocultar filtros",
+        "activeFilters": "Filtros activos",
+        "removeTimeRange": "Quitar filtro de rango de tiempo",
+        "removeCategory": "Quitar filtro de {{category}}",
+        "resetAll": "Restablecer todo",
+        "resetAllAria": "Restablecer todos los filtros",
+        "timeRange": "Rango de tiempo",
+        "aggregation": "Agregacion",
+        "metric": "Metrica",
+        "categories": "Categorias",
+        "categoryFilters": "Filtros de categoria",
+        "timeRangeOptions": {
+          "7d": "Ultimos 7 dias",
+          "30d": "Ultimos 30 dias",
+          "90d": "Ultimos 90 dias",
+          "1y": "Ultimo ano",
+          "all": "Todo el tiempo"
+        },
+        "aggregationOptions": {
+          "sum": "Suma",
+          "average": "Promedio",
+          "count": "Conteo",
+          "min": "Minimo",
+          "max": "Maximo"
+        },
+        "metrics": {
+          "enrollments": "Inscripciones",
+          "revenue": "Ingresos",
+          "completions": "Finalizaciones",
+          "views": "Vistas"
+        },
+        "categoriesOptions": {
+          "webDev": "Desarrollo web",
+          "dataScience": "Ciencia de datos",
+          "design": "Diseno",
+          "marketing": "Marketing",
+          "mobile": "Movil"
+        }
+      },
+      "panels": {
+        "enrollments": {
+          "title": "Inscripciones a cursos"
+        },
+        "revenue": {
+          "title": "Ingresos"
+        },
+        "completions": {
+          "title": "Finalizaciones"
+        },
+        "realtime": {
+          "title": "Actividad en vivo"
+        }
+      },
+      "datasets": {
+        "enrollments": "Inscripciones a cursos",
+        "revenue": "Ingresos",
+        "completions": "Finalizaciones",
+        "realtime": "Datos en vivo",
+        "views": "Vistas del curso"
+      },
+      "chartTypes": {
+        "line": "Grafico de lineas",
+        "bar": "Grafico de barras",
+        "area": "Grafico de area",
+        "pie": "Grafico circular",
+        "scatter": "Grafico de dispersion",
+        "radar": "Grafico radar"
+      },
+      "drillDown": {
+        "selected": "Seleccionado",
+        "allData": "Todos los datos",
+        "backToAllDataAria": "Volver a todos los datos",
+        "detailTitle": "Detalle - {{label}}",
+        "backToOverview": "Volver al resumen"
+      },
+      "realtime": {
+        "status": {
+          "paused": "Pausado",
+          "connected": "Conectado",
+          "simulating": "Simulando",
+          "disconnected": "Desconectado"
+        },
+        "pointsCount": "{{count}} pts",
+        "updateSpeed": "Velocidad de actualizacion",
+        "pause": "Pausar actualizaciones en vivo",
+        "resume": "Reanudar actualizaciones en vivo",
+        "reset": "Restablecer datos",
+        "loadingData": "Cargando datos...",
+        "waitingForData": "Esperando datos...",
+        "stats": {
+          "mean": "Media",
+          "median": "Mediana",
+          "trend": "Tendencia"
+        },
+        "trendDirections": {
+          "up": "Sube",
+          "down": "Baja",
+          "neutral": "Estable"
+        }
+      }
+    }
   },
   "profile": {
     "editProfile": "Editar Perfil",

--- a/src/utils/__tests__/visualizationUtils.test.ts
+++ b/src/utils/__tests__/visualizationUtils.test.ts
@@ -62,6 +62,16 @@ describe('visualizationUtils', () => {
       const labels = generateDateLabels('7d', 'short');
       expect(labels[0]).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
     });
+
+    it('should support locale-specific date labels', () => {
+      const labels = generateDateLabels('7d', 'short', 'es-ES');
+      const expectedDate = new Date();
+      expectedDate.setDate(expectedDate.getDate() - 6);
+
+      expect(labels[0]).toBe(
+        expectedDate.toLocaleDateString('es-ES', { month: 'short', day: 'numeric' }),
+      );
+    });
   });
 
   describe('calculateMovingAverage', () => {

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -67,6 +67,10 @@ const PANEL_DATA_CONFIG: Record<
 export const generateDashboardSampleData = (
   panelId: string,
   timeRange: TimeRange = '30d',
+  options?: {
+    locale?: string;
+    datasetLabel?: string;
+  },
 ): ChartData => {
   const cfg = PANEL_DATA_CONFIG[panelId] ?? {
     label: 'Metric',
@@ -76,14 +80,14 @@ export const generateDashboardSampleData = (
     max: 100,
   };
 
-  const labels = generateDateLabels(timeRange);
+  const labels = generateDateLabels(timeRange, 'short', options?.locale);
   const data = generateSampleData(labels.length, cfg.min, cfg.max);
 
   return {
     labels,
     datasets: [
       {
-        label: cfg.label,
+        label: options?.datasetLabel ?? cfg.label,
         data,
         borderColor: cfg.color,
         backgroundColor: cfg.bgColor,

--- a/src/utils/visualizationUtils.ts
+++ b/src/utils/visualizationUtils.ts
@@ -95,6 +95,7 @@ export const formatPercentage = (value: number, decimals = 1): string => {
 export const generateDateLabels = (
   range: TimeRange,
   format: 'short' | 'long' = 'short',
+  locale = 'en-US',
 ): string[] => {
   const now = new Date();
   const labels: string[] = [];
@@ -122,9 +123,9 @@ export const generateDateLabels = (
     date.setDate(date.getDate() - i);
 
     if (format === 'short') {
-      labels.push(date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }));
+      labels.push(date.toLocaleDateString(locale, { month: 'short', day: 'numeric' }));
     } else {
-      labels.push(date.toLocaleDateString('en-US'));
+      labels.push(date.toLocaleDateString(locale));
     }
   }
 
@@ -249,11 +250,11 @@ export const calculateTrend = (
 /**
  * Export chart data to CSV
  */
-export const exportToCSV = (data: ChartData, filename: string): void => {
+export const exportToCSV = (data: ChartData, filename: string, headerLabel = 'Label'): void => {
   const rows: string[] = [];
 
   // Header row
-  rows.push(['Label', ...data.datasets.map((d) => d.label)].join(','));
+  rows.push([headerLabel, ...data.datasets.map((d) => d.label)].join(','));
 
   // Data rows
   data.labels.forEach((label, index) => {


### PR DESCRIPTION
Closes #534
## Summary
- replace hardcoded Dashboard Analytics UI copy with localized strings
- add shared dashboard analytics translation helpers and locale entries for `en`, `es`, and `ar`
- localize chart controls, drill-down labels, realtime status text, toast messages, export headers, and date labels
- update dashboard and visualization tests to cover the i18n-aware behavior

## What changed
- added `src/components/dashboard/dashboardI18n.ts` to centralize dashboard analytics translation lookups and fallbacks
- updated dashboard components and hooks to use the existing `useInternationalization` flow
- made generated analytics date labels locale-aware
- made CSV export headers locale-aware
- expanded locale JSON files with dashboard analytics keys
- updated focused dashboard tests and added a locale-sensitive date-label test

## Testing
- locale JSON parse check passed with Node
- automated Vitest run is currently blocked in this environment because `node_modules` is missing, so `vitest` is not installed here

## Notes
- no staging or production deployment was performed from this environment
- branch pushed: `codex-dashboard-analytics-i18n`
- commit: `ed4fe06`