### PR TITLE
chore: notification system refactoring (#530)

### DIFF
--- a/src/app/hooks/__tests__/useNotifications.test.ts
+++ b/src/app/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,129 @@
+/**
+ * useNotifications – unit tests
+ *
+ * Focuses on the refactored clearNotification (delegates to store action)
+ * and basic hook behaviour.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useNotifications } from '../useNotifications';
+import { useNotificationStore } from '@/app/store/notificationStore';
+
+// ─── Mock localStorage ────────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  localStorageMock.clear();
+  useNotificationStore.setState({ notifications: [] });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useNotifications', () => {
+  beforeEach(resetStore);
+
+  // ── clearNotification ──────────────────────────────────────────────────────
+
+  it('clearNotification removes the notification via the store action', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    let id: string;
+    act(() => {
+      const n = result.current.sendNotification({ message: 'to remove' });
+      id = n.id;
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+
+    act(() => {
+      result.current.clearNotification(id);
+    });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it('clearNotification persists removal to localStorage', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    let id: string;
+    act(() => {
+      const n = result.current.sendNotification({ message: 'persist test' });
+      id = n.id;
+    });
+
+    act(() => {
+      result.current.clearNotification(id);
+    });
+
+    const stored = JSON.parse(localStorageMock.getItem('notifications_v1') ?? '[]');
+    expect(stored).toHaveLength(0);
+  });
+
+  it('clearNotification does not remove other notifications', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    let idA: string;
+    let idB: string;
+    act(() => {
+      idA = result.current.sendNotification({ message: 'keep' }).id;
+      idB = result.current.sendNotification({ message: 'remove' }).id;
+    });
+
+    act(() => {
+      result.current.clearNotification(idB);
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0].id).toBe(idA);
+  });
+
+  // ── markAsRead ─────────────────────────────────────────────────────────────
+
+  it('markAsRead marks the correct notification as read', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    let id: string;
+    act(() => {
+      id = result.current.sendNotification({ message: 'mark me' }).id;
+    });
+
+    act(() => {
+      result.current.markAsRead(id);
+    });
+
+    const n = result.current.notifications.find((x) => x.id === id);
+    expect(n?.read).toBe(true);
+  });
+
+  // ── unreadCount ────────────────────────────────────────────────────────────
+
+  it('unreadCount reflects the number of unread notifications', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.sendNotification({ message: 'a' });
+      result.current.sendNotification({ message: 'b' });
+    });
+
+    expect(result.current.unreadCount).toBe(2);
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+});

--- a/src/app/hooks/useNotifications.tsx
+++ b/src/app/hooks/useNotifications.tsx
@@ -80,6 +80,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
     addNotification,
     markAsRead: storeMarkAsRead,
     markAllAsRead: storeMarkAllAsRead,
+    removeNotification: storeRemoveNotification,
     clearRead: storeClearRead,
   } = useNotificationStore();
 
@@ -199,11 +200,9 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
   // Clear single notification
   const clearNotification = useCallback(
     (id: string) => {
-      const next = notifications.filter((n) => n.id !== id);
-      useNotificationStore.setState({ notifications: next });
-      localStorage.setItem('notifications_v1', JSON.stringify(next));
+      storeRemoveNotification(id);
     },
-    [notifications],
+    [storeRemoveNotification],
   );
 
   // Clear all read notifications
@@ -297,8 +296,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
       // Simulate delivery success/failure
       const success = Math.random() < deliveryRates[channel];
 
-      if (success) {
-      } else {
+      if (!success) {
         console.warn(`Failed to deliver notification ${notification.id} via ${channel}`);
       }
 

--- a/src/app/store/__tests__/notificationStore.test.ts
+++ b/src/app/store/__tests__/notificationStore.test.ts
@@ -1,0 +1,149 @@
+/**
+ * notificationStore – unit tests
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useNotificationStore } from '../notificationStore';
+
+// ─── Mock localStorage ────────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  localStorageMock.clear();
+  useNotificationStore.setState({ notifications: [] });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('notificationStore', () => {
+  beforeEach(resetStore);
+
+  // ── addNotification ────────────────────────────────────────────────────────
+
+  it('adds a notification and returns it', () => {
+    const { addNotification, notifications } = useNotificationStore.getState();
+    const n = addNotification({ type: 'info', message: 'hello' });
+
+    expect(n.id).toBeTruthy();
+    expect(n.type).toBe('info');
+    expect(n.message).toBe('hello');
+    expect(n.read).toBe(false);
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('prepends new notifications (newest first)', () => {
+    const { addNotification } = useNotificationStore.getState();
+    addNotification({ type: 'info', message: 'first' });
+    addNotification({ type: 'info', message: 'second' });
+
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications[0].message).toBe('second');
+    expect(notifications[1].message).toBe('first');
+  });
+
+  it('persists to localStorage on add', () => {
+    const { addNotification } = useNotificationStore.getState();
+    addNotification({ type: 'success', message: 'saved' });
+
+    const stored = JSON.parse(localStorageMock.getItem('notifications_v1') ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].message).toBe('saved');
+  });
+
+  // ── markAsRead ─────────────────────────────────────────────────────────────
+
+  it('marks a single notification as read', () => {
+    const { addNotification, markAsRead } = useNotificationStore.getState();
+    const n = addNotification({ type: 'info', message: 'test' });
+
+    markAsRead(n.id);
+
+    const updated = useNotificationStore.getState().notifications.find((x) => x.id === n.id);
+    expect(updated?.read).toBe(true);
+  });
+
+  it('does not affect other notifications when marking one as read', () => {
+    const { addNotification, markAsRead } = useNotificationStore.getState();
+    const a = addNotification({ type: 'info', message: 'a' });
+    const b = addNotification({ type: 'info', message: 'b' });
+
+    markAsRead(a.id);
+
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications.find((x) => x.id === a.id)?.read).toBe(true);
+    expect(notifications.find((x) => x.id === b.id)?.read).toBe(false);
+  });
+
+  // ── markAllAsRead ──────────────────────────────────────────────────────────
+
+  it('marks all notifications as read', () => {
+    const { addNotification, markAllAsRead } = useNotificationStore.getState();
+    addNotification({ type: 'info', message: 'a' });
+    addNotification({ type: 'warning', message: 'b' });
+
+    markAllAsRead();
+
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications.every((n) => n.read)).toBe(true);
+  });
+
+  // ── removeNotification ─────────────────────────────────────────────────────
+
+  it('removes the notification with the given id', () => {
+    const { addNotification, removeNotification } = useNotificationStore.getState();
+    const a = addNotification({ type: 'info', message: 'keep' });
+    const b = addNotification({ type: 'error', message: 'remove me' });
+
+    removeNotification(b.id);
+
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].id).toBe(a.id);
+  });
+
+  it('persists to localStorage after removal', () => {
+    const { addNotification, removeNotification } = useNotificationStore.getState();
+    const n = addNotification({ type: 'info', message: 'bye' });
+
+    removeNotification(n.id);
+
+    const stored = JSON.parse(localStorageMock.getItem('notifications_v1') ?? '[]');
+    expect(stored).toHaveLength(0);
+  });
+
+  it('is a no-op when id does not exist', () => {
+    const { addNotification, removeNotification } = useNotificationStore.getState();
+    addNotification({ type: 'info', message: 'stay' });
+
+    removeNotification('nonexistent-id');
+
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  // ── clearRead ──────────────────────────────────────────────────────────────
+
+  it('removes only read notifications', () => {
+    const { addNotification, markAsRead, clearRead } = useNotificationStore.getState();
+    const a = addNotification({ type: 'info', message: 'unread' });
+    const b = addNotification({ type: 'info', message: 'read' });
+
+    markAsRead(b.id);
+    clearRead();
+
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].id).toBe(a.id);
+  });
+});

--- a/src/app/store/notificationStore.ts
+++ b/src/app/store/notificationStore.ts
@@ -35,6 +35,7 @@ interface NotificationState {
   ) => AppNotification;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
+  removeNotification: (id: string) => void;
   clearRead: () => void;
 }
 
@@ -61,6 +62,11 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   },
   markAllAsRead: () => {
     const next = get().notifications.map((x) => ({ ...x, read: true }));
+    set({ notifications: next });
+    save(STORAGE_KEY, next);
+  },
+  removeNotification: (id) => {
+    const next = get().notifications.filter((x) => x.id !== id);
     set({ notifications: next });
     save(STORAGE_KEY, next);
   },


### PR DESCRIPTION
- Add removeNotification(id) action to notificationStore so single-item removal goes through the store (persists to localStorage, single source of truth)
- Fix clearNotification in useNotifications: was calling useNotificationStore.setState directly and writing localStorage manually; now delegates to storeRemoveNotification(id)
- Remove dead empty if(success){} block in sendToChannel
- Add unit tests: notificationStore (10 tests) covering add, markAsRead, markAllAsRead, removeNotification, clearRead; useNotifications (5 tests) covering clearNotification store delegation, localStorage persistence, isolation, markAsRead, and unreadCount

Closes #530

## Description

Brief description of changes

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
Closes #530 