### PR TITLE
feat: add Leaderboard Display with Conference Management (#486)

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { LeaderboardConference } from '@/components/leaderboard/LeaderboardConference';
+
+export const metadata: Metadata = {
+  title: 'Leaderboard | TeachLink',
+  description: 'View top contributors and join live conference sessions on TeachLink.',
+};
+
+export default function LeaderboardPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <LeaderboardConference />
+    </main>
+  );
+}

--- a/src/components/leaderboard/LeaderboardConference.tsx
+++ b/src/components/leaderboard/LeaderboardConference.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState } from 'react';
+import { Trophy, Medal, Crown, Users, Plus, Trash2, Video } from 'lucide-react';
+import { VideoConference } from '@/components/collaboration/VideoConference';
+
+export interface LeaderboardEntry {
+  id: string;
+  name: string;
+  avatar?: string;
+  score: number;
+  rank: number;
+}
+
+export interface Conference {
+  id: string;
+  name: string;
+  roomId: string;
+  participants: number;
+}
+
+interface LeaderboardConferenceProps {
+  entries?: LeaderboardEntry[];
+  conferences?: Conference[];
+  currentUserId?: string;
+  currentUserName?: string;
+}
+
+const RANK_ICONS = [
+  <Crown key="1" size={18} className="text-yellow-500" />,
+  <Medal key="2" size={18} className="text-slate-400" />,
+  <Medal key="3" size={18} className="text-amber-600" />,
+];
+
+const MOCK_ENTRIES: LeaderboardEntry[] = [
+  { id: '1', name: 'Alice Chen', score: 4820, rank: 1 },
+  { id: '2', name: 'Bob Okafor', score: 4310, rank: 2 },
+  { id: '3', name: 'Clara Diaz', score: 3990, rank: 3 },
+  { id: '4', name: 'David Kim', score: 3450, rank: 4 },
+  { id: '5', name: 'Eva Müller', score: 2980, rank: 5 },
+];
+
+export function LeaderboardConference({
+  entries = MOCK_ENTRIES,
+  conferences: initialConferences = [],
+  currentUserId = 'guest',
+  currentUserName = 'Guest',
+}: LeaderboardConferenceProps) {
+  const [conferences, setConferences] = useState<Conference[]>(initialConferences);
+  const [activeConference, setActiveConference] = useState<Conference | null>(null);
+  const [newConferenceName, setNewConferenceName] = useState('');
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  const sorted = [...entries].sort((a, b) => a.rank - b.rank);
+
+  const handleCreateConference = () => {
+    const name = newConferenceName.trim();
+    if (!name) return;
+    const conf: Conference = {
+      id: crypto.randomUUID(),
+      name,
+      roomId: `room-${Date.now()}`,
+      participants: 0,
+    };
+    setConferences((prev) => [...prev, conf]);
+    setNewConferenceName('');
+    setShowCreateForm(false);
+  };
+
+  const handleDeleteConference = (id: string) => {
+    if (activeConference?.id === id) setActiveConference(null);
+    setConferences((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Leaderboard */}
+      <section
+        className="rounded-3xl border border-gray-200 bg-white/90 p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950/90"
+        aria-label="Leaderboard"
+      >
+        <div className="flex items-center gap-2 mb-4">
+          <Trophy size={20} className="text-yellow-500" aria-hidden="true" />
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Leaderboard</h2>
+        </div>
+
+        <ol className="space-y-2" aria-label="Top participants">
+          {sorted.map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-center gap-3 rounded-2xl px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-100 dark:border-slate-800"
+            >
+              <span className="w-6 flex justify-center" aria-label={`Rank ${entry.rank}`}>
+                {entry.rank <= 3 ? RANK_ICONS[entry.rank - 1] : (
+                  <span className="text-sm font-semibold text-slate-500">{entry.rank}</span>
+                )}
+              </span>
+
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900 text-sm font-bold text-blue-700 dark:text-blue-300">
+                {entry.name.charAt(0)}
+              </div>
+
+              <span className="flex-1 text-sm font-medium text-slate-900 dark:text-slate-100">
+                {entry.name}
+              </span>
+
+              <span className="text-sm font-semibold text-blue-600 dark:text-blue-400" aria-label={`${entry.score} points`}>
+                {entry.score.toLocaleString()} pts
+              </span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Conference Management */}
+      <section
+        className="rounded-3xl border border-gray-200 bg-white/90 p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950/90"
+        aria-label="Conference management"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Users size={20} className="text-blue-500" aria-hidden="true" />
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Conferences</h2>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowCreateForm((v) => !v)}
+            className="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition"
+            aria-expanded={showCreateForm}
+          >
+            <Plus size={15} aria-hidden="true" />
+            New
+          </button>
+        </div>
+
+        {showCreateForm && (
+          <div className="mb-4 flex gap-2">
+            <input
+              type="text"
+              value={newConferenceName}
+              onChange={(e) => setNewConferenceName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCreateConference()}
+              placeholder="Conference name"
+              className="flex-1 rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Conference name"
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={handleCreateConference}
+              className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition"
+            >
+              Create
+            </button>
+          </div>
+        )}
+
+        {conferences.length === 0 ? (
+          <p className="py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+            No conferences yet. Create one to get started.
+          </p>
+        ) : (
+          <ul className="space-y-2" aria-label="Conference list">
+            {conferences.map((conf) => (
+              <li
+                key={conf.id}
+                className="flex items-center gap-3 rounded-2xl px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-100 dark:border-slate-800"
+              >
+                <Video size={16} className="text-slate-400 shrink-0" aria-hidden="true" />
+                <span className="flex-1 text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+                  {conf.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setActiveConference(activeConference?.id === conf.id ? null : conf)}
+                  className={`rounded-2xl px-3 py-1.5 text-xs font-semibold transition ${
+                    activeConference?.id === conf.id
+                      ? 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/40 dark:text-red-400'
+                      : 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-400'
+                  }`}
+                  aria-pressed={activeConference?.id === conf.id}
+                >
+                  {activeConference?.id === conf.id ? 'Leave' : 'Join'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDeleteConference(conf.id)}
+                  className="rounded-2xl p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition"
+                  aria-label={`Delete conference ${conf.name}`}
+                >
+                  <Trash2 size={15} aria-hidden="true" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Active Video Conference */}
+      {activeConference && (
+        <VideoConference
+          roomId={activeConference.roomId}
+          user={{ id: currentUserId, name: currentUserName, avatar: '', color: '#3b82f6' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/leaderboard/__tests__/LeaderboardConference.test.tsx
+++ b/src/components/leaderboard/__tests__/LeaderboardConference.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { LeaderboardConference } from '../LeaderboardConference';
+import type { LeaderboardEntry, Conference } from '../LeaderboardConference';
+
+// VideoConference uses socket.io and WebRTC — mock it to keep tests focused
+vi.mock('@/components/collaboration/VideoConference', () => ({
+  VideoConference: ({ roomId }: { roomId: string }) => (
+    <div data-testid="video-conference" data-room-id={roomId} />
+  ),
+}));
+
+const ENTRIES: LeaderboardEntry[] = [
+  { id: '1', name: 'Alice', score: 5000, rank: 1 },
+  { id: '2', name: 'Bob', score: 4000, rank: 2 },
+  { id: '3', name: 'Carol', score: 3000, rank: 3 },
+  { id: '4', name: 'Dave', score: 2000, rank: 4 },
+];
+
+const CONFERENCES: Conference[] = [
+  { id: 'c1', name: 'Study Hall', roomId: 'room-1', participants: 3 },
+];
+
+describe('LeaderboardConference', () => {
+  describe('Leaderboard section', () => {
+    it('renders the leaderboard heading', () => {
+      render(<LeaderboardConference entries={ENTRIES} />);
+      expect(screen.getByRole('region', { name: /leaderboard/i })).toBeInTheDocument();
+    });
+
+    it('renders all entries in rank order', () => {
+      render(<LeaderboardConference entries={ENTRIES} />);
+      const items = screen.getAllByRole('listitem');
+      expect(items[0]).toHaveTextContent('Alice');
+      expect(items[1]).toHaveTextContent('Bob');
+      expect(items[2]).toHaveTextContent('Carol');
+      expect(items[3]).toHaveTextContent('Dave');
+    });
+
+    it('displays formatted scores', () => {
+      render(<LeaderboardConference entries={ENTRIES} />);
+      expect(screen.getByText('5,000 pts')).toBeInTheDocument();
+      expect(screen.getByText('4,000 pts')).toBeInTheDocument();
+    });
+
+    it('shows rank number for entries beyond top 3', () => {
+      render(<LeaderboardConference entries={ENTRIES} />);
+      expect(screen.getByLabelText('Rank 4')).toHaveTextContent('4');
+    });
+
+    it('renders default mock entries when none provided', () => {
+      render(<LeaderboardConference />);
+      expect(screen.getByText('Alice Chen')).toBeInTheDocument();
+    });
+  });
+
+  describe('Conference management section', () => {
+    it('renders the conferences heading', () => {
+      render(<LeaderboardConference />);
+      expect(screen.getByRole('region', { name: /conference management/i })).toBeInTheDocument();
+    });
+
+    it('shows empty state when no conferences', () => {
+      render(<LeaderboardConference conferences={[]} />);
+      expect(screen.getByText(/no conferences yet/i)).toBeInTheDocument();
+    });
+
+    it('renders provided conferences', () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      expect(screen.getByText('Study Hall')).toBeInTheDocument();
+    });
+
+    it('toggles create form on New button click', async () => {
+      render(<LeaderboardConference conferences={[]} />);
+      const newBtn = screen.getByRole('button', { name: /new/i });
+
+      expect(screen.queryByPlaceholderText(/conference name/i)).not.toBeInTheDocument();
+      await userEvent.click(newBtn);
+      expect(screen.getByPlaceholderText(/conference name/i)).toBeInTheDocument();
+
+      await userEvent.click(newBtn);
+      expect(screen.queryByPlaceholderText(/conference name/i)).not.toBeInTheDocument();
+    });
+
+    it('creates a new conference', async () => {
+      render(<LeaderboardConference conferences={[]} />);
+      await userEvent.click(screen.getByRole('button', { name: /new/i }));
+
+      const input = screen.getByPlaceholderText(/conference name/i);
+      await userEvent.type(input, 'My Room');
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(screen.getByText('My Room')).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText(/conference name/i)).not.toBeInTheDocument();
+    });
+
+    it('creates a conference on Enter key', async () => {
+      render(<LeaderboardConference conferences={[]} />);
+      await userEvent.click(screen.getByRole('button', { name: /new/i }));
+
+      const input = screen.getByPlaceholderText(/conference name/i);
+      await userEvent.type(input, 'Enter Room{Enter}');
+
+      expect(screen.getByText('Enter Room')).toBeInTheDocument();
+    });
+
+    it('does not create a conference with empty name', async () => {
+      render(<LeaderboardConference conferences={[]} />);
+      await userEvent.click(screen.getByRole('button', { name: /new/i }));
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      // Form stays open, no new item added
+      expect(screen.getByPlaceholderText(/conference name/i)).toBeInTheDocument();
+      expect(screen.getByText(/no conferences yet/i)).toBeInTheDocument();
+    });
+
+    it('deletes a conference', async () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      expect(screen.getByText('Study Hall')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /delete conference study hall/i }));
+      expect(screen.queryByText('Study Hall')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Video conference integration', () => {
+    it('does not render VideoConference by default', () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      expect(screen.queryByTestId('video-conference')).not.toBeInTheDocument();
+    });
+
+    it('shows VideoConference when a conference is joined', async () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      await userEvent.click(screen.getByRole('button', { name: /^join$/i }));
+
+      const vc = screen.getByTestId('video-conference');
+      expect(vc).toBeInTheDocument();
+      expect(vc).toHaveAttribute('data-room-id', 'room-1');
+    });
+
+    it('hides VideoConference when leaving a conference', async () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      await userEvent.click(screen.getByRole('button', { name: /^join$/i }));
+      expect(screen.getByTestId('video-conference')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /^leave$/i }));
+      expect(screen.queryByTestId('video-conference')).not.toBeInTheDocument();
+    });
+
+    it('hides VideoConference when the active conference is deleted', async () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      await userEvent.click(screen.getByRole('button', { name: /^join$/i }));
+      expect(screen.getByTestId('video-conference')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /delete conference study hall/i }));
+      expect(screen.queryByTestId('video-conference')).not.toBeInTheDocument();
+    });
+
+    it('join button is aria-pressed when conference is active', async () => {
+      render(<LeaderboardConference conferences={CONFERENCES} />);
+      const joinBtn = screen.getByRole('button', { name: /^join$/i });
+      expect(joinBtn).toHaveAttribute('aria-pressed', 'false');
+
+      await userEvent.click(joinBtn);
+      expect(screen.getByRole('button', { name: /^leave$/i })).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  describe('Keyboard interaction', () => {
+    it('New button aria-expanded reflects form visibility', async () => {
+      render(<LeaderboardConference conferences={[]} />);
+      const newBtn = screen.getByRole('button', { name: /new/i });
+      expect(newBtn).toHaveAttribute('aria-expanded', 'false');
+
+      await userEvent.click(newBtn);
+      expect(newBtn).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});


### PR DESCRIPTION
What
  
  Implements the Leaderboard Display with Conference Management feature as described
  in issue #486.
  
  Changes
  
  New files:
  
  - src/components/leaderboard/LeaderboardConference.tsx — Core component with two
  sections:
    - Leaderboard — ranked participant list with crown/medal icons for top 3,
  formatted scores, and full ARIA accessibility
    - Conference Management — create, list, join/leave, and delete conference rooms;
  joining a room renders the existing VideoConference WebRTC component inline for live
  peer-to-peer sessions
  
  - src/app/leaderboard/page.tsx — Next.js App Router page at /leaderboard
  - src/components/leaderboard/__tests__/LeaderboardConference.test.tsx — 19 unit
  tests
  
  How it was tested
  
  - ✅ All 19 unit tests pass (pnpm vitest run)
  - ✅ No TypeScript errors in new files
  - ✅ No regressions in existing tests
  
  Acceptance criteria checklist
  
  - [x] Leaderboard Display properly implements Conference Management
  - [x] All related tests pass
  - [x] No regression in existing functionality
  - [x] Code follows project coding standards (Tailwind CSS, lucide icons, App Router,
  dark mode)
  - [x] Accessibility guidelines followed (ARIA labels, aria-pressed, aria-expanded,
  semantic landmarks)
  - [x] Performance impact is minimal (no new dependencies added)
  
  Notes
  
  The build was already failing before this PR due to a pre-existing syntax error in
  src/lib/api.ts — unrelated to this feature.
  
  Closes #486
  
  ──────────────