### PR TITLE
feat: Admin Panel Dark Mode Support (#535)

### DIFF
--- a/src/app/admin/cms/page.tsx
+++ b/src/app/admin/cms/page.tsx
@@ -9,6 +9,7 @@ import { ContentTemplates } from '@/components/cms/ContentTemplates';
 import { useCMS } from '@/hooks/useCMS';
 import { Save, Eye, Settings, Share2, AlertTriangle } from 'lucide-react';
 import { Toaster } from 'react-hot-toast';
+import AdminThemeToggle from '@/components/admin/AdminThemeToggle';
 
 export default function CMSDashboard() {
   const { course, setCourse } = useCMS();
@@ -69,6 +70,7 @@ export default function CMSDashboard() {
         </div>
 
         <div className="flex items-center gap-3">
+          <AdminThemeToggle />
           <button className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-all font-medium text-sm">
             <Eye className="w-4 h-4" />
             Preview

--- a/src/app/admin/permissions/page.tsx
+++ b/src/app/admin/permissions/page.tsx
@@ -4,33 +4,38 @@ import React from 'react';
 import { ROLES_PERMISSIONS } from '@/lib/auth/acl';
 import { UserRole, Permission } from '@/types/api';
 import { Shield, Check, X, Info } from 'lucide-react';
+import AdminThemeToggle from '@/components/admin/AdminThemeToggle';
 
 export default function PermissionsManagementPage() {
   const roles = Object.keys(ROLES_PERMISSIONS) as UserRole[];
   const allPermissions = Object.values(Permission);
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-            <Shield className="w-8 h-8 text-blue-600" />
-            Access Control Lists (ACL)
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-2">
-            Manage granular permissions for each user role in the system.
-          </p>
-        </div>
-        <div className="bg-blue-50 dark:bg-blue-900/30 p-4 rounded-lg border border-blue-100 dark:border-blue-800 max-w-md">
-          <div className="flex gap-3">
-            <Info className="w-5 h-5 text-blue-600 mt-0.5" />
-            <p className="text-sm text-blue-800 dark:text-blue-300">
-              <strong>Note:</strong> Permissions are currently read-only in this version. Changes
-              must be applied to the <code>acl.ts</code> configuration.
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 transition-colors duration-200">
+      <div className="container mx-auto py-8 px-4">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+              <Shield className="w-8 h-8 text-blue-600 dark:text-blue-400" />
+              Access Control Lists (ACL)
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">
+              Manage granular permissions for each user role in the system.
             </p>
           </div>
+          <div className="flex items-center gap-4">
+            <AdminThemeToggle />
+            <div className="bg-blue-50 dark:bg-blue-900/30 p-4 rounded-lg border border-blue-100 dark:border-blue-800 max-w-md">
+              <div className="flex gap-3">
+                <Info className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+                <p className="text-sm text-blue-800 dark:text-blue-300">
+                  <strong>Note:</strong> Permissions are currently read-only in this version. Changes
+                  must be applied to the <code className="bg-blue-100 dark:bg-blue-900/50 px-1 rounded">acl.ts</code> configuration.
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
 
       <div className="overflow-x-auto bg-white dark:bg-gray-900 rounded-xl shadow-lg border border-gray-200 dark:border-gray-800">
         <table className="w-full text-left border-collapse">
@@ -90,19 +95,20 @@ export default function PermissionsManagementPage() {
         </table>
       </div>
     </div>
+    </div>
   );
 }
 
 function getRoleColor(role: UserRole): string {
   switch (role) {
     case UserRole.ADMIN:
-      return 'bg-purple-100 text-purple-700 border border-purple-200';
+      return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-700';
     case UserRole.INSTRUCTOR:
-      return 'bg-blue-100 text-blue-700 border border-blue-200';
+      return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700';
     case UserRole.STUDENT:
-      return 'bg-green-100 text-green-700 border border-green-200';
+      return 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-700';
     default:
-      return 'bg-gray-100 text-gray-700 border border-gray-200';
+      return 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700';
   }
 }
 

--- a/src/components/admin/AdminThemeToggle.tsx
+++ b/src/components/admin/AdminThemeToggle.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { Moon, Sun, Monitor } from 'lucide-react';
+import { useThemeContext, Theme } from '@/contexts/ThemeContext';
+
+/**
+ * Admin-specific dark mode toggle for the admin panel header.
+ * Provides light/dark/system mode switching with visual feedback.
+ */
+export default function AdminThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useThemeContext();
+
+  const options: { value: Theme; icon: React.ReactNode; label: string }[] = [
+    { value: 'light', icon: <Sun className="w-4 h-4" />, label: 'Light' },
+    { value: 'dark', icon: <Moon className="w-4 h-4" />, label: 'Dark' },
+    { value: 'system', icon: <Monitor className="w-4 h-4" />, label: 'System' },
+  ];
+
+  return (
+    <div className="flex items-center gap-1 p-1 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => setTheme(opt.value)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${
+            theme === opt.value
+              ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+          }`}
+          aria-label={`Switch to ${opt.label} mode`}
+          aria-pressed={theme === opt.value}
+        >
+          {opt.icon}
+          <span className="hidden sm:inline">{opt.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds full dark mode support to the Admin Panel.

## Changes
- Create AdminThemeToggle component with light/dark/system mode switching
- Integrate theme toggle into CMS dashboard header
- Integrate theme toggle into permissions management page
- Add full dark mode background to permissions page wrapper
- Fix role color badges to support dark mode variants
- Ensure smooth transition-colors on theme change

Closes #535