### PR TITLE
feat: implement Knowledge Graph for Wallet Integration

### DIFF
--- a/src/hooks/useWalletKnowledgeGraph.ts
+++ b/src/hooks/useWalletKnowledgeGraph.ts
@@ -1,0 +1,110 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { walletKnowledgeGraph } from '@/lib/wallet/knowledgeGraph.service';
+import type {
+  WalletProfile,
+  TipRelationship,
+  GraphStats,
+  TransactionNode,
+  TokenNode,
+  ContentNode,
+} from '@/lib/wallet/knowledgeGraph.types';
+
+interface UseWalletKnowledgeGraphReturn {
+  /** Full profile for a wallet address */
+  getWalletProfile: (address: string) => WalletProfile | null;
+  /** Tip relationships originating from a wallet */
+  getTipRelationships: (address: string) => TipRelationship[];
+  /** Reputation score for a wallet (0–100) */
+  getReputationScore: (address: string) => number;
+  /** Current graph statistics */
+  stats: GraphStats;
+  /** Register a wallet in the graph */
+  registerWallet: (address: string, chainId: string | null, provider: string | null) => void;
+  /** Record a tip transaction */
+  recordTip: (tx: Omit<TransactionNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>) => void;
+  /** Register a token holding */
+  registerToken: (token: Omit<TokenNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>, walletAddress: string) => void;
+  /** Register authored content */
+  registerContent: (content: Omit<ContentNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>) => void;
+}
+
+/**
+ * useWalletKnowledgeGraph
+ *
+ * Provides access to the wallet knowledge graph for querying relationships,
+ * reputation scores, and tip history. Also exposes mutation helpers to
+ * populate the graph as wallet events occur.
+ */
+export function useWalletKnowledgeGraph(): UseWalletKnowledgeGraphReturn {
+  const [stats, setStats] = useState<GraphStats>(() => walletKnowledgeGraph.getStats());
+
+  const refreshStats = useCallback(() => {
+    setStats(walletKnowledgeGraph.getStats());
+  }, []);
+
+  const getWalletProfile = useCallback((address: string) => {
+    return walletKnowledgeGraph.getWalletProfile(address);
+  }, []);
+
+  const getTipRelationships = useCallback((address: string) => {
+    return walletKnowledgeGraph.getTipRelationships(address);
+  }, []);
+
+  const getReputationScore = useCallback((address: string) => {
+    return walletKnowledgeGraph.getReputationScore(address);
+  }, []);
+
+  const registerWallet = useCallback(
+    (address: string, chainId: string | null, provider: string | null) => {
+      walletKnowledgeGraph.upsertWallet(address, chainId, provider);
+      refreshStats();
+    },
+    [refreshStats],
+  );
+
+  const recordTip = useCallback(
+    (tx: Omit<TransactionNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>) => {
+      walletKnowledgeGraph.addTransaction(tx);
+      refreshStats();
+    },
+    [refreshStats],
+  );
+
+  const registerToken = useCallback(
+    (
+      token: Omit<TokenNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>,
+      walletAddress: string,
+    ) => {
+      walletKnowledgeGraph.addToken(token);
+      walletKnowledgeGraph.linkWalletToken(walletAddress, token.id);
+      refreshStats();
+    },
+    [refreshStats],
+  );
+
+  const registerContent = useCallback(
+    (content: Omit<ContentNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>) => {
+      walletKnowledgeGraph.addContent(content);
+      refreshStats();
+    },
+    [refreshStats],
+  );
+
+  // Sync stats on mount
+  useEffect(() => {
+    refreshStats();
+  }, [refreshStats]);
+
+  return {
+    getWalletProfile,
+    getTipRelationships,
+    getReputationScore,
+    stats,
+    registerWallet,
+    recordTip,
+    registerToken,
+    registerContent,
+  };
+}

--- a/src/lib/wallet/knowledgeGraph.service.ts
+++ b/src/lib/wallet/knowledgeGraph.service.ts
@@ -1,0 +1,359 @@
+/**
+ * Wallet Knowledge Graph Service
+ *
+ * In-memory graph store for tracking wallet relationships, tip history,
+ * and reputation scores. Designed for client-side use with optional
+ * persistence via localStorage.
+ */
+
+import type {
+  KnowledgeGraph,
+  GraphNode,
+  GraphEdge,
+  EdgeType,
+  WalletNode,
+  UserNode,
+  TransactionNode,
+  TokenNode,
+  ContentNode,
+  WalletProfile,
+  TipRelationship,
+  GraphStats,
+} from './knowledgeGraph.types';
+
+const STORAGE_KEY = 'teachlink_wallet_graph';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function now(): number {
+  return Date.now();
+}
+
+function makeEdgeId(type: EdgeType, fromId: string, toId: string): string {
+  return `${type}:${fromId}:${toId}`;
+}
+
+function createGraph(): KnowledgeGraph {
+  return {
+    nodes: new Map(),
+    edges: new Map(),
+    adjacency: new Map(),
+  };
+}
+
+// ─── WalletKnowledgeGraphService ─────────────────────────────────────────────
+
+export class WalletKnowledgeGraphService {
+  private graph: KnowledgeGraph;
+
+  constructor() {
+    this.graph = createGraph();
+    this.loadFromStorage();
+  }
+
+  // ── Node Operations ─────────────────────────────────────────────────────
+
+  addNode(node: GraphNode): void {
+    this.graph.nodes.set(node.id, { ...node, updatedAt: now() });
+    if (!this.graph.adjacency.has(node.id)) {
+      this.graph.adjacency.set(node.id, new Set());
+    }
+    this.persistToStorage();
+  }
+
+  getNode<T extends GraphNode>(id: string): T | undefined {
+    return this.graph.nodes.get(id) as T | undefined;
+  }
+
+  upsertWallet(address: string, chainId: string | null, provider: string | null): WalletNode {
+    const existing = this.getNode<WalletNode>(address);
+    const wallet: WalletNode = {
+      id: address,
+      type: 'wallet',
+      address,
+      chainId,
+      provider,
+      reputationScore: existing?.reputationScore ?? 0,
+      totalTipped: existing?.totalTipped ?? '0',
+      totalReceived: existing?.totalReceived ?? '0',
+      createdAt: existing?.createdAt ?? now(),
+      updatedAt: now(),
+      metadata: existing?.metadata ?? {},
+    };
+    this.addNode(wallet);
+    return wallet;
+  }
+
+  upsertUser(userId: string, walletAddress: string, displayName?: string): UserNode {
+    const existing = this.getNode<UserNode>(userId);
+    const user: UserNode = {
+      id: userId,
+      type: 'user',
+      userId,
+      displayName,
+      createdAt: existing?.createdAt ?? now(),
+      updatedAt: now(),
+      metadata: existing?.metadata ?? {},
+    };
+    this.addNode(user);
+    // Link user → wallet
+    this.addEdge('OWNS', userId, walletAddress);
+    return user;
+  }
+
+  addTransaction(tx: Omit<TransactionNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>): TransactionNode {
+    const node: TransactionNode = {
+      ...tx,
+      type: 'transaction',
+      createdAt: now(),
+      updatedAt: now(),
+      metadata: {},
+    };
+    this.addNode(node);
+
+    // Ensure wallet nodes exist
+    this.upsertWallet(tx.from, tx.chainId, null);
+    this.upsertWallet(tx.to, tx.chainId, null);
+
+    // Add directional edges
+    this.addEdge('SENT', tx.from, tx.id);
+    this.addEdge('RECEIVED', tx.to, tx.id);
+    this.addEdge('TIPPED', tx.from, tx.to, parseFloat(tx.value) || 0);
+
+    // Update reputation and totals
+    this.updateWalletStats(tx.from, tx.to, tx.value);
+
+    // Link to content if provided
+    if (tx.contentId) {
+      this.addEdge('TIPPED_CONTENT', tx.from, tx.contentId);
+    }
+
+    return node;
+  }
+
+  addToken(token: Omit<TokenNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>): TokenNode {
+    const node: TokenNode = {
+      ...token,
+      type: 'token',
+      createdAt: now(),
+      updatedAt: now(),
+      metadata: {},
+    };
+    this.addNode(node);
+    return node;
+  }
+
+  linkWalletToken(walletAddress: string, tokenId: string): void {
+    this.addEdge('HOLDS', walletAddress, tokenId);
+  }
+
+  addContent(content: Omit<ContentNode, 'type' | 'createdAt' | 'updatedAt' | 'metadata'>): ContentNode {
+    const node: ContentNode = {
+      ...content,
+      type: 'content',
+      createdAt: now(),
+      updatedAt: now(),
+      metadata: {},
+    };
+    this.addNode(node);
+    if (content.authorWallet) {
+      this.addEdge('AUTHORED', content.authorWallet, content.id);
+    }
+    return node;
+  }
+
+  // ── Edge Operations ─────────────────────────────────────────────────────
+
+  addEdge(type: EdgeType, fromId: string, toId: string, weight = 1): GraphEdge {
+    const id = makeEdgeId(type, fromId, toId);
+    const existing = this.graph.edges.get(id);
+
+    const edge: GraphEdge = {
+      id,
+      type,
+      fromId,
+      toId,
+      weight: (existing?.weight ?? 0) + weight,
+      createdAt: existing?.createdAt ?? now(),
+      metadata: existing?.metadata ?? {},
+    };
+
+    this.graph.edges.set(id, edge);
+
+    // Update adjacency
+    const fromAdj = this.graph.adjacency.get(fromId) ?? new Set();
+    fromAdj.add(id);
+    this.graph.adjacency.set(fromId, fromAdj);
+
+    this.persistToStorage();
+    return edge;
+  }
+
+  getEdgesBetween(fromId: string, toId: string): GraphEdge[] {
+    const adjEdgeIds = this.graph.adjacency.get(fromId) ?? new Set();
+    return Array.from(adjEdgeIds)
+      .map((id) => this.graph.edges.get(id))
+      .filter((e): e is GraphEdge => !!e && e.toId === toId);
+  }
+
+  // ── Query Operations ────────────────────────────────────────────────────
+
+  getWalletProfile(address: string): WalletProfile | null {
+    const wallet = this.getNode<WalletNode>(address);
+    if (!wallet) return null;
+
+    const adjEdgeIds = this.graph.adjacency.get(address) ?? new Set();
+    const edges = Array.from(adjEdgeIds)
+      .map((id) => this.graph.edges.get(id))
+      .filter((e): e is GraphEdge => !!e);
+
+    const connectedUsers: UserNode[] = [];
+    const recentTransactions: TransactionNode[] = [];
+    const heldTokens: TokenNode[] = [];
+    const authoredContent: ContentNode[] = [];
+
+    // Traverse incoming OWNS edges to find users
+    for (const [, edge] of this.graph.edges) {
+      if (edge.type === 'OWNS' && edge.toId === address) {
+        const user = this.getNode<UserNode>(edge.fromId);
+        if (user) connectedUsers.push(user);
+      }
+    }
+
+    for (const edge of edges) {
+      if (edge.type === 'SENT') {
+        const tx = this.getNode<TransactionNode>(edge.toId);
+        if (tx) recentTransactions.push(tx);
+      }
+      if (edge.type === 'HOLDS') {
+        const token = this.getNode<TokenNode>(edge.toId);
+        if (token) heldTokens.push(token);
+      }
+      if (edge.type === 'AUTHORED') {
+        const content = this.getNode<ContentNode>(edge.toId);
+        if (content) authoredContent.push(content);
+      }
+    }
+
+    // Sort transactions by most recent
+    recentTransactions.sort((a, b) => b.createdAt - a.createdAt);
+
+    return {
+      wallet,
+      connectedUsers,
+      recentTransactions: recentTransactions.slice(0, 20),
+      heldTokens,
+      authoredContent,
+      reputationScore: wallet.reputationScore,
+    };
+  }
+
+  getTipRelationships(address: string): TipRelationship[] {
+    const adjEdgeIds = this.graph.adjacency.get(address) ?? new Set();
+    const tipEdges = Array.from(adjEdgeIds)
+      .map((id) => this.graph.edges.get(id))
+      .filter((e): e is GraphEdge => !!e && e.type === 'TIPPED');
+
+    return tipEdges.map((edge) => {
+      // Count transactions between these two wallets
+      const txEdges = this.getEdgesBetween(address, edge.toId).filter(
+        (e) => e.type === 'SENT',
+      );
+      const txNodes = txEdges
+        .map((e) => this.getNode<TransactionNode>(e.toId))
+        .filter((t): t is TransactionNode => !!t && t.to === edge.toId);
+
+      const lastTipAt = txNodes.reduce((max, tx) => Math.max(max, tx.createdAt), 0);
+
+      return {
+        fromWallet: address,
+        toWallet: edge.toId,
+        totalValue: edge.weight.toString(),
+        transactionCount: txNodes.length,
+        lastTipAt,
+      };
+    });
+  }
+
+  getReputationScore(address: string): number {
+    return this.getNode<WalletNode>(address)?.reputationScore ?? 0;
+  }
+
+  getStats(): GraphStats {
+    let walletCount = 0;
+    let transactionCount = 0;
+    for (const node of this.graph.nodes.values()) {
+      if (node.type === 'wallet') walletCount++;
+      if (node.type === 'transaction') transactionCount++;
+    }
+    return {
+      nodeCount: this.graph.nodes.size,
+      edgeCount: this.graph.edges.size,
+      walletCount,
+      transactionCount,
+    };
+  }
+
+  // ── Persistence ─────────────────────────────────────────────────────────
+
+  clear(): void {
+    this.graph = createGraph();
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  private updateWalletStats(fromAddress: string, toAddress: string, value: string): void {
+    const amount = parseFloat(value) || 0;
+
+    const sender = this.getNode<WalletNode>(fromAddress);
+    if (sender) {
+      const newTipped = (parseFloat(sender.totalTipped) + amount).toString();
+      // Reputation increases slightly for tipping (active participation)
+      const newScore = Math.min(100, sender.reputationScore + 0.5);
+      this.addNode({ ...sender, totalTipped: newTipped, reputationScore: newScore });
+    }
+
+    const receiver = this.getNode<WalletNode>(toAddress);
+    if (receiver) {
+      const newReceived = (parseFloat(receiver.totalReceived) + amount).toString();
+      // Reputation increases more for receiving tips (recognition)
+      const newScore = Math.min(100, receiver.reputationScore + 1);
+      this.addNode({ ...receiver, totalReceived: newReceived, reputationScore: newScore });
+    }
+  }
+
+  private persistToStorage(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const serializable = {
+        nodes: Array.from(this.graph.nodes.entries()),
+        edges: Array.from(this.graph.edges.entries()),
+        adjacency: Array.from(this.graph.adjacency.entries()).map(([k, v]) => [k, Array.from(v)]),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializable));
+    } catch {
+      // Storage quota exceeded or unavailable — silently skip
+    }
+  }
+
+  private loadFromStorage(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      this.graph.nodes = new Map(parsed.nodes ?? []);
+      this.graph.edges = new Map(parsed.edges ?? []);
+      this.graph.adjacency = new Map(
+        (parsed.adjacency ?? []).map(([k, v]: [string, string[]]) => [k, new Set(v)]),
+      );
+    } catch {
+      // Corrupted storage — start fresh
+      this.graph = createGraph();
+    }
+  }
+}
+
+// Singleton instance
+export const walletKnowledgeGraph = new WalletKnowledgeGraphService();

--- a/src/lib/wallet/knowledgeGraph.types.ts
+++ b/src/lib/wallet/knowledgeGraph.types.ts
@@ -1,0 +1,122 @@
+/**
+ * Wallet Knowledge Graph Types
+ *
+ * Models the relationships between wallets, users, transactions, and tokens
+ * to enable reputation scoring, tip history, and social graph traversal.
+ */
+
+// ─── Node Types ──────────────────────────────────────────────────────────────
+
+export type NodeType = 'wallet' | 'user' | 'transaction' | 'token' | 'content';
+
+export interface BaseNode {
+  id: string;
+  type: NodeType;
+  createdAt: number;
+  updatedAt: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface WalletNode extends BaseNode {
+  type: 'wallet';
+  address: string;
+  chainId: string | null;
+  provider: string | null;
+  /** Reputation score derived from tip activity */
+  reputationScore: number;
+  /** Total value tipped out (in smallest unit) */
+  totalTipped: string;
+  /** Total value received */
+  totalReceived: string;
+}
+
+export interface UserNode extends BaseNode {
+  type: 'user';
+  userId: string;
+  displayName?: string;
+}
+
+export interface TransactionNode extends BaseNode {
+  type: 'transaction';
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  chainId: string;
+  status: 'pending' | 'confirmed' | 'failed';
+  /** Optional content reference this tip is associated with */
+  contentId?: string;
+}
+
+export interface TokenNode extends BaseNode {
+  type: 'token';
+  address: string;
+  symbol: string;
+  decimals: number;
+  chainId: string;
+}
+
+export interface ContentNode extends BaseNode {
+  type: 'content';
+  contentId: string;
+  title?: string;
+  authorWallet?: string;
+}
+
+export type GraphNode = WalletNode | UserNode | TransactionNode | TokenNode | ContentNode;
+
+// ─── Edge Types ──────────────────────────────────────────────────────────────
+
+export type EdgeType =
+  | 'OWNS'          // user → wallet
+  | 'SENT'          // wallet → transaction
+  | 'RECEIVED'      // wallet → transaction
+  | 'TIPPED'        // wallet → wallet (via transaction)
+  | 'HOLDS'         // wallet → token
+  | 'AUTHORED'      // wallet → content
+  | 'TIPPED_CONTENT'; // wallet → content
+
+export interface GraphEdge {
+  id: string;
+  type: EdgeType;
+  fromId: string;
+  toId: string;
+  weight: number;
+  createdAt: number;
+  metadata: Record<string, unknown>;
+}
+
+// ─── Graph Structure ─────────────────────────────────────────────────────────
+
+export interface KnowledgeGraph {
+  nodes: Map<string, GraphNode>;
+  edges: Map<string, GraphEdge>;
+  /** Adjacency list: nodeId → Set of edge IDs */
+  adjacency: Map<string, Set<string>>;
+}
+
+// ─── Query Results ────────────────────────────────────────────────────────────
+
+export interface WalletProfile {
+  wallet: WalletNode;
+  connectedUsers: UserNode[];
+  recentTransactions: TransactionNode[];
+  heldTokens: TokenNode[];
+  authoredContent: ContentNode[];
+  reputationScore: number;
+}
+
+export interface TipRelationship {
+  fromWallet: string;
+  toWallet: string;
+  totalValue: string;
+  transactionCount: number;
+  lastTipAt: number;
+}
+
+export interface GraphStats {
+  nodeCount: number;
+  edgeCount: number;
+  walletCount: number;
+  transactionCount: number;
+}


### PR DESCRIPTION
 feat: Implement Knowledge Graph for Wallet Integration
  
  Summary
  
  Adds a Knowledge Graph layer to the wallet integration, enabling structured
  relationship tracking between wallets, users, transactions, tokens, and content
  — powering reputation scoring, tip history, and social graph traversal.
  
  Changes
  
  src/lib/wallet/knowledgeGraph.types.ts
  
  Defines all graph primitives:
  
  - Node types: WalletNode, UserNode, TransactionNode, TokenNode, ContentNode
  - Edge types: OWNS, SENT, RECEIVED, TIPPED, HOLDS, AUTHORED, TIPPED_CONTENT
  - Query result types: WalletProfile, TipRelationship, GraphStats
  
  src/lib/wallet/knowledgeGraph.service.ts
  
  WalletKnowledgeGraphService class with:
  
  - Node/edge CRUD with Map-based adjacency list
  - upsertWallet, addTransaction, addToken, addContent helpers
  - getWalletProfile — full wallet context (users, txs, tokens, content)
  - getTipRelationships — who a wallet has tipped and how much
  - getReputationScore — score derived from tip activity (0–100)
  - localStorage persistence with graceful fallback
  - Exported singleton walletKnowledgeGraph
  
  src/hooks/useWalletKnowledgeGraph.ts
  
  React hook exposing graph queries and mutations:
  
  - registerWallet, recordTip, registerToken, registerContent
  - getWalletProfile, getTipRelationships, getReputationScore
  - Reactive stats (node/edge counts)
  
  Testing
  
  - Unit tests to be added in follow-up (task #5 pending)
  
  Closes
  
  Resolves: Wallet Integration Knowledge Graph implementation
closes #466
