### PR TITLE
Add notification persistent volume manifest

### DIFF
--- a/docs/NOTIFICATION_PERSISTENT_VOLUMES.md
+++ b/docs/NOTIFICATION_PERSISTENT_VOLUMES.md
@@ -1,0 +1,37 @@
+# Notification Persistent Volumes
+
+The production notification system stores durable notification data on a Kubernetes
+PersistentVolumeClaim so pod restarts do not discard queued or cached notification
+state.
+
+## Kubernetes Resources
+
+Apply `k8s/notification-system-persistence.yaml` with the rest of the production
+manifests:
+
+```bash
+kubectl apply -f k8s/notification-system-persistence.yaml
+```
+
+The manifest creates:
+
+- `PersistentVolumeClaim/teachlink-notification-data` with `1Gi` requested storage.
+- `Deployment/teachlink-notification-system` with the PVC mounted at
+  `/var/lib/teachlink/notifications`.
+- `NOTIFICATION_STORAGE_PATH=/var/lib/teachlink/notifications` for the application.
+
+The deployment uses one replica and the `Recreate` strategy because the PVC uses
+`ReadWriteOnce`. If the cluster provides a `ReadWriteMany` storage class, the
+replica count can be raised after updating the PVC access mode and validating
+concurrent writes.
+
+## Validation
+
+Run the manifest regression test before deploying:
+
+```bash
+pnpm test k8s/notification-system-persistence.test.ts
+```
+
+This confirms the deployment still mounts the notification PVC and keeps the
+storage-safe rollout settings.

--- a/k8s/notification-system-persistence.test.ts
+++ b/k8s/notification-system-persistence.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const manifest = readFileSync(join(process.cwd(), 'k8s/notification-system-persistence.yaml'), 'utf8');
+
+describe('notification system persistence manifest', () => {
+  it('declares a persistent volume claim for notification data', () => {
+    expect(manifest).toContain('kind: PersistentVolumeClaim');
+    expect(manifest).toContain('name: teachlink-notification-data');
+    expect(manifest).toContain('component: notification-system');
+    expect(manifest).toContain('storage: 1Gi');
+  });
+
+  it('mounts the notification PVC into the deployment', () => {
+    expect(manifest).toContain('kind: Deployment');
+    expect(manifest).toContain('name: teachlink-notification-system');
+    expect(manifest).toContain('mountPath: /var/lib/teachlink/notifications');
+    expect(manifest).toContain('claimName: teachlink-notification-data');
+  });
+
+  it('uses a single replica with Recreate for ReadWriteOnce storage safety', () => {
+    expect(manifest).toMatch(/replicas:\s*1/);
+    expect(manifest).toMatch(/strategy:\s*\n\s*type: Recreate/);
+    expect(manifest).toContain('ReadWriteOnce');
+  });
+});

--- a/k8s/notification-system-persistence.yaml
+++ b/k8s/notification-system-persistence.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: teachlink-notification-data
+  namespace: production
+  labels:
+    app: teachlink
+    component: notification-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teachlink-notification-system
+  namespace: production
+  labels:
+    app: teachlink
+    component: notification-system
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: teachlink
+      component: notification-system
+  template:
+    metadata:
+      labels:
+        app: teachlink
+        component: notification-system
+    spec:
+      securityContext:
+        fsGroup: 1001
+      containers:
+      - name: notification-system
+        image: rinafcode/teachlink-notification-system:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: NOTIFICATION_STORAGE_PATH
+          value: "/var/lib/teachlink/notifications"
+        volumeMounts:
+        - name: notification-data
+          mountPath: /var/lib/teachlink/notifications
+      volumes:
+      - name: notification-data
+        persistentVolumeClaim:
+          claimName: teachlink-notification-data


### PR DESCRIPTION
﻿Summary
- Added a Kubernetes persistence manifest for the Notification System so production notification data can survive pod restarts through a PersistentVolumeClaim.
- Documented how to apply and validate the manifest, including the storage path and ReadWriteOnce scaling tradeoff.
- Added a focused Vitest regression test that checks the PVC, deployment mount, and storage-safe rollout settings stay in place.

Issue
- Closes #372

Changes
- Added `k8s/notification-system-persistence.yaml` with `PersistentVolumeClaim/teachlink-notification-data` and `Deployment/teachlink-notification-system`.
- Mounted the PVC at `/var/lib/teachlink/notifications` and exposed that location through `NOTIFICATION_STORAGE_PATH`.
- Kept the deployment at one replica with `Recreate` strategy because the default PVC access mode is `ReadWriteOnce`.
- Added `k8s/notification-system-persistence.test.ts` to validate the persistence manifest.
- Added `docs/NOTIFICATION_PERSISTENT_VOLUMES.md` with deployment and validation notes.

Validation
- Ran `pnpm.cmd install --frozen-lockfile --ignore-scripts --offline`.
- Ran `pnpm.cmd test k8s/notification-system-persistence.test.ts`.
- Ran `git diff --check`.
- Ran `pnpm.cmd run type-check`; failed before/independent of this change with existing `tsconfig.json(4,27): error TS5103: Invalid value for '--ignoreDeprecations'.`
- Ran `pnpm.cmd run lint`; failed with existing unrelated lint/prettier and undefined component errors across the repo. `next lint` also attempted to rewrite `tsconfig.json`; those generated edits were reverted before commit.

Notes
- No lockfiles were changed.
- This uses a PVC for dynamic PersistentVolume provisioning rather than a cluster-specific static PersistentVolume.
- Horizontal scaling should use a `ReadWriteMany` storage class or another shared storage design after validating concurrent notification writes.
