### PR TITLE
feat: improve post editor accessibility (WCAG 2.1)

### DIFF
--- a/src/app/editor/EditorWorkspace.tsx
+++ b/src/app/editor/EditorWorkspace.tsx
@@ -26,6 +26,7 @@ export function EditorWorkspace() {
         </h1>
         <button
           onClick={() => setIsPreviewMode((prev) => !prev)}
+          aria-pressed={isPreviewMode}
           className={`rounded-lg px-4 py-2 font-medium transition-colors ${
             isPreviewMode
               ? 'bg-blue-600 text-white hover:bg-blue-700'

--- a/src/components/editor/CollaborativeEditingTools.tsx
+++ b/src/components/editor/CollaborativeEditingTools.tsx
@@ -10,20 +10,24 @@ const COLLABORATORS = [
 export const CollaborativeEditingTools: React.FC = () => {
   return (
     <div className="flex items-center gap-2">
-      <div className="flex -space-x-2">
+      <div className="flex -space-x-2" role="list" aria-label="Active collaborators">
         {COLLABORATORS.map((user) => (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             key={user.id}
+            role="listitem"
             src={user.avatar}
-            alt={user.name}
+            alt={`${user.name} is editing`}
             title={`${user.name} is editing`}
             className="w-8 h-8 rounded-full border-2 border-white dark:border-gray-800"
           />
         ))}
       </div>
-      <span className="text-xs text-green-500 font-medium px-2 py-1 bg-green-100 dark:bg-green-900 rounded-full">
-        3 active
+      <span
+        aria-label={`${COLLABORATORS.length} active collaborators`}
+        className="text-xs text-green-500 font-medium px-2 py-1 bg-green-100 dark:bg-green-900 rounded-full"
+      >
+        {COLLABORATORS.length} active
       </span>
     </div>
   );

--- a/src/components/editor/ContentTemplateLibrary.tsx
+++ b/src/components/editor/ContentTemplateLibrary.tsx
@@ -26,7 +26,10 @@ export const ContentTemplateLibrary: React.FC<ContentTemplateLibraryProps> = ({ 
   };
 
   return (
-    <div className="p-4 bg-gray-50 dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 h-full w-64 hidden lg:block">
+    <aside
+      aria-label="Content templates"
+      className="p-4 bg-gray-50 dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 h-full w-64 hidden lg:block"
+    >
       <h3 className="font-semibold text-sm text-gray-500 uppercase mb-4 tracking-wider">
         Templates
       </h3>
@@ -35,9 +38,12 @@ export const ContentTemplateLibrary: React.FC<ContentTemplateLibraryProps> = ({ 
           <button
             key={template.id}
             onClick={() => insertTemplate(editor, template.id)}
+            aria-label={`Insert ${template.name} template: ${template.description}`}
             className="w-full flex items-center gap-3 p-3 text-left rounded-lg bg-white dark:bg-gray-800 hover:bg-blue-50 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700 transition-colors group"
           >
-            <div className="text-gray-500 group-hover:text-blue-500">{getIcon(template.id)}</div>
+            <div className="text-gray-500 group-hover:text-blue-500" aria-hidden="true">
+              {getIcon(template.id)}
+            </div>
             <div>
               <div className="font-medium text-sm">{template.name}</div>
               <div className="text-xs text-gray-400 truncate w-32">{template.description}</div>
@@ -45,6 +51,6 @@ export const ContentTemplateLibrary: React.FC<ContentTemplateLibraryProps> = ({ 
           </button>
         ))}
       </div>
-    </div>
+    </aside>
   );
 };

--- a/src/components/editor/MediaEmbedder.tsx
+++ b/src/components/editor/MediaEmbedder.tsx
@@ -12,6 +12,8 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
   const [url, setUrl] = useState('');
   const [type, setType] = useState<'image' | 'youtube'>('image');
   const [urlError, setUrlError] = useState('');
+  const dialogTitleId = 'media-embedder-title';
+  const errorId = 'media-embedder-error';
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -39,9 +41,10 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
             setIsOpen(true);
           }}
           className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          aria-label="Add image"
           title="Add Image"
         >
-          <ImageIcon className="w-5 h-5" />
+          <ImageIcon className="w-5 h-5" aria-hidden="true" />
         </button>
         <button
           onClick={() => {
@@ -49,22 +52,32 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
             setIsOpen(true);
           }}
           className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          aria-label="Add YouTube video"
           title="Add YouTube Video"
         >
-          <YoutubeIcon className="w-5 h-5" />
+          <YoutubeIcon className="w-5 h-5" aria-hidden="true" />
         </button>
       </div>
     );
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={dialogTitleId}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg w-96">
-        <h3 className="text-lg font-bold mb-4">
+        <h3 id={dialogTitleId} className="text-lg font-bold mb-4">
           Add {type === 'image' ? 'Image' : 'YouTube Video'}
         </h3>
         <form onSubmit={handleSubmit}>
+          <label htmlFor="media-url" className="sr-only">
+            {type === 'image' ? 'Image URL' : 'YouTube video URL'}
+          </label>
           <input
+            id="media-url"
             type="url"
             value={url}
             onChange={(e) => {
@@ -73,9 +86,17 @@ export const MediaEmbedder: React.FC<MediaEmbedderProps> = ({ onAddImage, onAddY
             }}
             placeholder={`Enter ${type} URL...`}
             className="w-full p-2 border rounded mb-1 dark:bg-gray-700 dark:border-gray-600"
+            aria-describedby={errorId}
             required
           />
-          <p className="text-red-500 text-sm mb-3 min-h-[1.25rem]">{urlError}</p>
+          <p
+            id={errorId}
+            role="alert"
+            aria-live="assertive"
+            className="text-red-500 text-sm mb-3 min-h-[1.25rem]"
+          >
+            {urlError}
+          </p>
           <div className="flex justify-end gap-2">
             <button
               type="button"

--- a/src/components/editor/RichContentEditor.tsx
+++ b/src/components/editor/RichContentEditor.tsx
@@ -52,6 +52,8 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
     <button
       onClick={onClick}
       disabled={disabled}
+      aria-pressed={isActive}
+      aria-label={title}
       className={`p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors ${
         isActive ? 'bg-gray-200 dark:bg-gray-600 text-blue-600' : 'text-gray-600 dark:text-gray-300'
       } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
@@ -65,7 +67,11 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
     <div className="flex h-[calc(100vh-100px)] bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div className="flex flex-col flex-1 w-full min-w-0">
         {/* Toolbar */}
-        <div className="flex items-center justify-between p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 overflow-x-auto">
+        <div
+          role="toolbar"
+          aria-label="Text formatting"
+          className="flex items-center justify-between p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 overflow-x-auto"
+        >
           <div className="flex items-center gap-1">
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleBold().run()}
@@ -88,7 +94,7 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
             >
               <Strikethrough className="w-4 h-4" />
             </ToolbarButton>
-            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" />
+            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
               isActive={editor.isActive('heading', { level: 1 })}
@@ -103,7 +109,7 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
             >
               <Heading2 className="w-4 h-4" />
             </ToolbarButton>
-            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" />
+            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleBulletList().run()}
               isActive={editor.isActive('bulletList')}
@@ -118,7 +124,7 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
             >
               <ListOrdered className="w-4 h-4" />
             </ToolbarButton>
-            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" />
+            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleCodeBlock().run()}
               isActive={editor.isActive('codeBlock')}
@@ -133,9 +139,9 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
             >
               <Quote className="w-4 h-4" />
             </ToolbarButton>
-            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" />
+            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
             <MediaEmbedder onAddImage={addImage} onAddYoutube={addYoutubeVideo} />
-            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" />
+            <div className="w-px h-6 bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
             <ToolbarButton
               onClick={() => editor.chain().focus().undo().run()}
               disabled={!editor.can().undo()}
@@ -158,7 +164,10 @@ export const RichContentEditor: React.FC<RichContentEditorProps> = ({
         </div>
 
         {/* Editor Content */}
-        <div className="flex-1 overflow-y-auto bg-white dark:bg-gray-800">
+        <div
+          className="flex-1 overflow-y-auto bg-white dark:bg-gray-800"
+          aria-label="Post content editor"
+        >
           <EditorContent editor={editor} className="h-full p-8" />
         </div>
       </div>

--- a/src/components/editor/__tests__/accessibility.test.tsx
+++ b/src/components/editor/__tests__/accessibility.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CollaborativeEditingTools } from '../CollaborativeEditingTools';
+import { MediaEmbedder } from '../MediaEmbedder';
+import { ContentTemplateLibrary } from '../ContentTemplateLibrary';
+
+// ─── CollaborativeEditingTools ────────────────────────────────────────────────
+
+describe('CollaborativeEditingTools accessibility', () => {
+  it('renders collaborator list with role=list and aria-label', () => {
+    render(<CollaborativeEditingTools />);
+    const list = screen.getByRole('list', { name: /active collaborators/i });
+    expect(list).toBeInTheDocument();
+  });
+
+  it('renders each collaborator avatar as a listitem with descriptive alt', () => {
+    render(<CollaborativeEditingTools />);
+    const items = screen.getAllByRole('listitem');
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach((item) => {
+      expect(item).toHaveAttribute('alt', expect.stringMatching(/is editing/i));
+    });
+  });
+
+  it('status badge has aria-label with collaborator count', () => {
+    render(<CollaborativeEditingTools />);
+    const badge = screen.getByLabelText(/3 active collaborators/i);
+    expect(badge).toBeInTheDocument();
+  });
+});
+
+// ─── MediaEmbedder ────────────────────────────────────────────────────────────
+
+describe('MediaEmbedder accessibility', () => {
+  const noop = vi.fn();
+
+  it('image trigger button has aria-label', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    expect(screen.getByRole('button', { name: /add image/i })).toBeInTheDocument();
+  });
+
+  it('youtube trigger button has aria-label', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    expect(screen.getByRole('button', { name: /add youtube video/i })).toBeInTheDocument();
+  });
+
+  it('dialog has role=dialog, aria-modal, and aria-labelledby when open', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /add image/i }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+
+    const titleId = dialog.getAttribute('aria-labelledby')!;
+    expect(document.getElementById(titleId)).toBeInTheDocument();
+  });
+
+  it('URL input has an accessible label', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /add image/i }));
+    expect(screen.getByLabelText(/image url/i)).toBeInTheDocument();
+  });
+
+  it('error paragraph has role=alert and aria-live=assertive', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /add image/i }));
+
+    const errorEl = screen.getByRole('alert');
+    expect(errorEl).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('input is described by the error element', () => {
+    render(<MediaEmbedder onAddImage={noop} onAddYoutube={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /add image/i }));
+
+    const input = screen.getByLabelText(/image url/i);
+    const errorEl = screen.getByRole('alert');
+    expect(input).toHaveAttribute('aria-describedby', errorEl.id);
+  });
+});
+
+// ─── ContentTemplateLibrary ───────────────────────────────────────────────────
+
+describe('ContentTemplateLibrary accessibility', () => {
+  const mockEditor = {
+    chain: () => ({ focus: () => ({ insertContent: () => ({ run: vi.fn() }) }) }),
+  } as unknown as import('@tiptap/react').Editor;
+
+  it('renders as an aside with aria-label', () => {
+    render(<ContentTemplateLibrary editor={mockEditor} />);
+    const sidebar = screen.getByRole('complementary', { name: /content templates/i });
+    expect(sidebar).toBeInTheDocument();
+  });
+
+  it('each template button has a descriptive aria-label', () => {
+    render(<ContentTemplateLibrary editor={mockEditor} />);
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) => {
+      const label = btn.getAttribute('aria-label') ?? '';
+      expect(label.length).toBeGreaterThan(0);
+      expect(label.toLowerCase()).toContain('insert');
+    });
+  });
+
+  it('template icons are hidden from assistive technology', () => {
+    render(<ContentTemplateLibrary editor={mockEditor} />);
+    // Icon wrappers should carry aria-hidden="true"
+    const hiddenEls = document
+      .querySelectorAll('[aria-hidden="true"]');
+    expect(hiddenEls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Summary
  
  Implements accessibility improvements across all Post Editor components to meet WCAG 2.1 standards and ensure screen
  reader compatibility.
  
  Changes
  
  RichContentEditor
  
  - Toolbar now has role="toolbar" and aria-label
  - Each toolbar button exposes toggle state via aria-pressed
  - Decorative dividers marked aria-hidden="true"
  - Editor content area has a descriptive aria-label
  
  MediaEmbedder
  
  - Modal dialog has role="dialog", aria-modal="true", and aria-labelledby linked to the title
  - URL input has a visible-to-AT label and aria-describedby pointing to the error element
  - Error message uses role="alert" and aria-live="assertive" for immediate announcement
  - Trigger buttons have explicit aria-label; icons are aria-hidden
  
  CollaborativeEditingTools
  
  - Avatar list has role="list" and aria-label
  - Each avatar has role="listitem" and a descriptive alt text ("[Name] is editing")
  - Active collaborators badge exposes count via aria-label
  
  ContentTemplateLibrary
  
  - Container changed from <div> to <aside> landmark with aria-label
  - Template buttons have descriptive aria-label combining name and description
  - Icons are aria-hidden
  
  EditorWorkspace
  
  - Preview toggle button has aria-pressed to communicate state
  
  Tests
  
  Added 12 unit tests in src/components/editor/__tests__/accessibility.test.tsx covering all the above attributes. All
  tests pass.
  
  Testing
  
  npx vitest run src/components/editor/__tests__/accessibility.test.tsx

closes #499 