### PR TITLE
fix(settings): validate language against supported locales

### DIFF
--- a/src/lib/settings/__tests__/store.test.ts
+++ b/src/lib/settings/__tests__/store.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingsStore } from '../store';
+
+beforeEach(() => {
+  useSettingsStore.getState().resetSettings();
+});
+
+describe('useSettingsStore', () => {
+  it('falls back to the default language for unsupported locales', () => {
+    useSettingsStore.getState().patchSettings({ language: 'zz-ZZ' });
+
+    expect(useSettingsStore.getState().settings.language).toBe('en');
+  });
+
+  it('keeps supported languages when patching settings', () => {
+    useSettingsStore.getState().patchSettings({ language: 'fr' });
+
+    expect(useSettingsStore.getState().settings.language).toBe('fr');
+  });
+});

--- a/src/lib/settings/store.ts
+++ b/src/lib/settings/store.ts
@@ -41,6 +41,7 @@
  */
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '../../locales/config';
 import { SETTINGS_SCHEMA_VERSION, SETTINGS_STORAGE_KEY } from './constants';
 import { type AppSettings, appSettingsSchema, createDefaultSettings } from './types';
 
@@ -88,6 +89,13 @@ const noopStorage = {
   removeItem: (): void => undefined,
 };
 
+function normalizeLanguage(language: string): AppSettings['language'] {
+  const trimmed = language.trim();
+  return Object.prototype.hasOwnProperty.call(SUPPORTED_LANGUAGES, trimmed)
+    ? trimmed
+    : DEFAULT_LANGUAGE;
+}
+
 function localStorageOrNoop() {
   if (typeof window === 'undefined') return noopStorage;
   try {
@@ -112,7 +120,7 @@ export const useSettingsStore = create<SettingsSlice>()(
           version: SETTINGS_SCHEMA_VERSION,
           ...(partial.language !== undefined
             ? {
-                language: partial.language.trim().slice(0, 24) || 'en',
+                language: normalizeLanguage(partial.language),
               }
             : {}),
         };


### PR DESCRIPTION
## Summary
- validate patched settings language values against SUPPORTED_LANGUAGES
- fall back to DEFAULT_LANGUAGE for blank or unsupported locales
- add store coverage for unsupported locale fallback and supported locale retention

Closes #779