### PR TITLE
test(auth): cover password visibility toggle revert

### DIFF
--- a/src/app/components/auth/__tests__/FormInput.test.tsx
+++ b/src/app/components/auth/__tests__/FormInput.test.tsx
@@ -57,9 +57,15 @@ describe('Auth FormInput', () => {
     fireEvent.click(toggle);
 
     expect(input).toHaveAttribute('type', 'text');
-    expect(screen.getByRole('button', { name: 'Hide Password' })).toHaveAttribute(
+    const hideToggle = screen.getByRole('button', { name: 'Hide Password' });
+    expect(hideToggle).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(hideToggle);
+
+    expect(input).toHaveAttribute('type', 'password');
+    expect(screen.getByRole('button', { name: 'Show Password' })).toHaveAttribute(
       'aria-pressed',
-      'true',
+      'false',
     );
   });
 });


### PR DESCRIPTION
## Summary
- assert the password input returns to type="password" after the second toggle click
- verify the accessible toggle label changes back to "Show Password"
- keep the existing aria-pressed coverage for both states

Closes #780