### PR TITLE
feat: implement distributed tracing with traceId propagation across a…

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,7 +12,7 @@ import {
   STORAGE_KEYS,
   API_CACHE_TTL_DEFAULT,
 } from '@/constants/app.constants';
-import { logContextStorage } from './logging';
+import { logContextStorage } from './logging/context';
 
 export type { ErrorInfo };
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,7 @@ import {
   STORAGE_KEYS,
   API_CACHE_TTL_DEFAULT,
 } from '@/constants/app.constants';
+import { logContextStorage } from './logging';
 
 export type { ErrorInfo };
 
@@ -140,11 +141,13 @@ class ApiClientImpl {
 
     const timer = setTimeout(() => controller.abort(), timeout);
 
+    const contextStore = logContextStorage.getStore();
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...(config.headers || {}),
       [API_VERSION_HEADER]: this.config.apiVersion,
+      ...(contextStore?.traceId ? { 'x-trace-id': contextStore.traceId } : {}),
     };
 
     try {

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -1,4 +1,5 @@
 import { Pool, PoolConfig } from 'pg';
+import { logContextStorage } from '@/lib/logging';
 
 /**
  * Database Connection Pool Management
@@ -27,7 +28,8 @@ class DatabasePool {
       // Monitoring events
       DatabasePool.instance.on('connect', () => {
         if (process.env.NODE_ENV === 'development') {
-          console.log('[DB Pool] New client connected to database');
+          const traceId = logContextStorage.getStore()?.traceId ?? '';
+          console.log('[DB Pool] New client connected to database', traceId ? { traceId } : '');
         }
       });
 
@@ -36,7 +38,8 @@ class DatabasePool {
       });
 
       DatabasePool.instance.on('error', (err) => {
-        console.error('[DB Pool] Unexpected error on idle client', err);
+        const traceId = logContextStorage.getStore()?.traceId ?? '';
+        console.error('[DB Pool] Unexpected error on idle client', err, traceId ? { traceId } : '');
       });
     }
     return DatabasePool.instance;
@@ -72,5 +75,10 @@ class DatabasePool {
 }
 
 export const dbPool = DatabasePool;
-export const query = (text: string, params?: any[]) =>
-  DatabasePool.getInstance().query(text, params);
+export const query = (text: string, params?: any[]) => {
+  const traceId = logContextStorage.getStore()?.traceId ?? '';
+  if (traceId && process.env.NODE_ENV === 'development') {
+    console.log('[DB Query]', { text: text.slice(0, 100), traceId });
+  }
+  return DatabasePool.getInstance().query(text, params);
+};

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -1,5 +1,5 @@
 import { Pool, PoolConfig } from 'pg';
-import { logContextStorage } from '@/lib/logging';
+import { logContextStorage } from '@/lib/logging/context';
 
 /**
  * Database Connection Pool Management

--- a/src/lib/logging/context.ts
+++ b/src/lib/logging/context.ts
@@ -1,0 +1,30 @@
+export interface LogContextStore {
+  requestId?: string;
+  correlationId?: string;
+  traceId?: string;
+}
+
+class SimpleAsyncLocalStorage<T> {
+  private store: T | undefined;
+  getStore(): T | undefined {
+    return this.store;
+  }
+  run<R>(store: T, callback: () => R): R {
+    this.store = store;
+    try {
+      return callback();
+    } finally {
+      this.store = undefined;
+    }
+  }
+}
+
+export const logContextStorage = new SimpleAsyncLocalStorage<LogContextStore>();
+
+export function runWithLogContext<T>(context: LogContextStore, callback: () => T): T {
+  return logContextStorage.run(context, callback);
+}
+
+export function getLogContext(): LogContextStore | undefined {
+  return logContextStorage.getStore();
+}

--- a/src/lib/logging/context.ts
+++ b/src/lib/logging/context.ts
@@ -4,7 +4,12 @@ export interface LogContextStore {
   traceId?: string;
 }
 
-class SimpleAsyncLocalStorage<T> {
+export interface AsyncContextStorage<T> {
+  getStore(): T | undefined;
+  run<R>(store: T, callback: () => R): R;
+}
+
+class SimpleAsyncLocalStorage<T> implements AsyncContextStorage<T> {
   private store: T | undefined;
   getStore(): T | undefined {
     return this.store;

--- a/src/lib/logging/index.ts
+++ b/src/lib/logging/index.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
 import { logContextStorage as simpleStorage } from './context';
-import type { LogContextStore } from './context';
+import type { AsyncContextStorage, LogContextStore } from './context';
 
 // Try to enhance with Node's AsyncLocalStorage for proper async context tracking
 import type { AsyncLocalStorage as NodeAsyncLocalStorage } from 'node:async_hooks';
@@ -15,7 +15,7 @@ try {
   nodeAsyncLocalStorage = null;
 }
 
-export const logContextStorage: typeof simpleStorage = nodeAsyncLocalStorage ?? simpleStorage;
+export const logContextStorage: AsyncContextStorage<LogContextStore> = nodeAsyncLocalStorage ?? simpleStorage;
 
 export function runWithLogContext<T>(context: LogContextStore, callback: () => T): T {
   return logContextStorage.run(context, callback);

--- a/src/lib/logging/index.ts
+++ b/src/lib/logging/index.ts
@@ -1,21 +1,9 @@
 import pino from 'pino';
-import type { AsyncLocalStorage as NodeAsyncLocalStorage } from 'node:async_hooks';
-// Simple synchronous context storage compatible with both browser and Node.js
-class SimpleAsyncLocalStorage<T> {
-  private store: T | undefined;
-  getStore(): T | undefined {
-    return this.store;
-  }
-  run<R>(store: T, callback: () => R): R {
-    this.store = store;
-    try {
-      return callback();
-    } finally {
-      this.store = undefined;
-    }
-  }
-}
+import { logContextStorage as simpleStorage } from './context';
+import type { LogContextStore } from './context';
 
+// Try to enhance with Node's AsyncLocalStorage for proper async context tracking
+import type { AsyncLocalStorage as NodeAsyncLocalStorage } from 'node:async_hooks';
 let nodeAsyncLocalStorage: NodeAsyncLocalStorage<LogContextStore> | null = null;
 try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -25,6 +13,16 @@ try {
   }
 } catch {
   nodeAsyncLocalStorage = null;
+}
+
+export const logContextStorage: typeof simpleStorage = nodeAsyncLocalStorage ?? simpleStorage;
+
+export function runWithLogContext<T>(context: LogContextStore, callback: () => T): T {
+  return logContextStorage.run(context, callback);
+}
+
+export function getLogContext(): LogContextStore | undefined {
+  return logContextStorage.getStore();
 }
 
 import { createCounterMetric } from './performance';
@@ -56,24 +54,7 @@ const SENSITIVE_KEYS = [
   'pwd',
 ];
 
-export interface LogContextStore {
-  requestId?: string;
-  correlationId?: string;
-  traceId?: string;
-}
-
-export const logContextStorage:
-  | NodeAsyncLocalStorage<LogContextStore>
-  | SimpleAsyncLocalStorage<LogContextStore> =
-  nodeAsyncLocalStorage ?? new SimpleAsyncLocalStorage<LogContextStore>();
-
-export function runWithLogContext<T>(context: LogContextStore, callback: () => T): T {
-  return logContextStorage.run(context, callback);
-}
-
-export function getLogContext(): LogContextStore | undefined {
-  return logContextStorage.getStore();
-}
+export type { LogContextStore };
 
 export function generateCorrelationId(): string {
   return `corr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/src/lib/logging/index.ts
+++ b/src/lib/logging/index.ts
@@ -59,6 +59,7 @@ const SENSITIVE_KEYS = [
 export interface LogContextStore {
   requestId?: string;
   correlationId?: string;
+  traceId?: string;
 }
 
 export const logContextStorage:
@@ -198,6 +199,7 @@ function normalizeError(error: unknown): LogRecord['error'] | undefined {
 export interface LogPayload {
   requestId?: string;
   correlationId?: string;
+  traceId?: string;
   context?: Record<string, unknown>;
   metrics?: PerformanceMetric[];
   error?: unknown;
@@ -254,6 +256,11 @@ class Logger implements AppLogger {
       contextStore?.correlationId ||
       (this.baseContext.correlationId as string) ||
       activeRequestId;
+    const activeTraceId =
+      payload.traceId ||
+      contextStore?.traceId ||
+      (this.baseContext.traceId as string) ||
+      '';
 
     const baseRecord: LogRecord = {
       level,
@@ -262,6 +269,7 @@ class Logger implements AppLogger {
       timestamp: new Date().toISOString(),
       requestId: activeRequestId,
       correlationId: activeCorrelationId,
+      traceId: activeTraceId,
       context: {
         ...this.baseContext,
         ...(payload.context ?? {}),
@@ -277,6 +285,7 @@ class Logger implements AppLogger {
         scope: record.scope,
         requestId: record.requestId,
         correlationId: record.correlationId,
+        traceId: record.traceId,
         context: record.context,
         metrics: record.metrics,
         error: record.error,

--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -15,6 +15,7 @@ export interface LogRecord {
   timestamp: string;
   requestId?: string;
   correlationId?: string;
+  traceId?: string;
   context?: Record<string, unknown>;
   metrics?: PerformanceMetric[];
   error?: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,9 +15,13 @@ import {
 } from './lib/apiVersioning';
 
 export function middleware(request: NextRequest) {
+  const traceId = crypto.randomUUID();
+  request.headers.set('x-trace-id', traceId);
+
   // Handle redirects first (early in the chain)
   const redirectResponse = handleRedirects(request);
   if (redirectResponse) {
+    redirectResponse.headers.set('x-trace-id', traceId);
     return redirectResponse;
   }
 
@@ -26,6 +30,7 @@ export function middleware(request: NextRequest) {
   const userRole = roleCookie || null;
 
   const withHeaders = (response: NextResponse) => {
+    response.headers.set('x-trace-id', traceId);
     const withSecurity = applySecurityHeaders(response, request);
     return applyCspHeaders(withSecurity, request);
   };

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -21,11 +21,13 @@ export function createRequestLogger(
 ) {
   const requestId = request.headers.get('x-request-id') ?? createRequestId();
   const correlationId = request.headers.get('x-correlation-id') ?? requestId;
+  const traceId = request.headers.get('x-trace-id') ?? '';
 
   return createLogger(scope, {
     ...context,
     requestId,
     correlationId,
+    traceId,
     method: request.method,
     path: request.nextUrl.pathname,
   });
@@ -38,18 +40,22 @@ export async function withRequestLogging<T>(
 ): Promise<T> {
   const requestId = request.headers.get('x-request-id') ?? createRequestId();
   const correlationId = request.headers.get('x-correlation-id') ?? requestId;
+  const traceId = request.headers.get('x-trace-id') ?? '';
   const log = createLogger(scope, {
     requestId,
     correlationId,
+    traceId,
     method: request.method,
     path: request.nextUrl.pathname,
   });
   const start = globalThis.performance?.now?.() ?? Date.now();
 
-  log.info('Request started', { requestId, correlationId });
+  log.info('Request started', { requestId, correlationId, traceId });
 
   try {
-    const result = await runWithLogContext({ requestId, correlationId }, () => handler(requestId));
+    const result = await runWithLogContext({ requestId, correlationId, traceId }, () =>
+      handler(requestId),
+    );
     const duration = Number(((globalThis.performance?.now?.() ?? Date.now()) - start).toFixed(2));
     const status = getResponseStatus(result);
     const metric = recordMetric({
@@ -67,6 +73,7 @@ export async function withRequestLogging<T>(
     log.info('Request completed', {
       requestId,
       correlationId,
+      traceId,
       context: { status },
       metrics: [metric, createCounterMetric('http.requests', 1, { status: status ?? 'unknown' })],
     });
@@ -88,6 +95,7 @@ export async function withRequestLogging<T>(
     log.error('Request failed', {
       requestId,
       correlationId,
+      traceId,
       error,
       metrics: [metric, createCounterMetric('http.request.errors')],
     });


### PR DESCRIPTION
…sync service calls

- Generate traceId via crypto.randomUUID() in middleware and inject into request/response headers
- Pass traceId to createLogger and runWithLogContext in all request-scoped loggers
- Forward traceId as x-trace-id header on all outbound HTTP calls via apiClient
- Include traceId in database query logs and pool events via async context store
- Add traceId to LogContextStore, LogPayload, and LogRecord types

## Description

Brief description of changes

## Related Issue

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed

Closes #756 
