### PR TITLE
feat: consolidate approval status strings into shared const object

### DIFF
--- a/src/app/api/approvals/__tests__/approvals.test.tsx
+++ b/src/app/api/approvals/__tests__/approvals.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@/testing/utils/render';
 import { hasPermission } from '@/lib/auth/acl';
+import { ApprovalStatus, ReviewDecision } from '@/types/approvals';
 import { Permission, UserRole } from '@/types/api';
 import type { User } from '@/types/api';
 import { SubmitForApproval } from '@/components/approvals/SubmitForApproval';
@@ -79,7 +80,7 @@ describe('Approval API route', () => {
           title: 'Intro to Starknet',
           submittedBy: 'u-instructor',
           submittedAt: new Date().toISOString(),
-          status: 'PENDING',
+          status: ApprovalStatus.PENDING,
         },
       }),
     });
@@ -98,7 +99,7 @@ describe('Approval API route', () => {
     const json = await res.json();
 
     expect(json.success).toBe(true);
-    expect(json.data.status).toBe('PENDING');
+    expect(json.data.status).toBe(ApprovalStatus.PENDING);
     expect(json.data.contentId).toBe('course-42');
   });
 
@@ -108,7 +109,7 @@ describe('Approval API route', () => {
         success: true,
         data: {
           id: 'approval-1',
-          status: 'APPROVED',
+          status: ApprovalStatus.APPROVED,
           reviewedBy: 'u-admin',
           reviewedAt: new Date().toISOString(),
           reviewNote: 'Looks good',
@@ -122,7 +123,7 @@ describe('Approval API route', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         id: 'approval-1',
-        status: 'APPROVED',
+        status: ReviewDecision.APPROVED,
         reviewedBy: 'u-admin',
         reviewNote: 'Looks good',
       }),
@@ -130,7 +131,7 @@ describe('Approval API route', () => {
     const json = await res.json();
 
     expect(json.success).toBe(true);
-    expect(json.data.status).toBe('APPROVED');
+    expect(json.data.status).toBe(ApprovalStatus.APPROVED);
     expect(json.data.reviewedBy).toBe('u-admin');
   });
 
@@ -138,7 +139,7 @@ describe('Approval API route', () => {
     const mockFetch = vi.fn().mockResolvedValue({
       json: async () => ({
         success: true,
-        data: { id: 'approval-2', status: 'REJECTED', reviewedBy: 'u-admin' },
+        data: { id: 'approval-2', status: ApprovalStatus.REJECTED, reviewedBy: 'u-admin' },
       }),
     });
     vi.stubGlobal('fetch', mockFetch);
@@ -146,17 +147,17 @@ describe('Approval API route', () => {
     const res = await fetch('/api/approvals', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: 'approval-2', status: 'REJECTED', reviewedBy: 'u-admin' }),
+      body: JSON.stringify({ id: 'approval-2', status: ReviewDecision.REJECTED, reviewedBy: 'u-admin' }),
     });
     const json = await res.json();
 
-    expect(json.data.status).toBe('REJECTED');
+    expect(json.data.status).toBe(ApprovalStatus.REJECTED);
   });
 
   it('GET returns list of approvals', async () => {
     const items = [
-      { id: 'a1', status: 'PENDING', title: 'Course A' },
-      { id: 'a2', status: 'APPROVED', title: 'Course B' },
+      { id: 'a1', status: ApprovalStatus.PENDING, title: 'Course A' },
+      { id: 'a2', status: ApprovalStatus.APPROVED, title: 'Course B' },
     ];
     vi.stubGlobal(
       'fetch',
@@ -212,7 +213,7 @@ describe('SubmitForApproval component', () => {
       vi.fn().mockResolvedValue({
         json: async () => ({
           success: true,
-          data: { id: 'a-1', status: 'PENDING', title: 'My Course' },
+          data: { id: 'a-1', status: ApprovalStatus.PENDING, title: 'My Course' },
         }),
       }),
     );
@@ -237,7 +238,7 @@ describe('SubmitForApproval component', () => {
   });
 
   it('calls onSubmitted callback with returned item', async () => {
-    const returnedItem = { id: 'a-1', status: 'PENDING', title: 'My Course' };
+    const returnedItem = { id: 'a-1', status: ApprovalStatus.PENDING, title: 'My Course' };
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({ json: async () => ({ success: true, data: returnedItem }) }),
@@ -270,7 +271,7 @@ describe('ApprovalQueue component', () => {
       title: 'Blockchain Basics',
       submittedBy: 'instructor-1',
       submittedAt: new Date().toISOString(),
-      status: 'PENDING',
+      status: ApprovalStatus.PENDING,
     },
   ];
 
@@ -313,7 +314,7 @@ describe('ApprovalQueue component', () => {
       .mockResolvedValueOnce({
         json: async () => ({
           success: true,
-          data: { ...pendingItems[0], status: 'APPROVED' },
+          data: { ...pendingItems[0], status: ApprovalStatus.APPROVED },
         }),
       });
     vi.stubGlobal('fetch', mockFetch);
@@ -326,7 +327,7 @@ describe('ApprovalQueue component', () => {
       const patchCall = mockFetch.mock.calls.find((c) => c[1]?.method === 'PATCH');
       expect(patchCall).toBeDefined();
       const body = JSON.parse(patchCall![1].body);
-      expect(body.status).toBe('APPROVED');
+      expect(body.status).toBe(ReviewDecision.APPROVED);
     });
   });
 });

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -33,7 +33,9 @@ const ReviewSchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  status: z.enum([ApprovalStatus.PENDING, ApprovalStatus.APPROVED, ApprovalStatus.REJECTED]).optional(),
+  status: z
+    .enum([ApprovalStatus.PENDING, ApprovalStatus.APPROVED, ApprovalStatus.REJECTED])
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { withRateLimit } from '@/lib/ratelimit';
 import { logAuditMutation } from '@/middleware/audit';
 import { validateBody, validateQuery } from '@/lib/validation';
-import type { ApprovalItem } from '@/types/api';
+import { ApprovalStatus } from '@/types/approvals';
+import type { ApprovalItem, ReviewDecision } from '@/types/api';
 
 export const runtime = 'edge';
 
@@ -26,13 +27,13 @@ const SubmitSchema = z.object({
 
 const ReviewSchema = z.object({
   id: z.string().min(1),
-  status: z.enum(['APPROVED', 'REJECTED']),
+  status: z.enum([ApprovalStatus.APPROVED, ApprovalStatus.REJECTED]),
   reviewedBy: z.string().min(1),
   reviewNote: z.string().max(500).optional(),
 });
 
 const ListQuerySchema = z.object({
-  status: z.enum(['PENDING', 'APPROVED', 'REJECTED']).optional(),
+  status: z.enum([ApprovalStatus.PENDING, ApprovalStatus.APPROVED, ApprovalStatus.REJECTED]).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -73,7 +74,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     title: result.data.title,
     submittedBy: result.data.submittedBy,
     submittedAt: new Date().toISOString(),
-    status: 'PENDING',
+    status: ApprovalStatus.PENDING,
   };
 
   approvalsStore.set(item.id, item);
@@ -108,7 +109,7 @@ export async function PATCH(request: Request): Promise<NextResponse> {
     );
   }
 
-  if (existing.status !== 'PENDING') {
+  if (existing.status !== ApprovalStatus.PENDING) {
     return addHeaders(
       NextResponse.json(
         { success: false, message: 'Only PENDING approvals can be reviewed' },

--- a/src/components/admin/ApprovalQueue.tsx
+++ b/src/components/admin/ApprovalQueue.tsx
@@ -2,18 +2,20 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { CheckCircle, XCircle, Clock, RefreshCw } from 'lucide-react';
+import { ApprovalStatus, ReviewDecision } from '@/types/approvals';
+import type { ApprovalStatus, ReviewDecision } from '@/types/approvals';
 import { PermissionGate } from '@/app/components/auth/PermissionGate';
 import { Permission, User } from '@/types/api';
-import type { ApprovalItem, ApprovalStatus } from '@/types/api';
+import type { ApprovalItem } from '@/types/api';
 
 interface ApprovalQueueProps {
   user: User | null | undefined;
 }
 
 const STATUS_FILTER_OPTIONS: Array<{ label: string; value: ApprovalStatus | 'ALL' }> = [
-  { label: 'Pending', value: 'PENDING' },
-  { label: 'Approved', value: 'APPROVED' },
-  { label: 'Rejected', value: 'REJECTED' },
+  { label: 'Pending', value: ApprovalStatus.PENDING },
+  { label: 'Approved', value: ApprovalStatus.APPROVED },
+  { label: 'Rejected', value: ApprovalStatus.REJECTED },
   { label: 'All', value: 'ALL' },
 ];
 
@@ -40,7 +42,7 @@ function StatusBadge({ status }: { status: ApprovalStatus }) {
 
 export function ApprovalQueue({ user }: ApprovalQueueProps) {
   const [items, setItems] = useState<ApprovalItem[]>([]);
-  const [filter, setFilter] = useState<ApprovalStatus | 'ALL'>('PENDING');
+  const [filter, setFilter] = useState<ApprovalStatus | 'ALL'>(ApprovalStatus.PENDING);
   const [loading, setLoading] = useState(false);
   const [reviewNote, setReviewNote] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState<string | null>(null);
@@ -66,7 +68,7 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
     fetchItems();
   }, [fetchItems]);
 
-  const review = async (id: string, status: 'APPROVED' | 'REJECTED') => {
+  const review = async (id: string, status: ReviewDecision) => {
     if (!user) return;
     setSubmitting(id);
     setError(null);
@@ -167,7 +169,7 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
                   <StatusBadge status={item.status} />
                 </div>
 
-                {item.status === 'PENDING' && (
+                {item.status === ApprovalStatus.PENDING && (
                   <div className="space-y-2">
                     <textarea
                       value={reviewNote[item.id] ?? ''}
@@ -181,7 +183,7 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
                     />
                     <div className="flex gap-2">
                       <button
-                        onClick={() => review(item.id, 'APPROVED')}
+                        onClick={() => review(item.id, ReviewDecision.APPROVED)}
                         disabled={submitting === item.id}
                         className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium transition-colors disabled:opacity-50"
                       >
@@ -189,7 +191,7 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
                         Approve It
                       </button>
                       <button
-                        onClick={() => review(item.id, 'REJECTED')}
+                        onClick={() => review(item.id, ReviewDecision.REJECTED)}
                         disabled={submitting === item.id}
                         className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50"
                       >

--- a/src/components/admin/ApprovalQueue.tsx
+++ b/src/components/admin/ApprovalQueue.tsx
@@ -2,8 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { CheckCircle, XCircle, Clock, RefreshCw } from 'lucide-react';
-import { ApprovalStatus, ReviewDecision } from '@/types/approvals';
-import type { ApprovalStatus, ReviewDecision } from '@/types/approvals';
+import { type ApprovalStatus, type ReviewDecision } from '@/types/approvals';
 import { PermissionGate } from '@/app/components/auth/PermissionGate';
 import { Permission, User } from '@/types/api';
 import type { ApprovalItem } from '@/types/api';

--- a/src/components/admin/ApprovalQueue.tsx
+++ b/src/components/admin/ApprovalQueue.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { CheckCircle, XCircle, Clock, RefreshCw } from 'lucide-react';
-import { type ApprovalStatus, type ReviewDecision } from '@/types/approvals';
+import { ApprovalStatus, ReviewDecision } from '@/types/approvals';
 import { PermissionGate } from '@/app/components/auth/PermissionGate';
 import { Permission, User } from '@/types/api';
 import type { ApprovalItem } from '@/types/api';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -105,7 +105,9 @@ export type AnalyticsEventPayload = ZodAnalyticsEventPayload;
 // Approvals
 // ---------------------------------------------------------------------------
 
-export type ApprovalStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+import type { ApprovalStatus, ReviewDecision } from './approvals';
+
+export type { ApprovalStatus, ReviewDecision } from './approvals';
 
 export interface ApprovalItem {
   id: string;
@@ -127,6 +129,6 @@ export interface SubmitApprovalRequest {
 }
 
 export interface ReviewApprovalRequest {
-  status: 'APPROVED' | 'REJECTED';
+  status: ReviewDecision;
   reviewNote?: string;
 }

--- a/src/types/approvals.ts
+++ b/src/types/approvals.ts
@@ -1,0 +1,14 @@
+export const ApprovalStatus = {
+  PENDING: 'PENDING',
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
+} as const;
+
+export type ApprovalStatus = (typeof ApprovalStatus)[keyof typeof ApprovalStatus];
+
+export const ReviewDecision = {
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
+} as const;
+
+export type ReviewDecision = (typeof ReviewDecision)[keyof typeof ReviewDecision];


### PR DESCRIPTION
- Create src/types/approvals.ts with ApprovalStatus const (PENDING, APPROVED, REJECTED) and ReviewDecision const (APPROVED, REJECTED) as const objects, plus derived literal types
- Export ApprovalStatus and ReviewDecision types from src/types/api.ts for backward compatibility
- Update src/app/api/approvals/route.ts to use ApprovalStatus.xxx in Zod schemas and business logic
- Update src/components/admin/ApprovalQueue.tsx to use ApprovalStatus.xxx and ReviewDecision.xxx
- Update approval tests to reference the shared consts instead of bare string literals
- No bare 'PENDING', 'APPROVED', or 'REJECTED' string literals remain in src/ outside the definition

## Description

Brief description of changes

## Related Issue

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed

Closes #752 
