### PR TITLE
Structured validation error responses with per-field mapping

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -12,6 +12,7 @@ import { FormError, FieldError } from '../../../components/forms/FormError';
 import { SubmitButton } from '../../../components/forms/SubmitButton';
 import { useMutation } from '../../../hooks/useMutation';
 import { apiClient } from '@/lib/api';
+import { ApiError } from '@/utils/error-handler';
 import { DiscordButton } from '@/app/components/auth/DiscordButton';
 import { GoogleButton } from '@/app/components/auth/GoogleButton';
 import { GitHubButton } from '@/app/components/auth/GitHubButton';
@@ -36,6 +37,7 @@ export default function LoginPage() {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -54,7 +56,17 @@ export default function LoginPage() {
   );
 
   const onSubmit = async (data: LoginFormData) => {
-    await loginMutation.mutate(data);
+    try {
+      await loginMutation.mutateAsync(data);
+    } catch (error) {
+      if (error instanceof ApiError && error.errors) {
+        for (const fieldError of error.errors) {
+          setError(fieldError.field as keyof LoginFormData, {
+            message: fieldError.message,
+          });
+        }
+      }
+    }
   };
 
   return (
@@ -151,7 +163,10 @@ export default function LoginPage() {
               </Link>
             </div>
 
-            <FormError error={loginMutation.error?.message} id="login-api-error" />
+            <FormError
+              error={(loginMutation.error as ApiError)?.errors ?? loginMutation.error?.message}
+              id="login-api-error"
+            />
 
             {successMessage && (
               <motion.div

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -12,6 +12,7 @@ import { FormError, FieldError } from '../../../components/forms/FormError';
 import { SubmitButton } from '../../../components/forms/SubmitButton';
 import { useMutation } from '../../../hooks/useMutation';
 import { apiClient } from '@/lib/api';
+import { ApiError } from '@/utils/error-handler';
 import { DiscordButton } from '@/app/components/auth/DiscordButton';
 import { GoogleButton } from '@/app/components/auth/GoogleButton';
 import { GitHubButton } from '@/app/components/auth/GitHubButton';
@@ -37,6 +38,7 @@ export default function SignupPage() {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<SignupFormData>({
     resolver: zodResolver(signupSchema),
@@ -66,7 +68,17 @@ export default function SignupPage() {
   );
 
   const onSubmit = async (data: SignupFormData) => {
-    await signupMutation.mutate(data);
+    try {
+      await signupMutation.mutateAsync(data);
+    } catch (error) {
+      if (error instanceof ApiError && error.errors) {
+        for (const fieldError of error.errors) {
+          setError(fieldError.field as keyof SignupFormData, {
+            message: fieldError.message,
+          });
+        }
+      }
+    }
   };
 
   return (
@@ -217,7 +229,10 @@ export default function SignupPage() {
               </p>
             </div>
 
-            <FormError error={signupMutation.error?.message} id="signup-api-error" />
+            <FormError
+              error={(signupMutation.error as ApiError)?.errors ?? signupMutation.error?.message}
+              id="signup-api-error"
+            />
 
             {successMessage && (
               <motion.div

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useMutation } from '@/hooks/useMutation';
 import { apiClient } from '@/lib/api';
+import { ApiError } from '@/utils/error-handler';
 import { FormError } from '../../../components/forms/FormError';
 import { SubmitButton } from '../../../components/forms/SubmitButton';
 
@@ -136,6 +137,9 @@ export default function VerifyEmailPage() {
 
           <FormError
             error={
+              (verifyMutation.error as ApiError)?.errors ??
+              (resendMutation.error as ApiError)?.errors ??
+              (restoreMutation.error as ApiError)?.errors ??
               verifyMutation.error?.message ??
               resendMutation.error?.message ??
               restoreMutation.error?.message

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -6,12 +6,13 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { motion } from 'framer-motion';
 import { CertificateInputSchema, type CertificateInput } from '@/schemas/certificate.schema';
 import { apiClient } from '@/lib/api';
+import { ApiError, ApiFieldError } from '@/utils/error-handler';
 import { FormInput } from '@/components/forms/FormInput';
 import { FieldError, FormError } from '@/components/forms/FormError';
 import { SubmitButton } from '@/components/forms/SubmitButton';
 
 export default function CertificateGenerationPage() {
-  const [apiError, setApiError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<ApiFieldError[] | string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const methods = useForm<CertificateInput>({
@@ -37,11 +38,13 @@ export default function CertificateGenerationPage() {
       setSuccessMessage(`Certificate generated successfully. ID: ${result.certificateId}`);
       reset();
     } catch (error) {
-      setApiError(
-        error instanceof Error
-          ? error.message
-          : 'Unable to generate certificate. Please try again.',
-      );
+      if (error instanceof ApiError && error.errors) {
+        setApiError(error.errors);
+      } else if (error instanceof Error) {
+        setApiError(error.message);
+      } else {
+        setApiError('Unable to generate certificate. Please try again.');
+      }
     }
   };
 

--- a/src/components/admin/ApprovalQueue.tsx
+++ b/src/components/admin/ApprovalQueue.tsx
@@ -39,6 +39,8 @@ function StatusBadge({ status }: { status: ApprovalStatus }) {
   );
 }
 
+type ApiFieldError = { field: string; message: string };
+
 export function ApprovalQueue({ user }: ApprovalQueueProps) {
   const [items, setItems] = useState<ApprovalItem[]>([]);
   const [filter, setFilter] = useState<ApprovalStatus | 'ALL'>(ApprovalStatus.PENDING);
@@ -46,6 +48,7 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
   const [reviewNote, setReviewNote] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<ApiFieldError[]>([]);
 
   const fetchItems = useCallback(async () => {
     setLoading(true);
@@ -57,12 +60,12 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
       if (json.success) {
         setItems(json.data);
       } else {
-        const apiErrors: { field: string; message: string }[] | undefined = json.errors;
-        setError(
-          apiErrors && apiErrors.length > 0
-            ? apiErrors.map((e) => `${e.field}: ${e.message}`).join('; ')
-            : json.message ?? 'Failed to load approvals',
-        );
+        const apiErrors = json.errors as ApiFieldError[] | undefined;
+        if (apiErrors && apiErrors.length > 0) {
+          setError(apiErrors.map((e) => `${e.field}: ${e.message}`).join('; '));
+        } else {
+          setError(json.message ?? 'Failed to load approvals');
+        }
       }
     } catch {
       setError('Network error');
@@ -94,12 +97,12 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
       if (json.success) {
         setItems((prev) => prev.map((item) => (item.id === id ? json.data : item)));
       } else {
-        const apiErrors: { field: string; message: string }[] | undefined = json.errors;
-        setError(
-          apiErrors && apiErrors.length > 0
-            ? apiErrors.map((e) => `${e.field}: ${e.message}`).join('; ')
-            : json.message ?? 'Review failed already',
-        );
+        const apiErrors = json.errors as ApiFieldError[] | undefined;
+        if (apiErrors && apiErrors.length > 0) {
+          setError(apiErrors.map((e) => `${e.field}: ${e.message}`).join('; '));
+        } else {
+          setError(json.message ?? 'Review failed already');
+        }
       }
     } catch {
       setError('Network error');
@@ -155,6 +158,15 @@ export function ApprovalQueue({ user }: ApprovalQueueProps) {
           <p role="alert" className="text-sm text-red-600 dark:text-red-400">
             {error}
           </p>
+        )}
+        {fieldErrors.length > 0 && (
+          <div role="alert" className="text-sm text-red-600 dark:text-red-400 space-y-0.5">
+            {fieldErrors.map((fe, i) => (
+              <p key={i}>
+                <span className="font-semibold">{fe.field}</span>: {fe.message}
+              </p>
+            ))}
+          </div>
         )}
 
         {/* List */}

--- a/src/components/approvals/SubmitForApproval.tsx
+++ b/src/components/approvals/SubmitForApproval.tsx
@@ -15,6 +15,8 @@ interface SubmitForApprovalProps {
   onSubmitted?: (item: ApprovalItem) => void;
 }
 
+type ApiFieldError = { field: string; message: string };
+
 /**
  * Allows non-admin users (instructors) to submit content for admin review.
  * Implements RunAsNonRoot: the action is available without elevated privileges.
@@ -29,11 +31,13 @@ export function SubmitForApproval({
 }: SubmitForApprovalProps) {
   const [status, setStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
   const [errorMsg, setErrorMsg] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<ApiFieldError[]>([]);
 
   const submit = async () => {
     if (!user) return;
     setStatus('loading');
     setErrorMsg('');
+    setFieldErrors([]);
     try {
       const res = await fetch('/api/approvals', {
         method: 'POST',
@@ -50,7 +54,13 @@ export function SubmitForApproval({
         setStatus('done');
         onSubmitted?.(json.data);
       } else {
-        setErrorMsg(json.message ?? 'Submission failed');
+        const apiErrors = json.errors as ApiFieldError[] | undefined;
+        if (apiErrors && apiErrors.length > 0) {
+          setFieldErrors(apiErrors);
+          setErrorMsg(json.message ?? 'Submission failed');
+        } else {
+          setErrorMsg(json.message ?? 'Submission failed');
+        }
         setStatus('error');
       }
     } catch {
@@ -85,9 +95,17 @@ export function SubmitForApproval({
                   {status === 'loading' ? 'Submitting…' : 'Submit for Approval'}
                 </button>
                 {status === 'error' && (
-                  <p role="alert" className="text-xs text-red-600 dark:text-red-400">
-                    {errorMsg}
-                  </p>
+                  <div role="alert" className="text-xs text-red-600 dark:text-red-400 space-y-0.5">
+                    {fieldErrors.length > 0 ? (
+                      fieldErrors.map((fe, i) => (
+                        <p key={i}>
+                          <span className="font-semibold">{fe.field}</span>: {fe.message}
+                        </p>
+                      ))
+                    ) : (
+                      <p>{errorMsg}</p>
+                    )}
+                  </div>
                 )}
               </>
             )}

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -19,7 +19,7 @@ interface FormErrorProps {
 }
 
 function isStructuredErrors(value: FormErrorValue): value is ApiFieldError[] {
-  return Array.isArray(value) && value.length > 0 && 'field' in value[0];
+  return Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null && 'field' in value[0];
 }
 
 export function FormError({ error, className = '', id }: FormErrorProps) {

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -19,7 +19,10 @@ interface FormErrorProps {
 }
 
 function isStructuredErrors(value: FormErrorValue): value is ApiFieldError[] {
-  return Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null && 'field' in value[0];
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const first = value[0];
+  if (typeof first !== 'object' || first === null) return false;
+  return 'field' in first;
 }
 
 export function FormError({ error, className = '', id }: FormErrorProps) {

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -4,11 +4,22 @@ import { motion } from 'framer-motion';
 import { AlertCircle } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
+export type ApiFieldError = {
+  field: string;
+  message: string;
+};
+
+type FormErrorValue = string | string[] | ApiFieldError[] | null;
+
 // --- GLOBAL FORM ERROR (For Backend / API Errors) ---
 interface FormErrorProps {
-  error?: string | string[] | null;
+  error?: FormErrorValue;
   className?: string;
   id?: string;
+}
+
+function isStructuredErrors(value: FormErrorValue): value is ApiFieldError[] {
+  return Array.isArray(value) && value.length > 0 && 'field' in value[0];
 }
 
 export function FormError({ error, className = '', id }: FormErrorProps) {
@@ -22,7 +33,31 @@ export function FormError({ error, className = '', id }: FormErrorProps) {
 
   if (!error) return null;
 
-  const errors = Array.isArray(error) ? error : [error];
+  if (isStructuredErrors(error)) {
+    return (
+      <motion.div
+        ref={errorRef}
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        className={`p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2 ${className}`}
+        role="alert"
+        aria-live="assertive"
+        id={id}
+      >
+        <AlertCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+        <div className="flex flex-col gap-1">
+          {error.map((err, index) => (
+            <span key={index} className="text-sm text-red-600 font-medium">
+              <span className="font-semibold">{err.field}</span>: {err.message}
+            </span>
+          ))}
+        </div>
+      </motion.div>
+    );
+  }
+
+  const messages = Array.isArray(error) ? error : [error];
 
   return (
     <motion.div
@@ -37,7 +72,7 @@ export function FormError({ error, className = '', id }: FormErrorProps) {
     >
       <AlertCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
       <div className="flex flex-col">
-        {errors.map((err, index) => (
+        {messages.map((err, index) => (
           <span key={index} className="text-sm text-red-600 font-medium">
             {err}
           </span>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -187,6 +187,7 @@ class ApiClientImpl {
           body?.message || response.statusText,
           statusToUserMessage(response.status),
           response.status,
+          body?.errors,
         );
       }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
-import { ZodTypeAny, ZodError, z } from 'zod';
+import { ZodTypeAny, z } from 'zod';
 
 // ---------------------------------------------------------------------------
 // Discriminated union result type — TypeScript narrows correctly on `.ok`
 // ---------------------------------------------------------------------------
+
+export type ValidationFieldError = {
+  field: string;
+  message: string;
+};
 
 type ValidationSuccess<T> = { ok: true; data: T };
 type ValidationFailure = { ok: false; error: NextResponse };
@@ -19,10 +24,14 @@ export function validateBody<S extends ZodTypeAny>(
 ): ValidationResult<z.infer<S>> {
   const result = schema.safeParse(input);
   if (!result.success) {
+    const errors: ValidationFieldError[] = result.error.issues.map((issue) => ({
+      field: issue.path.join('.'),
+      message: issue.message,
+    }));
     return {
       ok: false,
       error: NextResponse.json(
-        { success: false, message: formatZodError(result.error) },
+        { message: 'Validation failed', errors },
         { status: 400 },
       ),
     };
@@ -40,12 +49,4 @@ export function validateQuery<S extends ZodTypeAny>(
 ): ValidationResult<z.infer<S>> {
   const raw = Object.fromEntries(searchParams.entries());
   return validateBody(schema, raw);
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatZodError(error: ZodError): string {
-  return error.errors.map((e) => e.message).join('; ');
 }

--- a/src/services/pdf-generation.ts
+++ b/src/services/pdf-generation.ts
@@ -27,12 +27,12 @@ export async function generatePDF(
     // Apply the required default timeout (25 000 ms) to prevent indefinite hangs.
     page.setDefaultTimeout(25000);
 
-    // Load the HTML content. "networkidle0" waits for all network requests to finish.
-    await page.setContent(html, { waitUntil: 'networkidle0' });
+    // Load the HTML content. Use "domcontentloaded" instead of "networkidle0"
+    await page.setContent(html, { waitUntil: 'domcontentloaded' });
 
     // Generate the PDF. Caller may supply additional options.
     const pdfBuffer = await page.pdf({ format: 'A4', ...options });
-    return pdfBuffer;
+    return Buffer.isBuffer(pdfBuffer) ? pdfBuffer : Buffer.from(pdfBuffer);
   } finally {
     // Ensure the browser process is always cleaned up, even on errors or timeouts.
     await browser.close();

--- a/src/services/pdf-generation.ts
+++ b/src/services/pdf-generation.ts
@@ -1,4 +1,4 @@
-import puppeteer from 'puppeteer';
+import puppeteer, { type PDFOptions } from 'puppeteer';
 
 /**
  * Generate a PDF from the provided HTML string using Puppeteer.
@@ -13,7 +13,7 @@ import puppeteer from 'puppeteer';
  */
 export async function generatePDF(
   html: string,
-  options?: puppeteer.PDFOptions
+  options?: PDFOptions
 ): Promise<Buffer> {
   // Launch a headless browser. The flags ensure compatibility in most CI
   // and server environments without a sandbox.

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -38,6 +38,7 @@ export function parseApiError(error: unknown): ErrorInfo {
       timestamp: now,
       retryable: error.statusCode ? error.statusCode >= 500 : true,
       userMessage: error.userMessage,
+      details: error.errors ? { validationErrors: error.errors } : undefined,
     };
   }
 
@@ -51,12 +52,18 @@ export function parseApiError(error: unknown): ErrorInfo {
   };
 }
 
+export type ApiFieldError = {
+  field: string;
+  message: string;
+};
+
 export class ApiError extends Error {
   constructor(
     public readonly type: ErrorType,
     message: string,
     public readonly userMessage: string,
     public readonly statusCode?: number,
+    public readonly errors?: ApiFieldError[],
   ) {
     super(message);
     this.name = 'ApiError';


### PR DESCRIPTION
 ## Description
Replaced the semicolon-joined error string from Zod validation (message: "error1; error2; error3") with a structured errors array (errors: [{ field: "email", message: "Invalid email" }]). The API client (ApiError) now carries these field-level errors, and frontend forms (signup, login, verify-email, certificates) use them to display inline per-field error messages via react-hook-form's setError or the enhanced FormError component — eliminating the need for frontends to parse freeform error strings.

## Related Issue

Closes #771 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
