### PR TITLE
Fix video analytics event cap to retain newest events

### DIFF
--- a/src/app/api/video-analytics/__tests__/analytics.test.ts
+++ b/src/app/api/video-analytics/__tests__/analytics.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, analyticsStore } from '../route';
+
+// ---------------------------------------------------------------------------
+// Mock dependencies
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: () => ({
+    addHeaders: (res: Response) => res,
+    rateLimitResponse: null,
+  }),
+}));
+
+vi.mock('@/../infra/edge-config', () => ({
+  edgeLog: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePost(body: Record<string, unknown>): Promise<Response> {
+  return POST(new Request('https://example.com/api/video-analytics', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/video-analytics', () => {
+  beforeEach(() => {
+    analyticsStore.clear();
+  });
+
+  it('returns 400 when lessonId is missing', async () => {
+    const res = await makePost({ eventType: 'play' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when eventType is missing', async () => {
+    const res = await makePost({ lessonId: 'lesson-1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('stores events in order and caps at 1000', async () => {
+    const lessonId = 'lesson-cap-test';
+    const eventType = 'play';
+
+    // Insert 1001 events
+    for (let i = 1; i <= 1001; i++) {
+      const res = await makePost({
+        lessonId,
+        eventType,
+        payload: { seq: i },
+      });
+      expect(res.status).toBe(200);
+    }
+
+    const key = `anon::${encodeURIComponent(lessonId)}`;
+    const stored = analyticsStore.get(key)!;
+
+    expect(stored).toHaveLength(1000);
+
+    // The first (oldest) stored event should be seq=2 (seq=1 was evicted)
+    expect(stored[0].payload).toEqual({ seq: 2 });
+    // The last (newest) stored event should be seq=1001
+    expect(stored[stored.length - 1].payload).toEqual({ seq: 1001 });
+  });
+
+  it('keeps newest events and discards oldest when over capacity', async () => {
+    const lessonId = 'lesson-discard-test';
+    const eventType = 'seek';
+
+    // Insert 1001 events with identifiable payloads
+    for (let i = 0; i < 1001; i++) {
+      await makePost({
+        lessonId,
+        eventType,
+        payload: { index: i },
+      });
+    }
+
+    const key = `anon::${encodeURIComponent(lessonId)}`;
+    const stored = analyticsStore.get(key)!;
+
+    // Event 0 (oldest) should be absent
+    expect(stored.find((e) => e.payload?.index === 0)).toBeUndefined();
+    // Event 1000 (newest) should be present
+    expect(stored.find((e) => e.payload?.index === 1000)).toBeDefined();
+    // Event 500 should still be present
+    expect(stored.find((e) => e.payload?.index === 500)).toBeDefined();
+  });
+});

--- a/src/app/api/video-analytics/route.ts
+++ b/src/app/api/video-analytics/route.ts
@@ -12,7 +12,7 @@ type AnalyticsEvent = {
   payload: Record<string, unknown>;
 };
 
-const analyticsStore = new Map<string, AnalyticsEvent[]>();
+export const analyticsStore = new Map<string, AnalyticsEvent[]>();
 
 const keyFor = (userId: string | undefined, lessonId: string) => {
   const safeUserId = encodeURIComponent(userId ?? 'anon');
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
 
   const key = keyFor(body.userId, body.lessonId);
   const prev = analyticsStore.get(key) ?? [];
-  analyticsStore.set(key, [event, ...prev].slice(0, 1000));
+  analyticsStore.set(key, [...prev, event].slice(-1000));
 
   return addHeaders(NextResponse.json({ success: true }));
 }


### PR DESCRIPTION


## Description

Changed the per-key capping logic in POST /api/video-analytics from [event, ...prev].slice(0, 1000) (prepend + keep first 1000) to [...prev, event].slice(-1000) (append + keep last 1000). The old implementation prepended the new event and took the first 1000, which unintentionally kept the oldest 999 events plus the new one — once the array exceeded 1000 items, the newest events were silently dropped. The fix stores events in chronological order and uses a negative slice index to retain only the 1000 most recent entries, discarding the oldest. A new test inserts 1001 events and asserts the first event is evicted while the last remains.


## Related Issue

Closes #736 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
