### PR TITLE
feat(api): persist notes, bookmarks, approvals, analytics to PostgreSQL

### DIFF
--- a/src/app/api/approvals/__tests__/route.test.ts
+++ b/src/app/api/approvals/__tests__/route.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, PATCH } from '../route';
+
+// Mock the database query
+vi.mock('@/lib/db/pool', () => ({
+  query: vi.fn(),
+}));
+
+// Mock rate limiting
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: vi.fn(() => ({
+    addHeaders: (response: Response) => response,
+    rateLimitResponse: null,
+  })),
+}));
+
+// Mock audit logging
+vi.mock('@/middleware/audit', () => ({
+  logAuditMutation: vi.fn(),
+}));
+
+import { query } from '@/lib/db/pool';
+
+describe('/api/approvals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET', () => {
+    it('should return all approvals', async () => {
+      const mockApprovals = [
+        {
+          id: 'approval-1',
+          contentId: 'course-1',
+          contentType: 'COURSE',
+          title: 'Test Course',
+          submittedBy: 'user-1',
+          submittedAt: '2024-01-01T00:00:00.000Z',
+          status: 'PENDING',
+        },
+      ];
+
+      vi.mocked(query).mockResolvedValue({ rows: mockApprovals, rowCount: 1 } as never);
+
+      const request = new Request('http://localhost/api/approvals');
+      const response = await GET(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockApprovals);
+    });
+
+    it('should filter approvals by status', async () => {
+      vi.mocked(query).mockResolvedValue({ rows: [], rowCount: 0 } as never);
+
+      const request = new Request('http://localhost/api/approvals?status=PENDING');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      expect(query).toHaveBeenCalledWith(expect.stringContaining('WHERE'), ['PENDING']);
+    });
+
+    it('should return 400 for invalid status', async () => {
+      const request = new Request('http://localhost/api/approvals?status=INVALID');
+      const response = await GET(request);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(query).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/approvals');
+      const response = await GET(request);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('POST', () => {
+    it('should create a new approval request', async () => {
+      const mockApproval = {
+        id: 'approval-123',
+        contentId: 'course-1',
+        contentType: 'COURSE',
+        title: 'New Course',
+        submittedBy: 'user-1',
+        submittedAt: '2024-01-01T00:00:00.000Z',
+        status: 'PENDING',
+      };
+
+      vi.mocked(query).mockResolvedValue({ rows: [mockApproval], rowCount: 1 } as never);
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'POST',
+        body: JSON.stringify({
+          contentId: 'course-1',
+          contentType: 'COURSE',
+          title: 'New Course',
+          submittedBy: 'user-1',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(json.success).toBe(true);
+      expect(json.data.status).toBe('PENDING');
+    });
+
+    it('should return 400 for missing required fields', async () => {
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'POST',
+        body: JSON.stringify({
+          contentId: 'course-1',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(query).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'POST',
+        body: JSON.stringify({
+          contentId: 'course-1',
+          contentType: 'COURSE',
+          title: 'New Course',
+          submittedBy: 'user-1',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('PATCH', () => {
+    it('should approve a pending approval', async () => {
+      const updatedApproval = {
+        id: 'approval-123',
+        contentId: 'course-1',
+        contentType: 'COURSE',
+        title: 'Test Course',
+        submittedBy: 'user-1',
+        submittedAt: '2024-01-01T00:00:00.000Z',
+        status: 'APPROVED',
+        reviewedBy: 'admin-1',
+        reviewedAt: '2024-01-02T00:00:00.000Z',
+      };
+
+      vi.mocked(query).mockResolvedValue({ rows: [updatedApproval], rowCount: 1 } as never);
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          id: 'approval-123',
+          status: 'APPROVED',
+          reviewedBy: 'admin-1',
+        }),
+      });
+
+      const response = await PATCH(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data.status).toBe('APPROVED');
+    });
+
+    it('should return 404 for non-existent approval', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          id: 'non-existent',
+          status: 'APPROVED',
+          reviewedBy: 'admin-1',
+        }),
+      });
+
+      const response = await PATCH(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(json.message).toBe('Approval not found');
+    });
+
+    it('should return 409 for already reviewed approval', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+        .mockResolvedValueOnce({ rows: [{ id: 'approval-123' }], rowCount: 1 } as never);
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          id: 'approval-123',
+          status: 'REJECTED',
+          reviewedBy: 'admin-2',
+        }),
+      });
+
+      const response = await PATCH(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(json.message).toBe('Only PENDING approvals can be reviewed');
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(query).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/approvals', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          id: 'approval-123',
+          status: 'APPROVED',
+          reviewedBy: 'admin-1',
+        }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/bookmarks/__tests__/route.test.ts
+++ b/src/app/api/bookmarks/__tests__/route.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, PATCH, DELETE } from '../route';
+
+// Mock the repository
+vi.mock('@/lib/db/repositories/bookmarks.repository', () => ({
+  findByUserAndLesson: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+}));
+
+// Mock rate limiting
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: vi.fn(() => ({
+    addHeaders: (response: Response) => response,
+    rateLimitResponse: null,
+  })),
+}));
+
+// Mock audit logging
+vi.mock('@/middleware/audit', () => ({
+  logAuditMutation: vi.fn(),
+}));
+
+// Mock edge logging
+vi.mock('@/../infra/edge-config', () => ({
+  edgeLog: vi.fn(),
+}));
+
+import * as bookmarksRepo from '@/lib/db/repositories/bookmarks.repository';
+
+describe('/api/bookmarks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET', () => {
+    it('should return bookmarks for a user and lesson', async () => {
+      const mockBookmarks = [
+        {
+          id: 'bookmark-1',
+          time: 30.5,
+          title: 'Important part',
+          note: 'Review this',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+
+      vi.mocked(bookmarksRepo.findByUserAndLesson).mockResolvedValue(mockBookmarks);
+
+      const request = new Request('http://localhost/api/bookmarks?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockBookmarks);
+      expect(bookmarksRepo.findByUserAndLesson).toHaveBeenCalledWith('user-1', 'lesson-1');
+    });
+
+    it('should return 400 for missing lessonId', async () => {
+      const request = new Request('http://localhost/api/bookmarks?userId=user-1');
+      const response = await GET(request);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return empty array when no bookmarks exist', async () => {
+      vi.mocked(bookmarksRepo.findByUserAndLesson).mockResolvedValue([]);
+
+      const request = new Request('http://localhost/api/bookmarks?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.data).toEqual([]);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(bookmarksRepo.findByUserAndLesson).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/bookmarks?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('POST', () => {
+    it('should create a new bookmark', async () => {
+      const mockBookmark = {
+        id: 'bookmark-123',
+        time: 45.0,
+        title: 'Key concept',
+        note: 'Remember this',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      vi.mocked(bookmarksRepo.create).mockResolvedValue(mockBookmark);
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          bookmark: { time: 45.0, title: 'Key concept', note: 'Remember this' },
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data.title).toBe('Key concept');
+    });
+
+    it('should create a bookmark without optional note', async () => {
+      const mockBookmark = {
+        id: 'bookmark-123',
+        time: 45.0,
+        title: 'Key concept',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      vi.mocked(bookmarksRepo.create).mockResolvedValue(mockBookmark);
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          bookmark: { time: 45.0, title: 'Key concept' },
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+    });
+
+    it('should return 400 for invalid payload', async () => {
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          bookmark: { time: 45.0 }, // missing title
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(bookmarksRepo.create).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          bookmark: { time: 45.0, title: 'Key concept' },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('PATCH', () => {
+    it('should update an existing bookmark', async () => {
+      vi.mocked(bookmarksRepo.update).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'bookmark-123',
+          title: 'Updated title',
+          note: 'Updated note',
+        }),
+      });
+
+      const response = await PATCH(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(bookmarksRepo.update).toHaveBeenCalledWith(
+        'bookmark-123',
+        'user-1',
+        'lesson-1',
+        { title: 'Updated title', note: 'Updated note', time: undefined },
+      );
+    });
+
+    it('should update bookmark with new time', async () => {
+      vi.mocked(bookmarksRepo.update).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'bookmark-123',
+          title: 'Updated title',
+          time: 60.0,
+        }),
+      });
+
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(200);
+      expect(bookmarksRepo.update).toHaveBeenCalledWith(
+        'bookmark-123',
+        'user-1',
+        'lesson-1',
+        { title: 'Updated title', note: undefined, time: 60.0 },
+      );
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(bookmarksRepo.update).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'bookmark-123',
+          title: 'Updated title',
+        }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('DELETE', () => {
+    it('should delete a bookmark', async () => {
+      vi.mocked(bookmarksRepo.remove).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'bookmark-123',
+        }),
+      });
+
+      const response = await DELETE(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(bookmarksRepo.remove).toHaveBeenCalledWith('bookmark-123', 'user-1', 'lesson-1');
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(bookmarksRepo.remove).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/bookmarks', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'bookmark-123',
+        }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -17,14 +17,7 @@ import type {
   BookmarksSuccessResponseDTO,
 } from '@/types/api/bookmarks.dto';
 
-export const runtime = 'edge';
-
-const bookmarksStore = new Map<string, VideoBookmark[]>();
-
-const keyFor = (userId: string | undefined, lessonId: string): string => {
-  const safeUserId = encodeURIComponent(userId ?? 'anon');
-  return `${safeUserId}::${encodeURIComponent(lessonId)}`;
-};
+import * as bookmarksRepo from '@/lib/db/repositories/bookmarks.repository';
 
 // ---------------------------------------------------------------------------
 // GET /api/bookmarks
@@ -40,12 +33,26 @@ export async function GET(request: Request): Promise<NextResponse<BookmarksListR
   const result = validateQuery(BookmarksGetQuerySchema, searchParams);
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  return addHeaders(
-    NextResponse.json({
-      data: bookmarksStore.get(keyFor(result.data.userId, result.data.lessonId)) ?? [],
-      success: true,
-    }),
-  );
+  try {
+    const bookmarks = await bookmarksRepo.findByUserAndLesson(
+      result.data.userId,
+      result.data.lessonId,
+    );
+    return addHeaders(
+      NextResponse.json({
+        data: bookmarks,
+        success: true,
+      }),
+    );
+  } catch (error) {
+    edgeLog('error', '/api/bookmarks', 'Database error in GET', { error });
+    return addHeaders(
+      NextResponse.json(
+        { data: [], success: false, message: 'Internal server error' },
+        { status: 500 },
+      ),
+    ) as NextResponse;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -61,38 +68,45 @@ export async function POST(request: Request): Promise<NextResponse<BookmarkRespo
   const result = validateBody(BookmarksCreateBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const now = new Date().toISOString();
+  try {
+    const bookmarkData = {
+      id: result.data.bookmark.id ?? `bookmark-${Date.now()}`,
+      time: result.data.bookmark.time,
+      title: result.data.bookmark.title,
+      note: result.data.bookmark.note,
+    };
 
-  const persisted: VideoBookmark = {
-    id: result.data.bookmark.id ?? `bookmark-${Date.now()}`,
-    time: result.data.bookmark.time,
-    title: result.data.bookmark.title,
-    note: result.data.bookmark.note,
-    createdAt: now,
-    updatedAt: now,
-  };
+    const persisted = await bookmarksRepo.create(
+      result.data.userId,
+      result.data.lessonId,
+      bookmarkData,
+    );
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = bookmarksStore.get(key) ?? [];
+    const response = addHeaders(
+      NextResponse.json({
+        success: true,
+        data: persisted,
+      }),
+    );
 
-  bookmarksStore.set(key, [persisted, ...prev.filter((b) => b.id !== persisted.id)]);
+    logAuditMutation(request, {
+      action: 'create',
+      targetType: 'video-bookmark',
+      targetId: persisted.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(
-    NextResponse.json({
-      success: true,
-      data: persisted,
-    }),
-  );
-
-  logAuditMutation(request, {
-    action: 'create',
-    targetType: 'video-bookmark',
-    targetId: persisted.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/bookmarks', 'Database error in POST', { error });
+    return addHeaders(
+      NextResponse.json(
+        { success: false, message: 'Internal server error' } as unknown as BookmarkResponseDTO,
+        { status: 500 },
+      ),
+    ) as NextResponse;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -108,35 +122,29 @@ export async function PATCH(request: Request): Promise<NextResponse<BookmarksSuc
   const result = validateBody(BookmarksPatchBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = bookmarksStore.get(key) ?? [];
-  const now = new Date().toISOString();
+  try {
+    await bookmarksRepo.update(result.data.id, result.data.userId, result.data.lessonId, {
+      title: result.data.title,
+      note: result.data.note,
+      time: result.data.time,
+    });
 
-  bookmarksStore.set(
-    key,
-    prev.map((b) =>
-      b.id === result.data.id
-        ? {
-            ...b,
-            title: result.data.title,
-            note: result.data.note,
-            time: result.data.time ?? b.time,
-            updatedAt: now,
-          }
-        : b,
-    ),
-  );
+    const response = addHeaders(NextResponse.json({ success: true }));
+    logAuditMutation(request, {
+      action: 'update',
+      targetType: 'video-bookmark',
+      targetId: result.data.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(NextResponse.json({ success: true }));
-  logAuditMutation(request, {
-    action: 'update',
-    targetType: 'video-bookmark',
-    targetId: result.data.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/bookmarks', 'Database error in PATCH', { error });
+    return addHeaders(
+      NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 }),
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -152,22 +160,23 @@ export async function DELETE(request: Request): Promise<NextResponse<BookmarksSu
   const result = validateBody(BookmarksDeleteBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = bookmarksStore.get(key) ?? [];
+  try {
+    await bookmarksRepo.remove(result.data.id, result.data.userId, result.data.lessonId);
 
-  bookmarksStore.set(
-    key,
-    prev.filter((b) => b.id !== result.data.id),
-  );
+    const response = addHeaders(NextResponse.json({ success: true }));
+    logAuditMutation(request, {
+      action: 'delete',
+      targetType: 'video-bookmark',
+      targetId: result.data.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(NextResponse.json({ success: true }));
-  logAuditMutation(request, {
-    action: 'delete',
-    targetType: 'video-bookmark',
-    targetId: result.data.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/bookmarks', 'Database error in DELETE', { error });
+    return addHeaders(
+      NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 }),
+    );
+  }
 }

--- a/src/app/api/notes/__tests__/route.test.ts
+++ b/src/app/api/notes/__tests__/route.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, PATCH, DELETE } from '../route';
+
+// Mock the repository
+vi.mock('@/lib/db/repositories/notes.repository', () => ({
+  findByUserAndLesson: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+}));
+
+// Mock rate limiting
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: vi.fn(() => ({
+    addHeaders: (response: Response) => response,
+    rateLimitResponse: null,
+  })),
+}));
+
+// Mock audit logging
+vi.mock('@/middleware/audit', () => ({
+  logAuditMutation: vi.fn(),
+}));
+
+// Mock edge logging
+vi.mock('@/../infra/edge-config', () => ({
+  edgeLog: vi.fn(),
+}));
+
+import * as notesRepo from '@/lib/db/repositories/notes.repository';
+
+describe('/api/notes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET', () => {
+    it('should return notes for a user and lesson', async () => {
+      const mockNotes = [
+        {
+          id: 'note-1',
+          time: 30.5,
+          text: 'Test note',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+
+      vi.mocked(notesRepo.findByUserAndLesson).mockResolvedValue(mockNotes);
+
+      const request = new Request('http://localhost/api/notes?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockNotes);
+      expect(notesRepo.findByUserAndLesson).toHaveBeenCalledWith('user-1', 'lesson-1');
+    });
+
+    it('should return 400 for missing lessonId', async () => {
+      const request = new Request('http://localhost/api/notes?userId=user-1');
+      const response = await GET(request);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return empty array when no notes exist', async () => {
+      vi.mocked(notesRepo.findByUserAndLesson).mockResolvedValue([]);
+
+      const request = new Request('http://localhost/api/notes?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.data).toEqual([]);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(notesRepo.findByUserAndLesson).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/notes?lessonId=lesson-1&userId=user-1');
+      const response = await GET(request);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('POST', () => {
+    it('should create a new note', async () => {
+      const mockNote = {
+        id: 'note-123',
+        time: 45.0,
+        text: 'New note',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      vi.mocked(notesRepo.create).mockResolvedValue(mockNote);
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          note: { time: 45.0, text: 'New note' },
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data.text).toBe('New note');
+    });
+
+    it('should return 400 for invalid payload', async () => {
+      const request = new Request('http://localhost/api/notes', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          note: { time: 'invalid' }, // missing text, invalid time
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(notesRepo.create).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          note: { time: 45.0, text: 'New note' },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('PATCH', () => {
+    it('should update an existing note', async () => {
+      vi.mocked(notesRepo.update).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'note-123',
+          text: 'Updated text',
+        }),
+      });
+
+      const response = await PATCH(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(notesRepo.update).toHaveBeenCalledWith(
+        'note-123',
+        'user-1',
+        'lesson-1',
+        { text: 'Updated text', time: undefined },
+      );
+    });
+
+    it('should update note with new time', async () => {
+      vi.mocked(notesRepo.update).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'note-123',
+          text: 'Updated text',
+          time: 60.0,
+        }),
+      });
+
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(200);
+      expect(notesRepo.update).toHaveBeenCalledWith(
+        'note-123',
+        'user-1',
+        'lesson-1',
+        { text: 'Updated text', time: 60.0 },
+      );
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(notesRepo.update).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'note-123',
+          text: 'Updated text',
+        }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('DELETE', () => {
+    it('should delete a note', async () => {
+      vi.mocked(notesRepo.remove).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'note-123',
+        }),
+      });
+
+      const response = await DELETE(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(notesRepo.remove).toHaveBeenCalledWith('note-123', 'user-1', 'lesson-1');
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(notesRepo.remove).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/notes', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          id: 'note-123',
+        }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -17,14 +17,7 @@ import type {
   NotesSuccessResponseDTO,
 } from '@/types/api/notes.dto';
 
-export const runtime = 'edge';
-
-const notesStore = new Map<string, VideoNote[]>();
-
-const keyFor = (userId: string | undefined, lessonId: string): string => {
-  const safeUserId = encodeURIComponent(userId ?? 'anon');
-  return `${safeUserId}::${encodeURIComponent(lessonId)}`;
-};
+import * as notesRepo from '@/lib/db/repositories/notes.repository';
 
 // ---------------------------------------------------------------------------
 // GET /api/notes
@@ -40,12 +33,23 @@ export async function GET(request: Request): Promise<NextResponse<NotesListRespo
   const result = validateQuery(NotesGetQuerySchema, searchParams);
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  return addHeaders(
-    NextResponse.json({
-      data: notesStore.get(keyFor(result.data.userId, result.data.lessonId)) ?? [],
-      success: true,
-    }),
-  );
+  try {
+    const notes = await notesRepo.findByUserAndLesson(result.data.userId, result.data.lessonId);
+    return addHeaders(
+      NextResponse.json({
+        data: notes,
+        success: true,
+      }),
+    );
+  } catch (error) {
+    edgeLog('error', '/api/notes', 'Database error in GET', { error });
+    return addHeaders(
+      NextResponse.json(
+        { data: [], success: false, message: 'Internal server error' },
+        { status: 500 },
+      ),
+    ) as NextResponse;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -61,37 +65,40 @@ export async function POST(request: Request): Promise<NextResponse<NoteResponseD
   const result = validateBody(NotesCreateBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const now = new Date().toISOString();
+  try {
+    const noteData = {
+      id: result.data.note.id ?? `note-${Date.now()}`,
+      time: result.data.note.time,
+      text: result.data.note.text,
+    };
 
-  const persisted: VideoNote = {
-    id: result.data.note.id ?? `note-${Date.now()}`,
-    time: result.data.note.time,
-    text: result.data.note.text,
-    createdAt: now,
-    updatedAt: now,
-  };
+    const persisted = await notesRepo.create(result.data.userId, result.data.lessonId, noteData);
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = notesStore.get(key) ?? [];
+    const response = addHeaders(
+      NextResponse.json({
+        success: true,
+        data: persisted,
+      }),
+    );
 
-  notesStore.set(key, [persisted, ...prev.filter((n) => n.id !== persisted.id)]);
+    logAuditMutation(request, {
+      action: 'create',
+      targetType: 'video-note',
+      targetId: persisted.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(
-    NextResponse.json({
-      success: true,
-      data: persisted,
-    }),
-  );
-
-  logAuditMutation(request, {
-    action: 'create',
-    targetType: 'video-note',
-    targetId: persisted.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/notes', 'Database error in POST', { error });
+    return addHeaders(
+      NextResponse.json(
+        { success: false, message: 'Internal server error' } as unknown as NoteResponseDTO,
+        { status: 500 },
+      ),
+    ) as NextResponse;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -107,34 +114,28 @@ export async function PATCH(request: Request): Promise<NextResponse<NotesSuccess
   const result = validateBody(NotesPatchBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = notesStore.get(key) ?? [];
-  const now = new Date().toISOString();
+  try {
+    await notesRepo.update(result.data.id, result.data.userId, result.data.lessonId, {
+      text: result.data.text,
+      time: result.data.time,
+    });
 
-  notesStore.set(
-    key,
-    prev.map((n) =>
-      n.id === result.data.id
-        ? {
-            ...n,
-            text: result.data.text,
-            time: result.data.time ?? n.time,
-            updatedAt: now,
-          }
-        : n,
-    ),
-  );
+    const response = addHeaders(NextResponse.json({ success: true }));
+    logAuditMutation(request, {
+      action: 'update',
+      targetType: 'video-note',
+      targetId: result.data.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(NextResponse.json({ success: true }));
-  logAuditMutation(request, {
-    action: 'update',
-    targetType: 'video-note',
-    targetId: result.data.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/notes', 'Database error in PATCH', { error });
+    return addHeaders(
+      NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 }),
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -150,22 +151,23 @@ export async function DELETE(request: Request): Promise<NextResponse<NotesSucces
   const result = validateBody(NotesDeleteBodySchema, await request.json());
   if (!result.ok) return addHeaders(result.error) as NextResponse;
 
-  const key = keyFor(result.data.userId, result.data.lessonId);
-  const prev = notesStore.get(key) ?? [];
+  try {
+    await notesRepo.remove(result.data.id, result.data.userId, result.data.lessonId);
 
-  notesStore.set(
-    key,
-    prev.filter((n) => n.id !== result.data.id),
-  );
+    const response = addHeaders(NextResponse.json({ success: true }));
+    logAuditMutation(request, {
+      action: 'delete',
+      targetType: 'video-note',
+      targetId: result.data.id,
+      statusCode: response.status,
+      metadata: { lessonId: result.data.lessonId },
+    });
 
-  const response = addHeaders(NextResponse.json({ success: true }));
-  logAuditMutation(request, {
-    action: 'delete',
-    targetType: 'video-note',
-    targetId: result.data.id,
-    statusCode: response.status,
-    metadata: { lessonId: result.data.lessonId },
-  });
-
-  return response;
+    return response;
+  } catch (error) {
+    edgeLog('error', '/api/notes', 'Database error in DELETE', { error });
+    return addHeaders(
+      NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 }),
+    );
+  }
 }

--- a/src/app/api/video-analytics/__tests__/route.test.ts
+++ b/src/app/api/video-analytics/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+
+// Mock the repository
+vi.mock('@/lib/db/repositories/video-events.repository', () => ({
+  create: vi.fn(),
+}));
+
+// Mock rate limiting
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: vi.fn(() => ({
+    addHeaders: (response: Response) => response,
+    rateLimitResponse: null,
+  })),
+}));
+
+// Mock edge logging
+vi.mock('@/../infra/edge-config', () => ({
+  edgeLog: vi.fn(),
+}));
+
+import * as videoEventsRepo from '@/lib/db/repositories/video-events.repository';
+
+describe('/api/video-analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST', () => {
+    it('should record an analytics event', async () => {
+      vi.mocked(videoEventsRepo.create).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          eventType: 'play',
+          payload: { timestamp: 30.5 },
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(videoEventsRepo.create).toHaveBeenCalledWith(
+        'user-1',
+        'lesson-1',
+        'play',
+        { timestamp: 30.5 },
+      );
+    });
+
+    it('should record event without userId (anonymous)', async () => {
+      vi.mocked(videoEventsRepo.create).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          lessonId: 'lesson-1',
+          eventType: 'pause',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(videoEventsRepo.create).toHaveBeenCalledWith(
+        undefined,
+        'lesson-1',
+        'pause',
+        {},
+      );
+    });
+
+    it('should record event with empty payload', async () => {
+      vi.mocked(videoEventsRepo.create).mockResolvedValue(undefined);
+
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          eventType: 'complete',
+        }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(videoEventsRepo.create).toHaveBeenCalledWith(
+        'user-1',
+        'lesson-1',
+        'complete',
+        {},
+      );
+    });
+
+    it('should return 400 for missing lessonId', async () => {
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          eventType: 'play',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.message).toBe('Invalid payload');
+    });
+
+    it('should return 400 for missing eventType', async () => {
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(json.success).toBe(false);
+    });
+
+    it('should return 500 on database error', async () => {
+      vi.mocked(videoEventsRepo.create).mockRejectedValue(new Error('DB error'));
+
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          eventType: 'play',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(500);
+    });
+
+    it('should handle complex payload objects', async () => {
+      vi.mocked(videoEventsRepo.create).mockResolvedValue(undefined);
+
+      const complexPayload = {
+        currentTime: 45.5,
+        duration: 120,
+        volume: 0.8,
+        playbackRate: 1.5,
+        quality: '1080p',
+        metadata: {
+          browser: 'Chrome',
+          platform: 'Windows',
+        },
+      };
+
+      const request = new Request('http://localhost/api/video-analytics', {
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'user-1',
+          lessonId: 'lesson-1',
+          eventType: 'progress',
+          payload: complexPayload,
+        }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(videoEventsRepo.create).toHaveBeenCalledWith(
+        'user-1',
+        'lesson-1',
+        'progress',
+        complexPayload,
+      );
+    });
+  });
+});

--- a/src/app/api/video-analytics/route.ts
+++ b/src/app/api/video-analytics/route.ts
@@ -3,21 +3,7 @@ import type { SuccessResponse } from '@/types/api';
 import { withRateLimit } from '@/lib/ratelimit';
 import { edgeLog } from '@/../infra/edge-config';
 
-export const runtime = 'edge';
-
-type AnalyticsEvent = {
-  userId?: string;
-  lessonId: string;
-  eventType: string;
-  payload: Record<string, unknown>;
-};
-
-export const analyticsStore = new Map<string, AnalyticsEvent[]>();
-
-const keyFor = (userId: string | undefined, lessonId: string) => {
-  const safeUserId = encodeURIComponent(userId ?? 'anon');
-  return `${safeUserId}::${encodeURIComponent(lessonId)}`;
-};
+import * as videoEventsRepo from '@/lib/db/repositories/video-events.repository';
 
 export async function POST(request: Request) {
   edgeLog('info', '/api/video-analytics', 'POST request received');
@@ -39,16 +25,14 @@ export async function POST(request: Request) {
     );
   }
 
-  const event: AnalyticsEvent = {
-    userId: body.userId,
-    lessonId: body.lessonId,
-    eventType: body.eventType,
-    payload: body.payload ?? {},
-  };
+  try {
+    await videoEventsRepo.create(body.userId, body.lessonId, body.eventType, body.payload ?? {});
 
-  const key = keyFor(body.userId, body.lessonId);
-  const prev = analyticsStore.get(key) ?? [];
-  analyticsStore.set(key, [...prev, event].slice(-1000));
-
-  return addHeaders(NextResponse.json({ success: true }));
+    return addHeaders(NextResponse.json({ success: true }));
+  } catch (error) {
+    edgeLog('error', '/api/video-analytics', 'Database error in POST', { error });
+    return addHeaders(
+      NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 }),
+    );
+  }
 }

--- a/src/lib/db/migrations/001_create_notes_table.sql
+++ b/src/lib/db/migrations/001_create_notes_table.sql
@@ -1,0 +1,18 @@
+-- Migration: Create notes table
+-- Description: Stores video notes for users per lesson
+
+CREATE TABLE IF NOT EXISTS notes (
+  id VARCHAR(64) PRIMARY KEY,
+  user_id VARCHAR(255),
+  lesson_id VARCHAR(255) NOT NULL,
+  time_seconds DECIMAL(10,3) NOT NULL,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for efficient lookups by user and lesson
+CREATE INDEX IF NOT EXISTS idx_notes_user_lesson ON notes(user_id, lesson_id);
+
+-- Index for ordering by creation time
+CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at DESC);

--- a/src/lib/db/migrations/002_create_bookmarks_table.sql
+++ b/src/lib/db/migrations/002_create_bookmarks_table.sql
@@ -1,0 +1,19 @@
+-- Migration: Create bookmarks table
+-- Description: Stores video bookmarks for users per lesson
+
+CREATE TABLE IF NOT EXISTS bookmarks (
+  id VARCHAR(64) PRIMARY KEY,
+  user_id VARCHAR(255),
+  lesson_id VARCHAR(255) NOT NULL,
+  time_seconds DECIMAL(10,3) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for efficient lookups by user and lesson
+CREATE INDEX IF NOT EXISTS idx_bookmarks_user_lesson ON bookmarks(user_id, lesson_id);
+
+-- Index for ordering by creation time
+CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at DESC);

--- a/src/lib/db/migrations/004_create_video_events_table.sql
+++ b/src/lib/db/migrations/004_create_video_events_table.sql
@@ -1,0 +1,20 @@
+-- Migration: Create video_events table
+-- Description: Stores video analytics events (play, pause, seek, etc.)
+
+CREATE TABLE IF NOT EXISTS video_events (
+  id SERIAL PRIMARY KEY,
+  user_id VARCHAR(255),
+  lesson_id VARCHAR(255) NOT NULL,
+  event_type VARCHAR(100) NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for efficient lookups by user and lesson
+CREATE INDEX IF NOT EXISTS idx_video_events_user_lesson ON video_events(user_id, lesson_id);
+
+-- Index for time-based queries and cleanup
+CREATE INDEX IF NOT EXISTS idx_video_events_created_at ON video_events(created_at DESC);
+
+-- Index for filtering by event type
+CREATE INDEX IF NOT EXISTS idx_video_events_type ON video_events(event_type);

--- a/src/lib/db/repositories/bookmarks.repository.ts
+++ b/src/lib/db/repositories/bookmarks.repository.ts
@@ -1,0 +1,101 @@
+import { query } from '../pool';
+import type { VideoBookmark } from '@/types/api';
+
+/**
+ * Bookmarks Repository
+ * Handles CRUD operations for video bookmarks in PostgreSQL
+ */
+
+export async function findByUserAndLesson(
+  userId: string | undefined,
+  lessonId: string
+): Promise<VideoBookmark[]> {
+  const result = await query(
+    `SELECT id, time_seconds as time, title, note, created_at, updated_at
+     FROM bookmarks
+     WHERE (user_id = $1 OR ($1 IS NULL AND user_id IS NULL))
+       AND lesson_id = $2
+     ORDER BY created_at DESC`,
+    [userId ?? null, lessonId]
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    time: parseFloat(row.time),
+    title: row.title,
+    note: row.note ?? undefined,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }));
+}
+
+export async function create(
+  userId: string | undefined,
+  lessonId: string,
+  bookmark: { id: string; time: number; title: string; note?: string }
+): Promise<VideoBookmark> {
+  const now = new Date();
+
+  await query(
+    `INSERT INTO bookmarks (id, user_id, lesson_id, time_seconds, title, note, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT (id) DO UPDATE SET
+       time_seconds = EXCLUDED.time_seconds,
+       title = EXCLUDED.title,
+       note = EXCLUDED.note,
+       updated_at = EXCLUDED.updated_at`,
+    [bookmark.id, userId ?? null, lessonId, bookmark.time, bookmark.title, bookmark.note ?? null, now, now]
+  );
+
+  return {
+    id: bookmark.id,
+    time: bookmark.time,
+    title: bookmark.title,
+    note: bookmark.note,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+}
+
+export async function update(
+  id: string,
+  userId: string | undefined,
+  lessonId: string,
+  data: { title: string; note?: string; time?: number }
+): Promise<void> {
+  const now = new Date();
+
+  if (data.time !== undefined) {
+    await query(
+      `UPDATE bookmarks
+       SET title = $1, note = $2, time_seconds = $3, updated_at = $4
+       WHERE id = $5
+         AND (user_id = $6 OR ($6 IS NULL AND user_id IS NULL))
+         AND lesson_id = $7`,
+      [data.title, data.note ?? null, data.time, now, id, userId ?? null, lessonId]
+    );
+  } else {
+    await query(
+      `UPDATE bookmarks
+       SET title = $1, note = $2, updated_at = $3
+       WHERE id = $4
+         AND (user_id = $5 OR ($5 IS NULL AND user_id IS NULL))
+         AND lesson_id = $6`,
+      [data.title, data.note ?? null, now, id, userId ?? null, lessonId]
+    );
+  }
+}
+
+export async function remove(
+  id: string,
+  userId: string | undefined,
+  lessonId: string
+): Promise<void> {
+  await query(
+    `DELETE FROM bookmarks
+     WHERE id = $1
+       AND (user_id = $2 OR ($2 IS NULL AND user_id IS NULL))
+       AND lesson_id = $3`,
+    [id, userId ?? null, lessonId]
+  );
+}

--- a/src/lib/db/repositories/notes.repository.ts
+++ b/src/lib/db/repositories/notes.repository.ts
@@ -1,0 +1,98 @@
+import { query } from '../pool';
+import type { VideoNote } from '@/types/api';
+
+/**
+ * Notes Repository
+ * Handles CRUD operations for video notes in PostgreSQL
+ */
+
+export async function findByUserAndLesson(
+  userId: string | undefined,
+  lessonId: string
+): Promise<VideoNote[]> {
+  const result = await query(
+    `SELECT id, time_seconds as time, text, created_at, updated_at
+     FROM notes
+     WHERE (user_id = $1 OR ($1 IS NULL AND user_id IS NULL))
+       AND lesson_id = $2
+     ORDER BY created_at DESC`,
+    [userId ?? null, lessonId]
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    time: parseFloat(row.time),
+    text: row.text,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }));
+}
+
+export async function create(
+  userId: string | undefined,
+  lessonId: string,
+  note: { id: string; time: number; text: string }
+): Promise<VideoNote> {
+  const now = new Date();
+
+  await query(
+    `INSERT INTO notes (id, user_id, lesson_id, time_seconds, text, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (id) DO UPDATE SET
+       time_seconds = EXCLUDED.time_seconds,
+       text = EXCLUDED.text,
+       updated_at = EXCLUDED.updated_at`,
+    [note.id, userId ?? null, lessonId, note.time, note.text, now, now]
+  );
+
+  return {
+    id: note.id,
+    time: note.time,
+    text: note.text,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+}
+
+export async function update(
+  id: string,
+  userId: string | undefined,
+  lessonId: string,
+  data: { text: string; time?: number }
+): Promise<void> {
+  const now = new Date();
+
+  if (data.time !== undefined) {
+    await query(
+      `UPDATE notes
+       SET text = $1, time_seconds = $2, updated_at = $3
+       WHERE id = $4
+         AND (user_id = $5 OR ($5 IS NULL AND user_id IS NULL))
+         AND lesson_id = $6`,
+      [data.text, data.time, now, id, userId ?? null, lessonId]
+    );
+  } else {
+    await query(
+      `UPDATE notes
+       SET text = $1, updated_at = $2
+       WHERE id = $3
+         AND (user_id = $4 OR ($4 IS NULL AND user_id IS NULL))
+         AND lesson_id = $5`,
+      [data.text, now, id, userId ?? null, lessonId]
+    );
+  }
+}
+
+export async function remove(
+  id: string,
+  userId: string | undefined,
+  lessonId: string
+): Promise<void> {
+  await query(
+    `DELETE FROM notes
+     WHERE id = $1
+       AND (user_id = $2 OR ($2 IS NULL AND user_id IS NULL))
+       AND lesson_id = $3`,
+    [id, userId ?? null, lessonId]
+  );
+}

--- a/src/lib/db/repositories/video-events.repository.ts
+++ b/src/lib/db/repositories/video-events.repository.ts
@@ -1,0 +1,19 @@
+import { query } from '../pool';
+
+/**
+ * Video Events Repository
+ * Handles insert operations for video analytics events in PostgreSQL
+ */
+
+export async function create(
+  userId: string | undefined,
+  lessonId: string,
+  eventType: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  await query(
+    `INSERT INTO video_events (user_id, lesson_id, event_type, payload, created_at)
+     VALUES ($1, $2, $3, $4, NOW())`,
+    [userId ?? null, lessonId, eventType, JSON.stringify(payload)]
+  );
+}


### PR DESCRIPTION
## Summary
  - Replace in-memory Map storage with PostgreSQL database persistence for notes, bookmarks, approvals, and video-analytics API routes
  - Add SQL migrations for 4 new tables: `notes`, `bookmarks`, `content_approvals`, `video_events`
  - Create repository layer with parameterized SQL queries for type-safe database operations

  ## Changes
  - **Migrations**: 4 SQL files in `src/lib/db/migrations/` defining table schemas with indexes
  - **Repositories**: 4 new repository modules in `src/lib/db/repositories/` with CRUD operations
  - **Route handlers**: Updated to use repositories instead of Maps, removed edge runtime
  - **Tests**: Integration tests with mocked database queries for all 4 routes

  ## Test plan
  - [ ] Run migrations against PostgreSQL database
  - [ ] Verify CRUD operations work for notes, bookmarks, approvals, analytics
  - [ ] Confirm data persists across server restarts
  - [ ] Run `npx vitest run src/app/api/notes/__tests__ src/app/api/bookmarks/__tests__ src/app/api/approvals/__tests__ src/app/api/video-analytics/__tests__`

  Closes #749