### PR TITLE
feat: make maxRetries configurable via hook options and add tests

### DIFF
--- a/src/app/hooks/__tests__/useVideoPlayer.test.tsx
+++ b/src/app/hooks/__tests__/useVideoPlayer.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { useVideoPlayer } from '../useVideoPlayer';
+import { RefObject } from 'react';
+import { vi } from 'vitest';
+
+describe('useVideoPlayer maxRetries option', () => {
+  // Mock a simple video element
+  const createVideoMock = () => {
+    const video = document.createElement('video') as HTMLVideoElement;
+    video.play = vi.fn().mockRejectedValue(new Error('play failed'));
+    video.src = 'test.mp4';
+    return video;
+  };
+
+  const videoRef = { current: createVideoMock() } as RefObject<HTMLVideoElement>;
+
+  it('should respect maxRetries option', () => {
+    const { result } = renderHook(() => useVideoPlayer(videoRef, { maxRetries: 1 }));
+
+    // Initial state
+    expect(result.current.maxRetries).toBe(1);
+    expect(result.current.retryCount).toBe(0);
+
+    // First retry should work
+    act(() => {
+      result.current.retry();
+    });
+    expect(result.current.retryCount).toBe(1);
+
+    // Second retry should not increase because maxRetries is 1
+    act(() => {
+      result.current.retry();
+    });
+    expect(result.current.retryCount).toBe(1);
+  });
+});

--- a/src/app/hooks/useVideoPlayer.tsx
+++ b/src/app/hooks/useVideoPlayer.tsx
@@ -8,7 +8,20 @@ interface VideoError {
   retryCount: number;
 }
 
-export const useVideoPlayer = (videoRef: RefObject<HTMLVideoElement>) => {
+interface UseVideoPlayerOptions {
+  maxRetries?: number;
+}
+
+/**
+ * Hook to manage video playback.
+ * @param videoRef Ref to HTMLVideoElement
+ * @param options Optional configuration
+ */
+export const useVideoPlayer = (
+  videoRef: RefObject<HTMLVideoElement>,
+  options: UseVideoPlayerOptions = {}
+) => {
+  const { maxRetries = 3 } = options;
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
@@ -19,7 +32,7 @@ export const useVideoPlayer = (videoRef: RefObject<HTMLVideoElement>) => {
   const [error, setError] = useState<VideoError | null>(null);
   const [isMuted, setIsMuted] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
-  const maxRetries = 3;
+
 
   const play = useCallback(() => {
     if (videoRef.current) {

--- a/src/app/hooks/useVideoPlayer.tsx
+++ b/src/app/hooks/useVideoPlayer.tsx
@@ -19,7 +19,7 @@ interface UseVideoPlayerOptions {
  */
 export const useVideoPlayer = (
   videoRef: RefObject<HTMLVideoElement>,
-  options: UseVideoPlayerOptions = {}
+  options: UseVideoPlayerOptions = {},
 ) => {
   const { maxRetries = 3 } = options;
   const [isPlaying, setIsPlaying] = useState(false);
@@ -32,7 +32,6 @@ export const useVideoPlayer = (
   const [error, setError] = useState<VideoError | null>(null);
   const [isMuted, setIsMuted] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
-
 
   const play = useCallback(() => {
     if (videoRef.current) {


### PR DESCRIPTION
## Description

Implemented a configurable `maxRetries` option for the `useVideoPlayer` hook, allowing callers to specify the number of retry attempts (default is 3). Updated the hook signature, added TypeScript typings, removed the hard‑coded constant, and introduced a new test to verify the option’s behavior.

## Related Issue

Closes #775 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed