### PR TITLE
fix: replace pnpm run test with pnpm vitest run --coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          if timeout 30s pnpm run test; then
+          if timeout 30s pnpm vitest run --coverage; then
             echo "Tests completed within the 30-second limit."
           else
             status=$?


### PR DESCRIPTION
## Description

Replaces the `pnpm run test` command in the CI workflow's Run Tests step with `pnpm vitest run --coverage`.

The previous `pnpm run test` command did not directly collect coverage, relying on an intermediate script. This change calls vitest directly with the `--coverage` flag, which works with the coverage reporters already configured in `vitest.config.ts`.

## Related Issue

Closes #751

## Changes

- `.github/workflows/ci.yml`: Changed `timeout 30s pnpm run test` to `timeout 30s pnpm vitest run --coverage`