### PR TITLE
Fix: Replace Object.assign with safe Error subclass in error-report r…

### DIFF
--- a/src/app/api/errors/report/route.ts
+++ b/src/app/api/errors/report/route.ts
@@ -3,15 +3,20 @@ import { createLogger } from '@/lib/logging';
 
 const logger = createLogger('errors.report');
 
+class ClientError extends Error {
+  constructor(message: string, name: string = 'ClientError') {
+    super(message);
+    this.name = name;
+  }
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const report = await request.json();
 
     // Build a real Error so normalizeError captures name + message + stack properly
     const clientError = report.errorData?.message
-      ? Object.assign(new Error(report.errorData.message), {
-          name: report.errorData.type ?? 'ClientError',
-        })
+      ? new ClientError(report.errorData.message, report.errorData.type ?? 'ClientError')
       : undefined;
 
     logger.error('Client error report', {


### PR DESCRIPTION
## Summary
Fixes #714 - Replaced Object.assign(new Error(), {...}) with a safe ClientError subclass in the error-report route.

## Changes
- Created ClientError class that extends Error and sets the name property in the constructor
- Avoids strict mode violations when mutating non-writable native Error properties
- Ensures instanceof Error checks work correctly on reconstructed objects
- PII scrubbing is already handled by the existing logging library's redaction system

## Acceptance Criteria
- ✅ Error reconstruction does not throw in strict mode
- ✅ The reconstructed object passes instanceof Error
- ✅ No writable-property violations occur