### PR TITLE
test: restore real timers after rate limit tests

### DIFF
--- a/src/app/api/tutorials/__tests__/ratelimit.test.ts
+++ b/src/app/api/tutorials/__tests__/ratelimit.test.ts
@@ -26,6 +26,11 @@ describe('slidingWindowRateLimit', () => {
     vi.useFakeTimers();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+
   it('allows requests within the limit', () => {
     const config = { limit: 3, windowMs: 60_000 };
     const id = `test-read-${Date.now()}`;


### PR DESCRIPTION
closes #710
## Description

Restored real timers after each test in the rate-limit test suite by adding `afterEach(() => { vi.useRealTimers(); })` to `src/app/api/tutorials/__tests__/ratelimit.test.ts`.

This isolates fake timer usage to the test suite that requires it, preventing timer state from leaking into other test files and reducing order-dependent test flakiness.

## Related Issue

Closes #<issue-number>

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] No console errors
* [ ] Uses Lucide icons consistently
* [ ] Responsive design implemented
* [x] Starknet best practices followed

