### PR TITLE
fix: Enable TLS certificate validation in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ DB_POOL_MAX=20
 DB_CONNECTION_TIMEOUT=5000
 DB_IDLE_TIMEOUT=30000
 
+# Database SSL Configuration (Required in production)
+# Path to CA certificate file for TLS verification
+# In production, this must be set to enable secure certificate validation
+# Example: /etc/ssl/certs/ca-bundle.crt or /path/to/ca.pem
+DB_SSL_CA=
+
 # SMS Integration (#448)
 # Provider selection: twilio | sns | vonage (default: twilio)
 SMS_PROVIDER=twilio

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -30,13 +30,13 @@ const getSSLConfig = () => {
   return false;
 };
 
-const DB_CONFIG: PoolConfig = {
+const getDbConfig = (): PoolConfig => ({
   connectionString: process.env.DATABASE_URL,
   max: parseInt(process.env.DB_POOL_MAX || '20', 10),
   connectionTimeoutMillis: parseInt(process.env.DB_CONNECTION_TIMEOUT || '5000', 10),
   idleTimeoutMillis: parseInt(process.env.DB_IDLE_TIMEOUT || '30000', 10),
   ssl: getSSLConfig(),
-};
+});
 
 type CircuitState = 'CLOSED' | 'OPEN';
 
@@ -61,7 +61,7 @@ class DatabasePool {
 
   public static getInstance(): Pool {
     if (!DatabasePool.instance) {
-      DatabasePool.instance = new Pool(DB_CONFIG);
+      DatabasePool.instance = new Pool(getDbConfig());
 
       DatabasePool.instance.on('connect', () => {
         if (process.env.NODE_ENV === 'development') {

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -13,12 +13,38 @@ import { retryWithBackoff } from '@/utils/errorUtils';
  * - Query queueing during reconnect windows
  */
 
+/**
+ * Validate DB_SSL_CA is provided in production
+ */
+function validateSSLConfig(): void {
+  if (process.env.NODE_ENV === 'production' && !process.env.DB_SSL_CA) {
+    throw new Error(
+      'DB_SSL_CA environment variable is required in production. ' +
+        'This should contain the path to your CA certificate file.',
+    );
+  }
+}
+
+// Validate on module load
+validateSSLConfig();
+
+const getSSLConfig = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return {
+      rejectUnauthorized: true,
+      ca: process.env.DB_SSL_CA,
+    };
+  }
+  // Allow unverified certificates in development
+  return false;
+};
+
 const DB_CONFIG: PoolConfig = {
   connectionString: process.env.DATABASE_URL,
   max: parseInt(process.env.DB_POOL_MAX || '20', 10),
   connectionTimeoutMillis: parseInt(process.env.DB_CONNECTION_TIMEOUT || '5000', 10),
   idleTimeoutMillis: parseInt(process.env.DB_IDLE_TIMEOUT || '30000', 10),
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: getSSLConfig(),
 };
 
 type CircuitState = 'CLOSED' | 'OPEN';

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -13,23 +13,14 @@ import { retryWithBackoff } from '@/utils/errorUtils';
  * - Query queueing during reconnect windows
  */
 
-/**
- * Validate DB_SSL_CA is provided in production
- */
-function validateSSLConfig(): void {
-  if (process.env.NODE_ENV === 'production' && !process.env.DB_SSL_CA) {
-    throw new Error(
-      'DB_SSL_CA environment variable is required in production. ' +
-        'This should contain the path to your CA certificate file.',
-    );
-  }
-}
-
-// Validate on module load
-validateSSLConfig();
-
 const getSSLConfig = () => {
   if (process.env.NODE_ENV === 'production') {
+    if (!process.env.DB_SSL_CA) {
+      throw new Error(
+        'DB_SSL_CA environment variable is required in production. ' +
+          'This should contain the path to your CA certificate file.',
+      );
+    }
     return {
       rejectUnauthorized: true,
       ca: process.env.DB_SSL_CA,


### PR DESCRIPTION
Fixed the PostgreSQL TLS certificate validation vulnerability (#709):

1. **src/lib/db/pool.ts** - Set `rejectUnauthorized: true` in production, added `DB_SSL_CA` environment variable for CA certificate path, and added startup validation to ensure it's provided in production.

2. **.env.example** - Documented the new `DB_SSL_CA` variable with usage examples.

3. **Branch & Commit** - Created `fix/709-postgresql-tls-certificate-validation` branch, committed changes with clear message, and pushed to origin. No type errors detected. Ready for PR.

Closes #709 