### PR TITLE
update ratelimter file

### DIFF
--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -28,17 +28,6 @@ interface RateLimitEntry {
 
 const stores = new Map<string, RateLimitEntry>();
 
-function cleanup(): void {
-  const now = Date.now();
-  for (const [key, entry] of stores.entries()) {
-    if (entry.resetAt <= now) {
-      stores.delete(key);
-    }
-  }
-}
-
-setInterval(cleanup, 60_000);
-
 export function slidingWindowRateLimit(
   identifier: string,
   config: RateLimitConfig,
@@ -47,6 +36,9 @@ export function slidingWindowRateLimit(
   const entry = stores.get(identifier);
 
   if (!entry || entry.resetAt <= now) {
+    if (entry) {
+      stores.delete(identifier);
+    }
     const resetAt = now + config.windowMs;
     stores.set(identifier, { count: 1, resetAt });
     return {


### PR DESCRIPTION

[Performance] Rate limiter cleanup is an O(n) linear scan fired every 60 seconds
Overview
src/lib/ratelimit.ts runs a setInterval every 60 seconds that iterates over the entire in-memory store to find and delete expired entries. Under high traffic the store can accumulate thousands of IP entries; an O(n) scan on every cleanup tick adds unnecessary latency to any request handled concurrently on the same event loop turn.

Specifications
Features:

Expired rate-limit entries are removed efficiently without scanning the entire store
Cleanup does not block request handling
Tasks:

Replace the flat Map with a min-heap or sorted structure ordered by expiry time
Alternatively, use lazy eviction: check and remove an entry at the moment it is accessed and found expired
If using Redis for distributed rate limiting, TTL-based expiry handles this natively
Impacted Files:

src/lib/ratelimit.ts
Acceptance Criteria
Cleanup time does not grow linearly with the number of tracked IPs
Expired entries are evicted before the next request from that IP is processed
Rate limiter tests still pass
closes #735
