### PR TITLE
perf: replace JSON.stringify with shallowEqual in synchronizationEngine

### DIFF
--- a/src/store/synchronizationEngine.ts
+++ b/src/store/synchronizationEngine.ts
@@ -2,6 +2,15 @@ import { useStore } from './stateManager';
 
 const CHANNEL_NAME = 'teachlink_state_sync';
 
+/** Shallow equality: primitives compared by value, objects by reference-per-key. */
+function shallowEqual(a: any, b: any): boolean {
+  if (a === b) return true;
+  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) return false;
+  const keysA = Object.keys(a);
+  if (keysA.length !== Object.keys(b).length) return false;
+  return keysA.every(k => a[k] === b[k]);
+}
+
 const SYNC_KEYS = ['user', 'preferences', 'offlineMode', 'lastSynced'] as const;
 
 /**
@@ -36,9 +45,7 @@ export class SynchronizationEngine {
     useStore.subscribe((state: any, prevState: any) => {
       if (this.isProcessingSync) return;
 
-      const hasChanged = SYNC_KEYS.some(key => 
-        JSON.stringify((state as any)[key]) !== JSON.stringify((prevState as any)[key])
-      );
+      const hasChanged = SYNC_KEYS.some(key => !shallowEqual(state[key], prevState[key]));
 
       if (hasChanged) {
         this.broadcastState(state);


### PR DESCRIPTION
Closes #733

- Add shallowEqual helper to compare per-key references/values
- Replace JSON.stringify diff with shallowEqual per SYNC_KEYS entry
- Eliminates full-state serialization on every Zustand update
- BroadcastChannel only fires when persisted state actually changes

## Description

Brief description of changes

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
closes #733 