### PR TITLE
fix(security): rate limit /api/errors/report to prevent log-flooding DoS

### DIFF
--- a/src/app/api/errors/report/__tests__/route.test.ts
+++ b/src/app/api/errors/report/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { RATE_LIMIT_TIERS } from '@/lib/ratelimit';
+
+// Silence the logger so error reports don't pollute test output.
+vi.mock('@/lib/logging', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const LIMIT = RATE_LIMIT_TIERS.REPORTING.limit;
+
+let ipCounter = 0;
+/** Fresh IP per call keeps each test isolated from the shared in-memory store. */
+function makeRequest(body: unknown, ip = `203.0.113.${ipCounter++}`): NextRequest {
+  return new NextRequest('https://example.com/api/errors/report', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': ip,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const sampleReport = {
+  id: 'rep_1',
+  sessionId: 'sess_1',
+  userId: 'user_1',
+  url: 'https://example.com/page',
+  environment: 'production',
+  errorData: { message: 'Something broke', type: 'TypeError' },
+};
+
+describe('POST /api/errors/report rate limiting', () => {
+  beforeEach(() => {
+    ipCounter = 0;
+  });
+
+  it('accepts legitimate error reports within the limit', async () => {
+    const res = await POST(makeRequest(sampleReport));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('returns 429 once the per-IP limit is exceeded', async () => {
+    const ip = '198.51.100.1';
+
+    // Exhaust the allowed quota for this IP.
+    for (let i = 0; i < LIMIT; i++) {
+      const ok = await POST(makeRequest(sampleReport, ip));
+      expect(ok.status).toBe(200);
+    }
+
+    // The next request from the same IP is rate limited.
+    const blocked = await POST(makeRequest(sampleReport, ip));
+    expect(blocked.status).toBe(429);
+  });
+
+  it('includes a Retry-After header on the 429 response', async () => {
+    const ip = '198.51.100.2';
+
+    for (let i = 0; i < LIMIT; i++) {
+      await POST(makeRequest(sampleReport, ip));
+    }
+    const blocked = await POST(makeRequest(sampleReport, ip));
+
+    expect(blocked.status).toBe(429);
+    const retryAfter = blocked.headers.get('Retry-After');
+    expect(retryAfter).not.toBeNull();
+    expect(Number(retryAfter)).toBeGreaterThan(0);
+  });
+
+  it('does not let one IP exhaust another IP quota', async () => {
+    const noisy = '198.51.100.3';
+    for (let i = 0; i < LIMIT; i++) {
+      await POST(makeRequest(sampleReport, noisy));
+    }
+    expect((await POST(makeRequest(sampleReport, noisy))).status).toBe(429);
+
+    // A different IP is unaffected.
+    const other = await POST(makeRequest(sampleReport, '198.51.100.4'));
+    expect(other.status).toBe(200);
+  });
+});

--- a/src/app/api/errors/report/route.ts
+++ b/src/app/api/errors/report/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@/lib/logging';
+import { withRateLimit } from '@/lib/ratelimit';
 
 const logger = createLogger('errors.report');
 
@@ -11,6 +12,11 @@ class ClientError extends Error {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Rate limit per IP — this endpoint is called by client-side JS and is
+  // otherwise open to log-flooding DoS. Use the lower REPORTING tier (10/min).
+  const { addHeaders, rateLimitResponse } = withRateLimit(request, 'REPORTING');
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
     const report = await request.json();
 
@@ -30,9 +36,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       error: clientError,
     });
 
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return addHeaders(NextResponse.json({ ok: true }, { status: 200 }));
   } catch (err) {
     logger.warn('Failed to process error report', { error: err });
-    return NextResponse.json({ ok: false }, { status: 400 });
+    return addHeaders(NextResponse.json({ ok: false }, { status: 400 }));
   }
 }

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -90,6 +90,9 @@ export const RATE_LIMIT_TIERS = {
   AUTH: { limit: 5, windowMs: 60_000 },
   WRITE: { limit: 30, windowMs: 60_000 },
   READ: { limit: 60, windowMs: 60_000 },
+  // Lower tier for unauthenticated, client-driven endpoints (e.g. error
+  // reporting) that are prone to log-flooding abuse.
+  REPORTING: { limit: 10, windowMs: 60_000 },
 } as const;
 
 export type RateLimitTier = keyof typeof RATE_LIMIT_TIERS;


### PR DESCRIPTION
## Summary

`/api/errors/report` accepted error reports from client-side JS with no rate limiting, leaving it open to log-flooding DoS — an attacker could script thousands of requests/sec, flooding the logging system and exhausting in-memory log buffers.

This adds per-IP rate limiting to the endpoint.

## Changes

- **New `REPORTING` rate-limit tier** (`src/lib/ratelimit.ts`) — 10 req/min per IP, a lower tier suited to unauthenticated, client-driven endpoints prone to flooding abuse.
- **Applied rate limiting** (`src/app/api/errors/report/route.ts`) — `withRateLimit(request, 'REPORTING')` runs at the top of the POST handler and short-circuits with HTTP 429 (including a `Retry-After` header) before any work is done. Accepted responses also carry `X-RateLimit-*` headers via `addHeaders`.
- **Tests** (`src/app/api/errors/report/__tests__/route.test.ts`) — cover over-limit → 429, presence of `Retry-After`, legitimate reports within the limit accepted, and per-IP isolation.

## Acceptance criteria

- [x] More than the configured limit within a window returns HTTP 429
- [x] A `Retry-After` header is present in the 429 response
- [x] Legitimate error reports within the limit are accepted and logged

## Testing

- New route tests: 4 passed
- Existing ratelimit tests: 18 passed
- `tsc --noEmit`: no type errors in changed files

Closes #721
