### PR TITLE
fix: enforce eslint rules - no-explicit-any and no-unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,8 @@
   "plugins": ["prettier", "unused-imports"],
   "reportUnusedDisableDirectives": false,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": "error",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": "off",
     "react/no-unescaped-entities": "warn",

--- a/pages/api/notifications/subscribe.js
+++ b/pages/api/notifications/subscribe.js
@@ -52,7 +52,7 @@ export default function handler(req, res) {
       subscriptions.delete(userId);
       console.log('[Push] Unsubscribed user:', userId);
       res.status(200).json({ success: true });
-    } catch (error) {
+    } catch (_error) {
       res.status(500).json({ error: 'Failed to unsubscribe' });
     }
   } else if (req.method === 'GET') {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   User,
   GraduationCap,
   Calendar,
-  Check,
   Wallet,
   LogOut,
   Globe,
@@ -15,7 +14,6 @@ import {
   FileText,
   Loader2,
   BookOpen,
-  Mail,
 } from 'lucide-react';
 
 import { FormWizardController } from '@/form-management/components';
@@ -154,9 +152,9 @@ export default function OnboardingPage() {
   const safeTrack = useCallback(
     (name: string, properties: EventProperties = {}) => {
       try {
-        track(name as any, properties);
-      } catch (err) {
-        logger.warn('[Onboarding Analytics] Failed to track event', { error: err });
+        track(name as string, properties);
+      } catch (_err) {
+        logger.warn('[Onboarding Analytics] Failed to track event', { error: _err });
       }
     },
     [track],
@@ -225,7 +223,7 @@ export default function OnboardingPage() {
     };
   }, [hasFinishedOnboarding, safeTrack]);
 
-  const handleFieldChange = async (fieldId: string, value: any) => {
+  const handleFieldChange = async (fieldId: string, value: unknown) => {
     stateManager.updateField(fieldId, value);
 
     // Perform real-time validation
@@ -268,7 +266,7 @@ export default function OnboardingPage() {
   };
 
   // Final onboarding submission
-  const handleComplete = async (values: Record<string, any>) => {
+  const handleComplete = async (values: Record<string, unknown>) => {
     const loadingToastId = loading('Finalizing your registration profile...');
 
     try {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -280,14 +280,14 @@ export default function OnboardingPage() {
         stepId: currentStep.id,
         stepIndex: currentStep.index,
         stepTitle: currentStep.title,
-        role: values.role,
+        role: values.role as string,
         walletConnected: !!values.walletAddress,
       });
 
       // Save onboarding preference state locally so other pages know user is onboarded
       if (typeof window !== 'undefined') {
         localStorage.setItem('teachlink_onboarded', 'true');
-        localStorage.setItem('teachlink_user_role', values.role);
+        localStorage.setItem('teachlink_user_role', values.role as string);
       }
 
       // Redirect to main dashboard

--- a/src/features/collaboration/types.ts
+++ b/src/features/collaboration/types.ts
@@ -70,7 +70,7 @@ export type CollaborationMessage =
   | {
       type: 'poll:created';
       roomId: string;
-      poll: any;
+      poll: unknown;
     }
   | {
       type: 'poll:vote';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,6 @@ import { checkRoutePermission } from './middleware/rbac';
 import { applySecurityHeaders } from './middleware/security';
 import { applyCspHeaders } from './middleware/csp';
 import { handleRedirects } from './middleware/redirectManagement';
-import { UserRole } from './types/api';
 import {
   API_DEPRECATION_HEADER,
   API_DEPRECATION_INFO_HEADER,

--- a/src/utils/structuredDataUtils.ts
+++ b/src/utils/structuredDataUtils.ts
@@ -24,7 +24,7 @@ export interface StructuredDataFilterGroup {
  * Uses schema.org ItemList to represent filterable options
  */
 export function generateFilterStructuredData(filterGroups: StructuredDataFilterGroup[]): string {
-  const itemListElement = filterGroups.map((group, groupIndex) => ({
+  const itemListElement = filterGroups.map((group, _groupIndex) => ({
     '@type': 'ItemList',
     name: group.name,
     description: group.description,
@@ -115,7 +115,7 @@ export function validateStructuredData(jsonLd: string): { valid: boolean; errors
     }
 
     return { valid: errors.length === 0, errors };
-  } catch (error) {
+  } catch (_error) {
     return { valid: false, errors: ['Invalid JSON format'] };
   }
 }


### PR DESCRIPTION
- Change @typescript-eslint/no-explicit-any from off to warn
- Change @typescript-eslint/no-unused-vars from off to error
- Fix unused variables and imports across codebase
- Replace 'any' types with proper types (unknown, string, Record<string, unknown>)
- Prefix unused caught errors with underscore to match eslint convention

## Description

Brief description of changes

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed

closes #747 