### PR TITLE
fix(search): stabilize onReset callback passed to FacetedFilterSystem

### DIFF
--- a/src/components/search/AdvancedSearchInterface.tsx
+++ b/src/components/search/AdvancedSearchInterface.tsx
@@ -44,6 +44,11 @@ export const AdvancedSearchInterface = React.memo(() => {
     setHasSearched(false);
   }, [clearFilters, updateSearchText]);
 
+  const handleFilterReset = useCallback(() => {
+    clearFilters();
+    setHasSearched(false);
+  }, [clearFilters]);
+
   const handleShare = useCallback(async () => {
     const ok = await copyShareableUrl();
     if (ok) {
@@ -150,10 +155,7 @@ export const AdvancedSearchInterface = React.memo(() => {
             <FacetedFilterSystem
               filters={query.filters}
               onFilterChange={updateFilters}
-              onReset={() => {
-                clearFilters();
-                setHasSearched(false);
-              }}
+              onReset={handleFilterReset}
             />
           </div>
         )}


### PR DESCRIPTION
 Description
Wrap the inline onReset arrow function in useCallback so the React.memo-wrapped FacetedFilterSystem doesn't re-render on every parent render.

## Related Issue
Closes #984

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [x] Uses Lucide icons consistently
- [x] Responsive design implemented
- [x] Starknet best practices followed" --base main