### PR TITLE
perf(calendar): memoize recurring-event expansion (#982)

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Calendar as BigCalendar, dateFnsLocalizer, SlotInfo, Views } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay, addWeeks, addDays } from 'date-fns';
 import { enUS } from 'date-fns/locale/en-US';
@@ -48,7 +48,7 @@ interface CalendarProps {
 }
 
 export default function Calendar({ events, onSelectSlot, onSelectEvent }: CalendarProps) {
-  const expanded = events.flatMap(expandRecurring);
+  const expanded = useMemo(() => events.flatMap(expandRecurring), [events]);
 
   const eventStyleGetter = useCallback(
     (event: CalendarEvent) => ({


### PR DESCRIPTION
### Summary
Fixes #982: Memoizes recurring-event expansion in [Calendar.tsx](file:///c:/Users/USER/Desktop/teachLink_web/src/components/Calendar.tsx).

### Context & Changes
Previously, `events.flatMap(expandRecurring)` was executed on every component render. Because `expandRecurring` performs up to 52 iterations per event, re-running this logic repeatedly was producing a new array instance identity on every render. This forced `react-big-calendar` to unnecessarily re-process events.

- Wrapped `events.flatMap(expandRecurring)` inside `useMemo`, with a dependency array keyed on `events`.

### Verification
- Verified that recurring event expansion only recalculates when `events` changes.
- Checked TypeScript types and component structure.