### PR TITLE
Fix/remove hardcoded discovery time

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Calendar as BigCalendar, dateFnsLocalizer, SlotInfo, Views } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay, addWeeks, addDays } from 'date-fns';
 import { enUS } from 'date-fns/locale/en-US';
@@ -48,7 +48,7 @@ interface CalendarProps {
 }
 
 export default function Calendar({ events, onSelectSlot, onSelectEvent }: CalendarProps) {
-  const expanded = events.flatMap(expandRecurring);
+  const expanded = useMemo(() => events.flatMap(expandRecurring), [events]);
 
   const eventStyleGetter = useCallback(
     (event: CalendarEvent) => ({

--- a/src/components/search/SearchResultsVisualizer.tsx
+++ b/src/components/search/SearchResultsVisualizer.tsx
@@ -64,8 +64,7 @@ export const SearchResultsVisualizer = React.memo<SearchResultsVisualizerProps>(
       <div className="space-y-6">
         <div className="flex items-center justify-between pb-4 border-b border-slate-100">
           <h2 className="text-lg font-bold font-sans text-slate-800 flex items-center gap-2">
-            {results.length} results{' '}
-            <span className="text-slate-300 text-sm font-normal">discovered in 0.8s</span>
+            {results.length} results
           </h2>
           <div className="relative group">
             <select


### PR DESCRIPTION
### Summary
Fixes #983: Removes hardcoded search discovery time claim in [SearchResultsVisualizer.tsx](file:///c:/Users/USER/Desktop/teachLink_web/src/components/search/SearchResultsVisualizer.tsx).

### Context & Changes
`SearchResultsVisualizer` was rendering a static `"discovered in 0.8s"` string for every query regardless of actual search duration, misrepresenting search timing to users.

- Removed the hardcoded `discovered in 0.8s` span element from the search results count header.

### Verification
- Verified that search result counts render accurately without displaying an arbitrary timing claim.