### PR TITLE
fix: remove exhaustive-deps suppression in CourseReviews

### DIFF
--- a/src/components/courses/CourseReviews.tsx
+++ b/src/components/courses/CourseReviews.tsx
@@ -75,8 +75,7 @@ export default function CourseReviews({
         })),
         { query, minRating, sortBy },
       ).map((scored) => scored.review),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [reviews, query, minRating, sortBy],
+    [reviews, query, minRating, sortBy, getHelpfulCount],
   );
 
   const sortOptions: { value: ReviewSortKey; label: string }[] = [


### PR DESCRIPTION
Closes #985

---

## Summary

This PR fixes the React Hooks `exhaustive-deps` warning in `CourseReviews.tsx`.

### Changes
- Added `getHelpfulCount` to the `useMemo` dependency array.
- Removed the `react-hooks/exhaustive-deps` suppression comment.
- Preserved existing behavior since `getHelpfulCount` is a stable Zustand action.

### Verification
- ✅ Added `getHelpfulCount` to the dependency array.
- ✅ Removed the ESLint suppression.
- ✅ Confirmed `getHelpfulCount` is a stable Zustand action.
- ✅ Editor diagnostics report no errors.
- ✅ `git diff --check` passed.
- ⚠️ ESLint could not be run locally because project dependencies are not installed (`node_modules` unavailable).