### PR TITLE
fix: reset ProfileEditForm when store-derived defaultValues change

### DIFF
--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -62,7 +62,12 @@ export default function ProfileEditForm() {
     handleSubmit,
     formState: { errors },
     setValue,
+    reset,
   } = methods;
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
 
   const onSubmit = useCallback(
     async (data: ProfileFormData) => {


### PR DESCRIPTION
Closes #972 
This PR resolves an issue in ProfileEditForm where the form fields do not update to reflect changes in the underlying store state (such as name, theme, and notifications).

While the defaultValues object was correctly memoized and updated on store changes, useForm only consumes these defaults on the initial component mount.

Solution:

Extracted the reset method from useForm.
Added a useEffect hook that triggers reset(defaultValues) whenever the memoized defaultValues change, ensuring the form stays in sync with the global store state.
Changes
Updated imports to include useEffect in src/components/profile/ProfileEditForm.tsx.
Added the reset effect keyed on defaultValues.