### PR TITLE
fix(#967): use usePathname for active state in SidebarNavigation

### DIFF
--- a/src/components/navigation/SidebarNavigation.tsx
+++ b/src/components/navigation/SidebarNavigation.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Home, BookOpen, Users, Settings } from 'lucide-react';
 
 interface NavItem {
@@ -18,7 +19,7 @@ const navItems: NavItem[] = [
 ];
 
 export const SidebarNavigation: React.FC = () => {
-  const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
+  const pathname = usePathname();
   return (
     <aside className="w-full lg:w-72 shrink-0 space-y-8 pr-2">
       <div className="glass-panel p-5 rounded-xl">


### PR DESCRIPTION
## Description

Updates `SidebarNavigation` to use the Next.js `usePathname` hook from `next/navigation` instead of `window.location.pathname`. This fixes a hydration mismatch during Server-Side Rendering (SSR) and ensures the active navigation link correctly highlights upon client-side navigation.

## Related Issue

Closes #967

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [x] Uses Lucide icons consistently
- [x] Responsive design implemented
- [x] Starknet best practices followed