### PR TITLE
fix(modal): dismiss primary modal on Escape

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -15,9 +15,12 @@ const SIZE_CLASSES: Record<ModalSize, string> = {
   full: 'max-w-full',
 };
 
+/** How the modal came to be closed. Optional so existing `() => void` handlers keep working. */
+export type ModalCloseReason = 'escape' | 'backdrop' | 'button';
+
 export interface ModalProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (reason?: ModalCloseReason) => void;
   title: string;
   children: React.ReactNode;
   /** Controls the maximum width of the modal panel */
@@ -29,6 +32,22 @@ export interface ModalProps {
 /**
  * Accessible modal dialog with focus trap, Escape-to-close, and screen reader announcements.
  * Uses the existing `useFocusTrap` hook from `useAccessibility`.
+ *
+ * `onClose` now receives an optional reason ('escape' | 'backdrop' | 'button')
+ * so consumers that need to distinguish an ambient dismiss gesture from an
+ * explicit close action can do so — see `ModalFeedbackLoop`, which uses this
+ * to make Escape/backdrop always cancel outright instead of interrupting the
+ * user with a feedback prompt. Existing `() => void` handlers are unaffected;
+ * they simply ignore the extra argument.
+ *
+ * NOTE on native `<dialog>`: this was evaluated as a follow-up (native
+ * top-layer stacking, a real `::backdrop`, built-in inertness of background
+ * content) but jsdom 26, which this repo's Vitest suite runs on, does not
+ * implement `HTMLDialogElement.showModal()`/`close()` — every test that
+ * renders a Modal (this file's suite, plus any test touching the 9 current
+ * consumers) would throw immediately. Revisit once the test environment
+ * upgrades to a jsdom version with dialog support, or the suite moves to a
+ * real-browser runner (e.g. Playwright component tests) for this component.
  */
 export function Modal({
   isOpen,
@@ -59,7 +78,7 @@ export function Modal({
   useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') onClose('escape');
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
@@ -70,7 +89,11 @@ export function Modal({
   return (
     <>
       {/* Backdrop */}
-      <div className="fixed inset-0 z-40 bg-black/50" onClick={onClose} aria-hidden="true" />
+      <div
+        className="fixed inset-0 z-40 bg-black/50"
+        onClick={() => onClose('backdrop')}
+        aria-hidden="true"
+      />
 
       {/* Dialog */}
       <div
@@ -89,7 +112,7 @@ export function Modal({
               {title}
             </h2>
             <button
-              onClick={onClose}
+              onClick={() => onClose('button')}
               aria-label="Close dialog"
               className="rounded p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:text-gray-200"
             >

--- a/src/components/ui/ModalFeedbackLoop.tsx
+++ b/src/components/ui/ModalFeedbackLoop.tsx
@@ -46,9 +46,20 @@ export function ModalFeedbackLoop<T>({
     }
   }, [isOpen]);
 
-  const handlePrimaryClose = useCallback(() => {
-    setAwaitingFeedback(true);
-  }, []);
+  const handlePrimaryClose = useCallback(
+    (reason?: 'escape' | 'backdrop' | 'button') => {
+      // Escape and backdrop clicks are "get me out of here" gestures — the
+      // user expects them to dismiss the whole flow immediately, with no
+      // extra step. Only an explicit close (e.g. the header close button)
+      // advances to the feedback prompt.
+      if (reason === 'escape' || reason === 'backdrop') {
+        onClose();
+        return;
+      }
+      setAwaitingFeedback(true);
+    },
+    [onClose]
+  );
 
   const handleSubmitFeedback = useCallback(async () => {
     if (rating == null) return;

--- a/src/components/ui/__tests__/Modal.test.tsx
+++ b/src/components/ui/__tests__/Modal.test.tsx
@@ -32,25 +32,28 @@ describe('Modal', () => {
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
-  it('calls onClose when backdrop is clicked', () => {
+  it('calls onClose("backdrop") when backdrop is clicked', () => {
     const onClose = vi.fn();
     render(<Modal {...defaultProps} onClose={onClose} />);
     fireEvent.click(screen.getByRole('dialog').previousElementSibling!);
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith('backdrop');
   });
 
-  it('calls onClose when Escape is pressed', () => {
+  it('calls onClose("escape") when Escape is pressed', () => {
     const onClose = vi.fn();
     render(<Modal {...defaultProps} onClose={onClose} />);
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith('escape');
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it('calls onClose("button") when close button is clicked', () => {
     const onClose = vi.fn();
     render(<Modal {...defaultProps} onClose={onClose} />);
     fireEvent.click(screen.getByLabelText('Close dialog'));
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith('button');
   });
 
   describe('size classes', () => {

--- a/src/components/ui/__tests__/ModalFeedbackLoop.test.tsx
+++ b/src/components/ui/__tests__/ModalFeedbackLoop.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ModalFeedbackLoop } from '../ModalFeedbackLoop';
+
+vi.mock('@/hooks/useAccessibility', () => ({
+  useFocusTrap: () => ({ current: null }),
+  useScreenReaderAnnouncement: () => vi.fn(),
+}));
+
+function setup(overrides: Partial<React.ComponentProps<typeof ModalFeedbackLoop<{ id: string }>>> = {}) {
+  const onClose = vi.fn();
+  const onFeedback = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ModalFeedbackLoop
+      isOpen
+      title="Primary modal"
+      modalData={{ id: 'abc' }}
+      onFeedback={onFeedback}
+      onClose={onClose}
+      {...overrides}
+    >
+      <p>Primary content</p>
+    </ModalFeedbackLoop>
+  );
+  return { onClose, onFeedback };
+}
+
+describe('ModalFeedbackLoop', () => {
+  it('closes the whole flow on Escape, without showing the feedback prompt', () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('How was that experience?')).not.toBeInTheDocument();
+  });
+
+  it('closes the whole flow on backdrop click, without showing the feedback prompt', () => {
+    const { onClose } = setup();
+    const backdrop = screen.getByRole('dialog').previousElementSibling!;
+    fireEvent.click(backdrop);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('How was that experience?')).not.toBeInTheDocument();
+  });
+
+  it('still advances to the feedback prompt on explicit close (X button)', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByLabelText('Close dialog'));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('How was that experience?')).toBeInTheDocument();
+  });
+
+  it('lets the user skip the feedback prompt, which closes the flow', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByLabelText('Close dialog'));
+    fireEvent.click(screen.getByText('Skip'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends feedback then closes the flow', async () => {
+    const { onClose, onFeedback } = setup();
+    fireEvent.click(screen.getByLabelText('Close dialog'));
+    fireEvent.click(screen.getByLabelText('5 of 5'));
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() =>
+      expect(onFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ rating: 5, sourceData: { id: 'abc' } })
+      )
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), { timeout: 2000 });
+  });
+});


### PR DESCRIPTION
## Description

Brief description of changes
Updates the `ModalFeedbackLoop` so pressing Escape or clicking the backdrop on the primary modal dismisses the dialog instead of advancing to the feedback prompt, aligning the behavior with standard modal accessibility expectations.


## Related Issue

Closes #958 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently
- [x] Responsive design implemented
- [ ] Starknet best practices followed
