### PR TITLE
fix(store): validate courseProgressStore updates with type guard

### DIFF
--- a/src/app/store/courseProgressStore.test.ts
+++ b/src/app/store/courseProgressStore.test.ts
@@ -1,0 +1,51 @@
+import {
+  useCourseProgressStore,
+  InvalidProgressError,
+  isValidLessonProgress,
+} from './courseProgressStore';
+
+describe('courseProgressStore', () => {
+  beforeEach(() => {
+    useCourseProgressStore.setState({ currentProgress: null });
+  });
+  describe('isValidLessonProgress Type Guard', () => {
+    it('returns true for complete lesson data', () => {
+      const validData = { lessonId: 'lesson-1', progress: 50 };
+      expect(isValidLessonProgress(validData)).toBe(true);
+    });
+    it('returns false when required fields are missing', () => {
+      expect(isValidLessonProgress({ lessonId: 'lesson-1' })).toBe(false); // missing progress
+      expect(isValidLessonProgress({ progress: 50 })).toBe(false); // missing lessonId
+      expect(isValidLessonProgress({})).toBe(false); // missing both
+    });
+  });
+  describe('updateProgress', () => {
+    it('successfully updates the store when given valid lesson data', () => {
+      const store = useCourseProgressStore.getState();
+      const validUpdate = { lessonId: 'lesson-123', progress: 100 };
+      store.updateProgress(validUpdate);
+      const updatedStore = useCourseProgressStore.getState();
+      expect(updatedStore.currentProgress).toEqual(validUpdate);
+    });
+    it('throws InvalidProgressError when required fields are missing', () => {
+      const store = useCourseProgressStore.getState();
+      const invalidUpdate = { progress: 75 }; // missing lessonId
+      expect(() => {
+        store.updateProgress(invalidUpdate);
+      }).toThrow(InvalidProgressError);
+      expect(() => {
+        store.updateProgress(invalidUpdate);
+      }).toThrow('Update rejected: lessonData is missing required fields');
+    });
+    it('does not mutate the store state when an invalid update is rejected', () => {
+      const store = useCourseProgressStore.getState();
+      store.updateProgress({ lessonId: 'initial-lesson', progress: 0 });
+      const stateBeforeError = useCourseProgressStore.getState().currentProgress;
+      try {
+        useCourseProgressStore.getState().updateProgress({ lessonId: 'new-lesson' }); // missing progress
+      } catch (e) {}
+      const stateAfterError = useCourseProgressStore.getState().currentProgress;
+      expect(stateAfterError).toEqual(stateBeforeError);
+    });
+  });
+});

--- a/src/app/store/courseProgressStore.ts
+++ b/src/app/store/courseProgressStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+export interface LessonProgress {
+  lessonId: string;
+  progress: number;
+  lastAccessed?: number; // Optional field example
+}
+interface CourseProgressState {
+  currentProgress: LessonProgress | null;
+  updateProgress: (lessonData: Partial<LessonProgress>) => void;
+}
+export class InvalidProgressError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidProgressError';
+  }
+}
+export function isValidLessonProgress(data: Partial<LessonProgress>): data is LessonProgress {
+  return (
+    typeof data.lessonId === 'string' &&
+    data.lessonId.trim() !== '' &&
+    typeof data.progress === 'number'
+  );
+}
+export const useCourseProgressStore = create<CourseProgressState>((set) => ({
+  currentProgress: null,
+  updateProgress: (lessonData: Partial<LessonProgress>) => {
+    // Apply the type guard before the spread operation
+    if (!isValidLessonProgress(lessonData)) {
+      throw new InvalidProgressError(
+        'Update rejected: lessonData is missing required fields (lessonId or progress).',
+      );
+    }
+    set((state) => ({
+      currentProgress: {
+        ...state.currentProgress,
+        ...lessonData,
+      },
+    }));
+  },
+}));


### PR DESCRIPTION
Closes #808

PR Description:
Added the `isValidLessonProgress` type guard to `courseProgressStore.ts` to validate `lessonData` updates before spreading them into the store state. Updates missing required fields (`lessonId` or `progress`) are now safely rejected with a custom `InvalidProgressError` to prevent state corruption. Added unit tests covering the type guard logic and store rejection scenarios.

Type of Change:
[x] Bug fix

Checklist:
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [x] Starknet best practices followed