### PR TITLE
fix(dashboard): stop RealTimeUpdater from recreating interval on data updates (#981)

### DIFF
--- a/src/components/dashboard/RealTimeUpdater.tsx
+++ b/src/components/dashboard/RealTimeUpdater.tsx
@@ -6,7 +6,7 @@
 
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { Wifi, WifiOff, Activity, Pause, Play, RefreshCw } from 'lucide-react';
 import { InteractiveChartLibrary } from '@/components/visualization/InteractiveChartLibrary';
 import { useDataVisualization } from '@/hooks/useDataVisualization';
@@ -84,18 +84,26 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
       websocketUrl,
     });
 
+    const dataRef = useRef(data);
+    dataRef.current = data;
+    const addDataPointRef = useRef(addDataPoint);
+    addDataPointRef.current = addDataPoint;
+    const updateDataRef = useRef(updateData);
+    updateDataRef.current = updateData;
+
     useEffect(() => {
       if (!simulationEnabled || isPaused) return;
 
       const timer = setInterval(() => {
         const timeLabel = new Date().toLocaleTimeString(language);
         const value = Math.floor(Math.random() * 100);
-        addDataPoint(0, value, timeLabel);
+        addDataPointRef.current(0, value, timeLabel);
 
-        if (data && data.labels.length > maxDataPoints) {
-          updateData({
-            labels: data.labels.slice(-maxDataPoints),
-            datasets: data.datasets.map((dataset) => ({
+        const currentData = dataRef.current;
+        if (currentData && currentData.labels.length > maxDataPoints) {
+          updateDataRef.current({
+            labels: currentData.labels.slice(-maxDataPoints),
+            datasets: currentData.datasets.map((dataset) => ({
               ...dataset,
               data: dataset.data.slice(-maxDataPoints),
             })),
@@ -105,14 +113,11 @@ export const RealTimeUpdater = React.memo<RealTimeUpdaterProps>(
 
       return () => clearInterval(timer);
     }, [
-      addDataPoint,
-      data,
       interval,
       isPaused,
       language,
       maxDataPoints,
       simulationEnabled,
-      updateData,
     ]);
 
     const stats = calculateStats();

--- a/src/components/dashboard/__tests__/RealTimeUpdater.test.tsx
+++ b/src/components/dashboard/__tests__/RealTimeUpdater.test.tsx
@@ -138,4 +138,19 @@ describe('RealTimeUpdater', () => {
     // Just verify no errors were thrown; component is still mounted
     expect(screen.getByText(/simulating/i)).toBeInTheDocument();
   });
+
+  it('does not recreate interval on data updates (Issue #981)', async () => {
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+    render(<RealTimeUpdater updateInterval={1000} />);
+
+    const initialCalls = setIntervalSpy.mock.calls.length;
+
+    // Advance through 3 update ticks
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+    });
+
+    // setInterval should still have the same call count, not torn down and recreated per point
+    expect(setIntervalSpy.mock.calls.length).toBe(initialCalls);
+  });
 });


### PR DESCRIPTION
## Description

Resolves #981.

In `src/components/dashboard/RealTimeUpdater.tsx`, the simulation `useEffect` previously included `data`, `addDataPoint`, and `updateData` in its dependency array. Because `data` updates on every added data point (and the callback references were volatile across renders), the `setInterval` timer was torn down (`clearInterval`) and recreated on every single data tick. This defeated the fixed interval setting and caused timer drift.

## Changes Made

- **Refactored `RealTimeUpdater.tsx`**:
  - Wrapped `data`, `addDataPoint`, and `updateData` in React `useRef` hooks (`dataRef`, `addDataPointRef`, `updateDataRef`).
  - Updated the `setInterval` callback to access current values via `.current`.
  - Removed `data`, `addDataPoint`, and `updateData` from the `useEffect` dependency array so the interval remains stable throughout data streaming.
- **Added Unit Test**:
  - Added a test case in `src/components/dashboard/__tests__/RealTimeUpdater.test.tsx` verifying that `setInterval` call count remains stable across multiple simulated data point ticks.

## Verification

- ✅ Unit Tests: `npx vitest run src/components/dashboard/__tests__/RealTimeUpdater.test.tsx` (10/10 passed)
- ✅ Type Check: `npx tsc --noEmit` (0 errors)
- ✅ Linting: `pnpm run lint` (0 warnings, 0 errors)

Closes #981