### PR TITLE
fix: set metadataBase in root layout for correct OG/canonical URL resolution

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'https://teachlink.app'),
   title: 'TeachLink - Offline Learning Platform',
   description: 'Learn anywhere, anytime with offline capabilities',
   manifest: '/manifest.json',


### PR DESCRIPTION
## Summary

Set `metadataBase` in the root layout (`src/app/layout.tsx`) so that relative `openGraph.images` and `alternates.canonical` URLs from child pages resolve correctly against the configured site URL instead of defaulting to localhost.

## Changes

- Added `metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'https://teachlink.app')` as the first property in the root layout's metadata export

This ensures all relative metadata URLs (OG images, canonical links) resolve against the production URL. The env var fallback matches the existing pattern used across the codebase (`sitemap.ts`, `email-verification.ts`, etc.).

## Verification

- TypeScript typecheck passes with no errors
- `metadataBase` placement follows Next.js conventions

Closes #956