### PR TITLE
fix: hide quiz navigation after completion

### DIFF
--- a/src/components/quizzes/QuizContainer.tsx
+++ b/src/components/quizzes/QuizContainer.tsx
@@ -58,17 +58,21 @@ const QuizContainer = React.memo(({ quiz }: QuizContainerProps) => {
         />
       ) : null}
 
-      <QuestionCard question={currentQuestion} quizState={quizState} />
+      {!isCompleted && (
+        <>
+          <QuestionCard question={currentQuestion} quizState={quizState} />
 
-      <QuizNavigation
-        onPrevious={handleGoPrevious}
-        onNext={handleGoNext}
-        onComplete={handleComplete}
-        canGoPrevious={quizState.canGoPrevious}
-        canGoNext={quizState.canGoNext}
-        isLastQuestion={currentQuestionIndex === totalQuestions - 1}
-        isCompleted={isCompleted}
-      />
+          <QuizNavigation
+            onPrevious={handleGoPrevious}
+            onNext={handleGoNext}
+            onComplete={handleComplete}
+            canGoPrevious={quizState.canGoPrevious}
+            canGoNext={quizState.canGoNext}
+            isLastQuestion={currentQuestionIndex === totalQuestions - 1}
+            isCompleted={isCompleted}
+          />
+        </>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary

This PR fixes the quiz completion flow by hiding the active question and navigation controls once a quiz has been completed.

## Changes

- Render `QuestionCard` only when `!isCompleted`
- Render `QuizNavigation` only when `!isCompleted`
- Ensure only the `QuizCompletionCard` is displayed after the user finishes the quiz

## Problem

Previously, after completing a quiz, the completion card was displayed while the active question and Previous/Next navigation remained visible. This allowed users to continue interacting with the quiz even though it had already been completed.

## Solution

Gate the question content and navigation behind `!isCompleted` so that only the completion view is rendered after the quiz is finished.

## Testing

- Verified the quiz displays questions and navigation during the quiz.
- Verified that after the final submission, only the `QuizCompletionCard` is shown.
- Verified that the question card and navigation controls are no longer rendered after completion.

Closes #951