### PR TITLE
refactor(worker): Terminate the SMS cluster worker infinite setTimeout loop and gate demo seeding

### DIFF
--- a/src/__tests__/sms-cluster-worker.test.ts
+++ b/src/__tests__/sms-cluster-worker.test.ts
@@ -1,0 +1,33 @@
+import {
+  startSMSClusterWorker,
+  stopSMSClusterWorker,
+  seedDemoSMSQueue,
+  smsQueue,
+} from '../workers/sms-cluster-worker';
+
+describe('SMS Cluster Worker (Issue #918)', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    delete process.env.SEED_DEMO_SMS;
+    stopSMSClusterWorker();
+  });
+
+  it('does NOT seed demo queue in production or default test env', () => {
+    process.env.NODE_ENV = 'production';
+    seedDemoSMSQueue();
+    expect(smsQueue.length).toBe(0);
+  });
+
+  it('seeds demo queue when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development';
+    seedDemoSMSQueue();
+    expect(smsQueue.length).toBe(50);
+  });
+
+  it('can be started and stopped cleanly without leaving active timers', () => {
+    startSMSClusterWorker();
+    expect(() => stopSMSClusterWorker()).not.toThrow();
+  });
+});

--- a/src/workers/sms-cluster-worker.ts
+++ b/src/workers/sms-cluster-worker.ts
@@ -1,10 +1,8 @@
 import cluster from 'cluster';
 import os from 'os';
-import { sendSMS } from '../utils/notificationUtils'; // Assuming we have this or we'll mock it
 import { createLogger } from '../lib/logging';
 
 const logger = createLogger('sms-cluster-worker');
-
 const numCPUs = os.cpus().length;
 
 // Mock Queue implementation
@@ -24,41 +22,59 @@ class SMSQueue {
   }
 }
 
-const smsQueue = new SMSQueue();
+export const smsQueue = new SMSQueue();
 
-// Seed queue for demonstration
-for (let i = 0; i < 50; i++) {
-  smsQueue.enqueue(`+155512345${i.toString().padStart(2, '0')}`, `Test message ${i}`);
-}
+// Seed queue for demonstration only when explicitly enabled
+export const seedDemoSMSQueue = () => {
+  if (process.env.NODE_ENV === 'development' || process.env.SEED_DEMO_SMS === 'true') {
+    for (let i = 0; i < 50; i++) {
+      smsQueue.enqueue(`+155512345${i.toString().padStart(2, '0')}`, `Test message ${i}`);
+    }
+  }
+};
+
+let queueTimer: NodeJS.Timeout | null = null;
+let isRunning = false;
+
+export const stopSMSClusterWorker = () => {
+  isRunning = false;
+  if (queueTimer) {
+    clearTimeout(queueTimer);
+    queueTimer = null;
+  }
+  logger.info(`Worker ${process.pid} stopped SMS processing`);
+};
 
 export const startSMSClusterWorker = () => {
+  // Gate demo queue seeding behind environment check
+  seedDemoSMSQueue();
+
   if (cluster.isPrimary) {
     logger.info(`Primary ${process.pid} is running`);
     logger.info(`Setting up cluster with ${numCPUs} workers for SMS processing...`);
 
-    // Fork workers.
     for (let i = 0; i < numCPUs; i++) {
       cluster.fork();
     }
 
     cluster.on('exit', (worker, code, signal) => {
       logger.warn(`Worker ${worker.process.pid} died with code: ${code}, and signal: ${signal}`);
-      logger.info('Starting a new worker...');
-      cluster.fork(); // Auto-heal workers
+      if (isRunning) {
+        logger.info('Starting a new worker...');
+        cluster.fork(); // Auto-heal workers only if active
+      }
     });
   } else {
-    // Workers can share any TCP connection
-    // In this case it is an HTTP server or a message queue listener
     logger.info(`Worker ${process.pid} started for SMS processing`);
+    isRunning = true;
 
     const processQueue = async () => {
-      // Basic mock of polling a queue
+      if (!isRunning) return;
+
       const messageJob = smsQueue.dequeue();
       if (messageJob) {
         try {
           logger.debug(`[Worker ${process.pid}] Processing SMS for ${messageJob.to}...`);
-          // Note: In a real app we'd use sendSMS(messageJob.to, messageJob.message)
-          // For now we just mock the delay
           await new Promise((resolve) => setTimeout(resolve, Math.random() * 500 + 100));
           logger.info(`[Worker ${process.pid}] Successfully sent SMS to ${messageJob.to}`);
         } catch (error) {
@@ -66,15 +82,14 @@ export const startSMSClusterWorker = () => {
         }
       }
 
-      // Continue polling with a small delay to prevent tight loop
-      setTimeout(processQueue, 1000);
+      if (isRunning) {
+        queueTimer = setTimeout(processQueue, 1000);
+        if (queueTimer && typeof queueTimer === 'object' && 'unref' in queueTimer) {
+          queueTimer.unref();
+        }
+      }
     };
 
     processQueue();
   }
 };
-
-// In a real entrypoint file, you'd call this:
-// if (require.main === module) {
-//   startSMSClusterWorker();
-// }


### PR DESCRIPTION
Closes #918

## Summary of Changes
- Gated demo SMS queue seeding behind environment flags (`process.env.NODE_ENV === 'development'` or `process.env.SEED_DEMO_SMS === 'true'`) to prevent unconditional demo data injection on module import.
- Added `stopSMSClusterWorker()` lifecycle method with clearable timer and `isRunning` flag.
- Called `.unref()` on the polling timer in Node.js environment to prevent blocking process exit.
- Added unit tests in `src/__tests__/sms-cluster-worker.test.ts`.

## Technical Requirements Checklist
- [x] Clearable timer and shutdown control (`stopSMSClusterWorker`).
- [x] Timer `.unref()` to avoid blocking process exit.
- [x] Gate demo queue seeding behind explicit development environment check.
