### PR TITLE
feat: add per-segment error, loading, and not-found for data-driven r…

### DIFF
--- a/src/app/certificates/error.tsx
+++ b/src/app/certificates/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('CertificatesError');
+
+interface CertificatesErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function CertificatesError({ error, reset }: CertificatesErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('certificates/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Certificates page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load certificates"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/certificates/loading.tsx
+++ b/src/app/certificates/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function CertificatesLoading() {
+  return <ServerlessPageSkeleton variant="generic" label="Loading certificates" />;
+}

--- a/src/app/courses/[courseId]/error.tsx
+++ b/src/app/courses/[courseId]/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('CourseDetailError');
+
+interface CourseErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function CourseDetailError({ error, reset }: CourseErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('courses/[courseId]/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Course detail page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load course"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/courses/[courseId]/loading.tsx
+++ b/src/app/courses/[courseId]/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function CourseDetailLoading() {
+  return <ServerlessPageSkeleton variant="courses" label="Loading course details" />;
+}

--- a/src/app/courses/[courseId]/not-found.tsx
+++ b/src/app/courses/[courseId]/not-found.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { BookOpen, ArrowLeft, Home } from 'lucide-react';
+
+export default function CourseNotFound() {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 px-6 py-20 text-white">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-center gap-8 rounded-3xl border border-white/10 bg-white/10 p-10 text-center shadow-2xl backdrop-blur-xl">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-cyan-500/20 text-cyan-300">
+          <BookOpen className="h-8 w-8" aria-hidden="true" />
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-300">
+            404 error
+          </p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">Course not found</h1>
+          <p className="mx-auto max-w-2xl text-lg text-slate-300">
+            This course doesn&apos;t exist or may have been removed. Browse all available courses or
+            head back to the previous screen.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/courses"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-5 py-3 font-medium text-slate-950 transition hover:bg-cyan-400"
+          >
+            <BookOpen className="h-4 w-4" aria-hidden="true" />
+            Browse courses
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-3 font-medium text-white transition hover:bg-white/20"
+          >
+            <Home className="h-4 w-4" aria-hidden="true" />
+            Go home
+          </Link>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-3 font-medium text-white transition hover:bg-white/20"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Go back
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/leaderboard/error.tsx
+++ b/src/app/leaderboard/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('LeaderboardError');
+
+interface LeaderboardErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function LeaderboardError({ error, reset }: LeaderboardErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('leaderboard/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Leaderboard page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load leaderboard"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/leaderboard/loading.tsx
+++ b/src/app/leaderboard/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function LeaderboardLoading() {
+  return <ServerlessPageSkeleton variant="generic" label="Loading leaderboard" />;
+}

--- a/src/app/messages/error.tsx
+++ b/src/app/messages/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('MessagesError');
+
+interface MessagesErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function MessagesError({ error, reset }: MessagesErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('messages/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Messages page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load messages"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/messages/loading.tsx
+++ b/src/app/messages/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function MessagesLoading() {
+  return <ServerlessPageSkeleton variant="generic" label="Loading messages" />;
+}

--- a/src/app/study-groups/error.tsx
+++ b/src/app/study-groups/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('StudyGroupsError');
+
+interface StudyGroupsErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function StudyGroupsError({ error, reset }: StudyGroupsErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('study-groups/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Study groups page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load study groups"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/study-groups/loading.tsx
+++ b/src/app/study-groups/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function StudyGroupsLoading() {
+  return <ServerlessPageSkeleton variant="generic" label="Loading study groups" />;
+}

--- a/src/app/topics/[slug]/error.tsx
+++ b/src/app/topics/[slug]/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { UserFriendlyErrorDisplay } from '@/components/errors/UserFriendlyErrorDisplay';
+import { errorReportingService } from '@/services/errorReporting';
+import { createLogger } from '@/lib/logging';
+
+const logger = createLogger('TopicError');
+
+interface TopicErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function TopicError({ error, reset }: TopicErrorProps) {
+  useEffect(() => {
+    errorReportingService.addBreadcrumb('topics/[slug]/error.tsx', {
+      errorMessage: error.message,
+      digest: error.digest,
+    });
+    errorReportingService.reportError(error, {
+      errorInfo: { componentStack: '' },
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
+    logger.error('Topic page error', { error });
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center p-4">
+      <UserFriendlyErrorDisplay
+        error={error}
+        title="Unable to load topic"
+        onRetry={reset}
+        showDetails={process.env.NODE_ENV === 'development'}
+        severity="error"
+      />
+    </div>
+  );
+}

--- a/src/app/topics/[slug]/loading.tsx
+++ b/src/app/topics/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ServerlessPageSkeleton } from '@/components/ui/ServerlessSkeleton';
+
+export default function TopicLoading() {
+  return <ServerlessPageSkeleton variant="search" label="Loading topic feed" />;
+}

--- a/src/app/topics/[slug]/not-found.tsx
+++ b/src/app/topics/[slug]/not-found.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Hash, ArrowLeft, Home } from 'lucide-react';
+
+export default function TopicNotFound() {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 px-6 py-20 text-white">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-center gap-8 rounded-3xl border border-white/10 bg-white/10 p-10 text-center shadow-2xl backdrop-blur-xl">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-cyan-500/20 text-cyan-300">
+          <Hash className="h-8 w-8" aria-hidden="true" />
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-300">
+            404 error
+          </p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">Topic not found</h1>
+          <p className="mx-auto max-w-2xl text-lg text-slate-300">
+            This topic doesn&apos;t exist or may have been removed. Explore other topics or head
+            back to the previous screen.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/search"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-5 py-3 font-medium text-slate-950 transition hover:bg-cyan-400"
+          >
+            <Hash className="h-4 w-4" aria-hidden="true" />
+            Explore topics
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-3 font-medium text-white transition hover:bg-white/20"
+          >
+            <Home className="h-4 w-4" aria-hidden="true" />
+            Go home
+          </Link>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-3 font-medium text-white transition hover:bg-white/20"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Go back
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…outes

- Add error.tsx (with reset + error reporting) for courses/[courseId], topics/[slug], messages, study-groups, leaderboard, certificates
- Add loading.tsx (ServerlessPageSkeleton) for all six segments
- Add not-found.tsx for dynamic segments courses/[courseId] and topics/[slug]

Fetch failures now surface a localized recovery UI instead of bubbling to the global error page. Navigation shows a skeleton while data loads.

## Description

Brief description of changes

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed


closes #945
