### PR TITLE
Add global react-hot-toast Toaster to RootProviders

### DIFF
--- a/src/providers/RootProviders.tsx
+++ b/src/providers/RootProviders.tsx
@@ -22,6 +22,7 @@ import { FeatureFlagProvider } from '@/components/shared/FeatureFlagProvider';
 import { ToastProvider } from '@/context/ToastContext';
 import { Loading } from '@/components/ui/Loading';
 import i18n from '@/lib/i18n/config';
+import { Toaster } from 'react-hot-toast';
 
 // Lazy load heavy/non-critical providers/components to improve initial render time
 const OfflineModeProvider = dynamic(
@@ -107,6 +108,7 @@ export function RootProviders({
                               <Suspense fallback={<Loading />}>{children}</Suspense>
                             </ErrorBoundary>
                             <CookieConsentBanner />
+                            <Toaster />
                           </ToastProvider>
                         </OfflineModeProvider>
                       </PerformanceMonitoringProvider>


### PR DESCRIPTION
  Here are the actions taken:

  1. Created and switched to a new branch: fix-global-toast-provider.
  2. Imported Toaster from react-hot-toast into src/providers/RootProviders.
  tsx.
  3. Mounted the <Toaster /> within the context providers tree.
  4. Committed these changes.

  Now, all components, including ShareModal, should successfully display
  feedback toasts across every page, and the appropriate aria-live regions
  will be globally available for screen readers. Let me know if you would
  also like to track down and remove the duplicate Toaster instances on those
  ad hoc pages (admin/cms, StudyGroups, dashboards).

closes #963 