### PR TITLE
feat: Add polls table migration and clean up API route

### DIFF
--- a/infrastructure/migrations/003_create_polls_table.sql
+++ b/infrastructure/migrations/003_create_polls_table.sql
@@ -1,0 +1,20 @@
+-- Create polls table for storing user-created polls
+-- This table stores polls that can be created via command palette and shared in real-time
+
+CREATE TABLE IF NOT EXISTS polls (
+  id VARCHAR(255) PRIMARY KEY,
+  question TEXT NOT NULL,
+  options JSONB NOT NULL,
+  course_id VARCHAR(255),
+  created_by VARCHAR(255),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create index on course_id for fast lookups
+CREATE INDEX IF NOT EXISTS idx_polls_course_id ON polls(course_id);
+
+-- Create index on created_at for sorting
+CREATE INDEX IF NOT EXISTS idx_polls_created_at ON polls(created_at DESC);
+
+-- Add comment to table
+COMMENT ON TABLE polls IS 'Stores polls created by users via command palette';

--- a/src/app/api/polls/route.ts
+++ b/src/app/api/polls/route.ts
@@ -30,18 +30,6 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { id, question, options, course_id, created_by } = body;
 
-    // Create table if it doesn't exist
-    await query(
-      'CREATE TABLE IF NOT EXISTS polls (' +
-        'id VARCHAR(255) PRIMARY KEY, ' +
-        'question TEXT NOT NULL, ' +
-        'options JSONB NOT NULL, ' +
-        'course_id VARCHAR(255), ' +
-        'created_by VARCHAR(255), ' +
-        'created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP' +
-        ')',
-    );
-
     const result = await query(
       'INSERT INTO polls (id, question, options, course_id, created_by) ' +
         'VALUES ($1, $2, $3, $4, $5) ' +


### PR DESCRIPTION
## Summary
- Create 003_create_polls_table.sql migration for polls table
- Remove table creation logic from polls API route (now handled by migration)
- Addresses #768: CommandPalette poll creation backend integration

## Changes
- Added infrastructure/migrations/003_create_polls_table.sql with proper schema and indexes
- Cleaned up src/app/api/polls/route.ts by removing inline table creation

## Background
The poll backend integration was already implemented in a previous commit. This PR improves it by:
1. Creating a proper database migration file following the project's migration pattern
2. Removing runtime table creation logic from the API route (best practice)

## Acceptance Criteria
- ✅ Creating a poll via command palette persists to database
- ✅ Poll appears for other connected participants via WebSocket
- ✅ No TODO comment remains in CommandPalette.tsx

Closes #768 