### PR TITLE
fix(visualizationUtils): avoid Math.min/max spread over large arrays

### DIFF
--- a/src/utils/visualizationUtils.ts
+++ b/src/utils/visualizationUtils.ts
@@ -181,10 +181,10 @@ export const aggregateByTimePeriod = (
         aggregatedValue = values.length;
         break;
       case 'min':
-        aggregatedValue = Math.min(...values);
+        aggregatedValue = values.reduce((a, b) => (b < a ? b : a), values[0]);
         break;
       case 'max':
-        aggregatedValue = Math.max(...values);
+        aggregatedValue = values.reduce((a, b) => (b > a ? b : a), values[0]);
         break;
     }
 
@@ -214,8 +214,12 @@ export const calculateMovingAverage = (data: number[], windowSize: number): numb
  * Normalize data to 0-100 scale
  */
 export const normalizeData = (data: number[]): number[] => {
-  const min = Math.min(...data);
-  const max = Math.max(...data);
+  let min = Infinity;
+  let max = -Infinity;
+  for (const val of data) {
+    if (val < min) min = val;
+    if (val > max) max = val;
+  }
   const range = max - min;
 
   if (range === 0) return data.map(() => 50);
@@ -327,8 +331,8 @@ export const calculateStatistics = (
     mean,
     median,
     mode,
-    min: Math.min(...data),
-    max: Math.max(...data),
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
     stdDev,
   };
 };


### PR DESCRIPTION
## Summary

Replaces `Math.min(...values)` / `Math.max(...values)` spread syntax in `visualizationUtils.ts` with reduce/loop-based alternatives to avoid `Maximum call stack size exceeded` errors on large arrays.

## Changes

### `aggregateByTimePeriod` (lines 183-188)
Replaced spread with `Array.reduce` for min/max aggregation cases.

### `normalizeData` (lines 217-218)
Replaced two separate spread calls with a single O(n) for-loop pass computing both min and max simultaneously.

### `calculateStatistics` (lines 330-331)
Since the data is already sorted on line 309 (`const sorted = [...data].sort((a, b) => a - b)`), replaced spread with `sorted[0]` and `sorted[sorted.length - 1]`.

## Testing
- All 26 existing tests pass.
- No functional changes — outputs remain identical.

Closes #922