### PR TITLE
fix(ai): guard against setState after unmount in PersonalizedRecommendations

### DIFF
--- a/src/components/ai/PersonalizedRecommendations.tsx
+++ b/src/components/ai/PersonalizedRecommendations.tsx
@@ -30,11 +30,21 @@ export default function PersonalizedRecommendations() {
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     apiClient
       .get<{ items: Recommendation[] }>('/api/ai/recommendations')
-      .then((r) => setItems(r.items))
-      .catch(() => setError(true))
-      .finally(() => setLoading(false));
+      .then((r) => {
+        if (!cancelled) setItems(r.items);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (


### PR DESCRIPTION



## Description

Add a cancelled flag inside the mount fetch effect, matching the existing pattern in SmartNotifications, so that setItems/setError/ setLoading are not called after the component unmounts before the request resolves.


## Related Issue

Closes #1042

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
