### PR TITLE
Add ExpirationPlugin to static-js and static-css service worker caches

### DIFF
--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -48,12 +48,28 @@ registerRoute(
 // Runtime caching for static assets
 registerRoute(
   ({ url }) => url.origin === self.location.origin && url.pathname.endsWith('.js'),
-  new StaleWhileRevalidate({ cacheName: 'static-js' }),
+  new StaleWhileRevalidate({
+    cacheName: 'static-js',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+      }),
+    ],
+  }),
 );
 
 registerRoute(
   ({ url }) => url.origin === self.location.origin && url.pathname.endsWith('.css'),
-  new StaleWhileRevalidate({ cacheName: 'static-css' }),
+  new StaleWhileRevalidate({
+    cacheName: 'static-css',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+      }),
+    ],
+  }),
 );
 
 // Runtime caching for images


### PR DESCRIPTION
## Summary

Adds `ExpirationPlugin` with `maxEntries: 50` and `maxAgeSeconds: 30 days` to both the `static-js` and `static-css` `StaleWhileRevalidate` runtime caches in `src/serviceWorker.ts`.

## Problem

In `src/serviceWorker.ts` the `.js` and `.css` runtime routes used `StaleWhileRevalidate` with cache names `static-js`/`static-css` and no `ExpirationPlugin`, unlike images, fonts, and API routes which set `maxEntries`/`maxAgeSeconds`. Since Next.js content-hashes chunk filenames, every deployment adds entries that are never evicted — these caches grow without bound.

## Changes

- **`static-js` cache** — Added `ExpirationPlugin` with `maxEntries: 50`, `maxAgeSeconds: 30 * 24 * 60 * 60`
- **`static-css` cache** — Added `ExpirationPlugin` with `maxEntries: 50`, `maxAgeSeconds: 30 * 24 * 60 * 60`

## Testing

- Verified the service worker compiles without errors
- Existing caching patterns for images, fonts, and API routes were used as reference to ensure consistency

Closes #925