### PR TITLE
Surface toast feedback when oversized attachments are rejected in the messaging composer

### DIFF
--- a/src/app/hooks/useMessaging.tsx
+++ b/src/app/hooks/useMessaging.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
+import toast from 'react-hot-toast';
 import { useMessagingStore } from '@/app/store/messagingStore';
 import type { Attachment } from '@/app/store/messagingStore';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -108,6 +109,13 @@ export function useMessaging() {
     (files: FileList) => {
       const fileArray = Array.from(files);
       const maxSize = 10 * 1024 * 1024; // 10MB limit
+      const rejectedFiles = fileArray.filter((file) => file.size > maxSize);
+      if (rejectedFiles.length > 0) {
+        const names = rejectedFiles.map((f) => f.name).join(', ');
+        toast.error(
+          `Skipped ${rejectedFiles.length} file(s): ${names}. Max file size is 10MB.`,
+        );
+      }
       const validFiles = fileArray.filter((file) => file.size <= maxSize);
       setSelectedFiles([...selectedFiles, ...validFiles]);
     },


### PR DESCRIPTION
## Summary

Adds a toast error notification when users select files larger than the 10MB limit in the messaging composer, so they get clear feedback instead of the file silently disappearing.

## Problem

In `src/app/hooks/useMessaging.tsx`, `handleFileSelect` filters files with `file.size <= maxSize` (10MB) but gives no feedback when a file is rejected — it simply disappears from the selection. Users attaching a large file get no error and may assume it was attached.

## Changes

- **`src/app/hooks/useMessaging.tsx`** — Added `toast.error()` call in `handleFileSelect` that lists the rejected file name(s) and the 10MB size limit
- Added `import toast from 'react-hot-toast'` (already a dependency in the project)

## Testing

- Selected files >10MB and verified a toast error appears with the file names and size limit
- Ensured valid files (<10MB) still get attached without any spurious toast

Closes #933