### PR TITLE
fix(quizzes): wire up review mode in QuizContainer

### DIFF
--- a/src/components/quizzes/QuizContainer.tsx
+++ b/src/components/quizzes/QuizContainer.tsx
@@ -30,7 +30,10 @@ const QuizContainer = React.memo(({ quiz }: QuizContainerProps) => {
   const totalQuestions = quiz.questions.length;
 
   const handleRestart = useCallback(() => actions.restart(), [actions]);
-  const handleReviewAnswers = useCallback(() => actions.setCurrentQuestionIndex(0), [actions]);
+  const handleReviewAnswers = useCallback(() => {
+    actions.enterReviewMode();
+    actions.setCurrentQuestionIndex(0);
+  }, [actions]);
   const handleGoPrevious = useCallback(() => actions.goPrevious(), [actions]);
   const handleGoNext = useCallback(() => actions.goNext(), [actions]);
   const handleComplete = useCallback(() => actions.complete(), [actions]);
@@ -49,7 +52,7 @@ const QuizContainer = React.memo(({ quiz }: QuizContainerProps) => {
         isReviewMode={isReviewMode}
       />
 
-      {isCompleted ? (
+      {isCompleted && !isReviewMode ? (
         <QuizCompletionCard
           score={score}
           maxScore={maxScore}
@@ -58,7 +61,7 @@ const QuizContainer = React.memo(({ quiz }: QuizContainerProps) => {
         />
       ) : null}
 
-      {!isCompleted && (
+      {(!isCompleted || isReviewMode) && (
         <>
           <QuestionCard question={currentQuestion} quizState={quizState} />
 


### PR DESCRIPTION
## Description

'Review Answers' called setCurrentQuestionIndex(0) but never actions.enterReviewMode(), so isCompleted stayed true and the QuestionCard/QuizNavigation block (gated on !isCompleted per #1038) stayed hidden - review mode was unreachable despite every question-type component already having isReviewMode-aware rendering.

- handleReviewAnswers now calls actions.enterReviewMode()
- QuizCompletionCard hides while isReviewMode is true
- QuestionCard/QuizNavigation render when !isCompleted OR isReviewMode



## Related Issue

Closes #1038 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
