### PR TITLE
fix(a11y): announce QuizHeader countdown timer to screen readers at t…

### DIFF
--- a/src/components/quizzes/QuizHeader.tsx
+++ b/src/components/quizzes/QuizHeader.tsx
@@ -1,5 +1,13 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { formatTime } from '@/utils/quizUtils';
+
+/**
+ * Time thresholds (in seconds) at which the timer announces to screen readers.
+ * Early thresholds are coarse; near the end we announce every second.
+ */
+const ANNOUNCEMENT_THRESHOLDS: readonly number[] = [
+  600, 300, 120, 60, 30, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+];
 
 interface QuizHeaderProps {
   title: string;
@@ -13,6 +21,22 @@ interface QuizHeaderProps {
   isReviewMode: boolean;
 }
 
+/**
+ * Build a human-friendly announcement string for a given number of seconds.
+ */
+function getTimeAnnouncement(seconds: number): string {
+  if (seconds <= 0) return 'Time is up!';
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (minutes > 0 && secs === 0) {
+    return `${minutes} minute${minutes !== 1 ? 's' : ''} remaining`;
+  }
+  if (minutes > 0) {
+    return `${minutes} minute${minutes !== 1 ? 's' : ''} and ${secs} second${secs !== 1 ? 's' : ''} remaining`;
+  }
+  return `${secs} second${secs !== 1 ? 's' : ''} remaining`;
+}
+
 export const QuizHeader: React.FC<QuizHeaderProps> = ({
   title,
   description,
@@ -24,6 +48,19 @@ export const QuizHeader: React.FC<QuizHeaderProps> = ({
   maxScore,
   isReviewMode,
 }) => {
+  /**
+   * Compute screen-reader announcement text only at predefined thresholds.
+   * Returns empty string when no announcement is needed, so the
+   * aria-live region's content stays stable between thresholds.
+   */
+  const srAnnouncement = useMemo<string>(() => {
+    if (typeof timeRemainingSeconds !== 'number' || isReviewMode) return '';
+    if (ANNOUNCEMENT_THRESHOLDS.includes(timeRemainingSeconds)) {
+      return getTimeAnnouncement(timeRemainingSeconds);
+    }
+    return '';
+  }, [timeRemainingSeconds, isReviewMode]);
+
   return (
     <>
       <div className="mb-6">
@@ -34,7 +71,11 @@ export const QuizHeader: React.FC<QuizHeaderProps> = ({
       <div className="mb-6 flex justify-between items-center gap-4">
         <div className="flex flex-col">
           {typeof timeRemainingSeconds === 'number' && !isReviewMode ? (
-            <div className="text-lg font-medium text-[#0F172A] dark:text-white">
+            <div
+              role="timer"
+              aria-label={`Time remaining: ${formatTime(timeRemainingSeconds)}`}
+              className="text-lg font-medium text-[#0F172A] dark:text-white"
+            >
               Time Remaining: {formatTime(timeRemainingSeconds)}
             </div>
           ) : null}
@@ -51,6 +92,19 @@ export const QuizHeader: React.FC<QuizHeaderProps> = ({
             Score: {score} / {maxScore}
           </div>
         </div>
+      </div>
+
+      {/*
+        Visually hidden live region that announces time remaining
+        only at predefined thresholds so the screen reader isn't
+        flooded with every-second tick announcements.
+      */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {srAnnouncement}
       </div>
     </>
   );


### PR DESCRIPTION
## Description

Improve the accessibility of the quiz countdown timer by exposing it to assistive technologies. The countdown is now announced through an accessible timer region, with updates communicated politely at meaningful thresholds instead of every second, ensuring blind and low-vision users receive timely notifications without excessive interruptions.

## Related Issue

Closes #950

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently (N/A)
- [x] Responsive design implemented
- [x] Starknet best practices followed (N/A)