### PR TITLE
Fix zero-width react-window list in InfiniteList fixed-height mode

### DIFF
--- a/src/components/InfiniteList.tsx
+++ b/src/components/InfiniteList.tsx
@@ -67,7 +67,11 @@ export function InfiniteList<T>({
       style={fixedHeight ? { height: fixedHeight } : undefined}
     >
       {fixedHeight ? (
-        listContent(fixedHeight, 0)
+        <AutoSizer disableHeight>
+          {({ width }: { width: number }) =>
+            listContent(fixedHeight, width) as React.ReactElement
+          }
+        </AutoSizer>
       ) : (
         <AutoSizer>
           {({ height, width }: { height: number; width: number }) =>


### PR DESCRIPTION
## Description
`InfiniteList` was calling `listContent(fixedHeight, 0)` in fixed-height mode, hardcoding `width={0}` and passed to react-window's `FixedSizeList`. Every row was laid out at zero width, making the list content effectively invisible whenever a caller supplied the `height` prop.

Fixed by wrapping the fixed-height branch in `AutoSizer` (with `disableHeight`, since height is already fixed via inline style on the container) to measure the actual container width and pass it to `listContent` instead of `0`. This mirrors the pattern already used in the dynamic-height branch below it.

## Related Issue
Closes #1032

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently
- [x] Responsive design implemented
- [ ] Starknet best practices followed