### PR TITLE
Lazy-load date-fns locales instead of importing all 12 at top level i…

### DIFF
--- a/src/hooks/useInternationalization.tsx
+++ b/src/hooks/useInternationalization.tsx
@@ -16,6 +16,7 @@ import {
   getCulturalPreferences,
   formatDate as formatDateUtil,
   formatRelativeTime,
+  preloadDateFnsLocale,
   formatNumber as formatNumberUtil,
   formatCurrency as formatCurrencyUtil,
   formatPercentage,
@@ -74,6 +75,10 @@ export function I18nProvider({
         void i18n.changeLanguage(language);
       });
     }
+  }, [language]);
+
+  useEffect(() => {
+    void preloadDateFnsLocale(language);
   }, [language]);
 
   // Load translations when language changes

--- a/src/utils/__tests__/i18nUtils.test.ts
+++ b/src/utils/__tests__/i18nUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('date-fns/locale', () => {
+  throw new Error('date-fns locale barrel should not be imported eagerly');
+});
+
+describe('i18nUtils locale loading', () => {
+  it('does not depend on the date-fns locale barrel export', async () => {
+    const { formatDate } = await import('../i18nUtils');
+
+    const date = new Date('2024-01-02T03:04:05.000Z');
+    const formatted = formatDate(date, 'es');
+
+    expect(typeof formatted).toBe('string');
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/i18nUtils.ts
+++ b/src/utils/i18nUtils.ts
@@ -5,26 +5,61 @@
 import type { LanguageCode, CulturalPreferences } from '@/locales/types';
 import { getLocaleConfig } from '@/locales/config';
 import { format, formatDistanceToNow, type Locale } from 'date-fns';
-import { enUS, es, fr, de, ar, he, ja, zhCN, ptBR, ru, it, ko } from 'date-fns/locale';
+import { enUS } from 'date-fns/locale/en-US';
 import { getNumberFormat } from './intlCache';
 import { createLogger } from '@/lib/logging';
+
 const logger = createLogger('i18nUtils');
 
-// Date-fns locale mapping
-const dateFnsLocales: Record<LanguageCode, Locale> = {
-  en: enUS,
-  es: es,
-  fr: fr,
-  de: de,
-  ar: ar,
-  he: he,
-  ja: ja,
-  zh: zhCN,
-  pt: ptBR,
-  ru: ru,
-  it: it,
-  ko: ko,
+const dateFnsLocaleLoaders: Record<LanguageCode, () => Promise<Locale>> = {
+  en: () => import('date-fns/locale/en-US').then((module) => module.enUS),
+  es: () => import('date-fns/locale/es').then((module) => module.es),
+  fr: () => import('date-fns/locale/fr').then((module) => module.fr),
+  de: () => import('date-fns/locale/de').then((module) => module.de),
+  ar: () => import('date-fns/locale/ar').then((module) => module.ar),
+  he: () => import('date-fns/locale/he').then((module) => module.he),
+  ja: () => import('date-fns/locale/ja').then((module) => module.ja),
+  zh: () => import('date-fns/locale/zh-CN').then((module) => module.zhCN),
+  pt: () => import('date-fns/locale/pt-BR').then((module) => module.ptBR),
+  ru: () => import('date-fns/locale/ru').then((module) => module.ru),
+  it: () => import('date-fns/locale/it').then((module) => module.it),
+  ko: () => import('date-fns/locale/ko').then((module) => module.ko),
 };
+
+const dateFnsLocaleCache: Partial<Record<LanguageCode, Locale>> = {
+  en: enUS,
+};
+
+const dateFnsLocalePromises: Partial<Record<LanguageCode, Promise<Locale>>> = {};
+
+export async function preloadDateFnsLocale(language: LanguageCode): Promise<Locale> {
+  if (dateFnsLocaleCache[language]) {
+    return dateFnsLocaleCache[language] as Locale;
+  }
+
+  if (!dateFnsLocalePromises[language]) {
+    dateFnsLocalePromises[language] = dateFnsLocaleLoaders[language]()
+      .then((locale) => {
+        dateFnsLocaleCache[language] = locale;
+        return locale;
+      })
+      .catch((error) => {
+        logger.warn('Failed to load date-fns locale', { language, error });
+        return dateFnsLocaleCache.en as Locale;
+      });
+  }
+
+  return dateFnsLocalePromises[language] as Promise<Locale>;
+}
+
+function getDateFnsLocale(language: LanguageCode): Locale {
+  if (dateFnsLocaleCache[language]) {
+    return dateFnsLocaleCache[language] as Locale;
+  }
+
+  void preloadDateFnsLocale(language);
+  return dateFnsLocaleCache.en as Locale;
+}
 
 /**
  * Get cultural preferences for a locale
@@ -82,7 +117,7 @@ export function formatDate(
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
 
   const config = getLocaleConfig(language);
-  const locale = dateFnsLocales[language] || dateFnsLocales.en;
+  const locale = getDateFnsLocale(language);
   const formatPattern = formatStr || config.dateFormat || 'PP';
 
   try {
@@ -99,7 +134,7 @@ export function formatDate(
 export function formatRelativeTime(date: Date | string | number, language: LanguageCode): string {
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
 
-  const locale = dateFnsLocales[language] || dateFnsLocales.en;
+  const locale = getDateFnsLocale(language);
 
   try {
     return formatDistanceToNow(dateObj, { addSuffix: true, locale });


### PR DESCRIPTION

## Description

Lazy-load date-fns locales instead of importing all 12 at top level in i18nUtils
## Related Issue

Closes #909 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed
