### PR TITLE
fix(#931): replace mojibake (corrupted UTF-8) strings in useStudyGrou…

### DIFF
--- a/src/app/hooks/useStudyGroups.tsx
+++ b/src/app/hooks/useStudyGroups.tsx
@@ -265,11 +265,11 @@ export function useStudyGroups(currentUser?: { id: string; name: string }): UseS
         const { addNotification } = useNotificationStore.getState();
         addNotification({
           type: 'success',
-          message: `Created group Ã¢â‚¬Å“${group.name}Ã¢â‚¬Â`,
+          message: `Created group "${group.name}"`,
           meta: { groupId: group.id },
         });
       } catch {}
-      toast.success(`Created group Ã¢â‚¬Å“${group.name}Ã¢â‚¬Â`);
+      toast.success(`Created group "${group.name}"`);
       return group;
     },
     [me.id, me.name, triggerSync],
@@ -326,7 +326,7 @@ export function useStudyGroups(currentUser?: { id: string; name: string }): UseS
           meta: { groupId },
         });
       } catch {}
-      toast('Left group', { icon: 'Ã°Å¸â€˜â€¹' });
+      toast('Left group', { icon: '👋' });
     },
     [me.id, triggerSync],
   );


### PR DESCRIPTION
…ps toast and notification messages

Fix three user-facing strings in useStudyGroups.tsx that showed garbled characters:

- toast.success: 'Created group "..."' - smart quotes were corrupted to 'Ã¢â‚¬Å“/Ã¢â‚¬Â'\n- addNotification toast: same quote corruption in message template\n- toast 'Left group': wave emoji icon corrupted from '👋' to 'Ã°Å¸â€˜â€¹'\n\nThese were caused by UTF-8 bytes being misinterpreted as Latin-1 (mojibake). Replaced with proper ASCII quotes and the Unicode emoji character.

## Description

Brief description of changes

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed


closes #931 

