### PR TITLE
Handle clipboard failures in SocialInteractions share button

### DIFF
--- a/src/components/social/SocialInteractions.tsx
+++ b/src/components/social/SocialInteractions.tsx
@@ -16,12 +16,19 @@ export default function SocialInteractions({ contentId, contentUrl }: SocialInte
   const [showComments, setShowComments] = useState(false);
   const [draft, setDraft] = useState('');
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
 
   const handleShare = async () => {
     const url = contentUrl ?? window.location.href;
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setCopyError(false);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), 2000);
+    }
   };
 
   const handleAddComment = async (e: React.FormEvent) => {
@@ -65,7 +72,9 @@ export default function SocialInteractions({ contentId, contentUrl }: SocialInte
           className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-green-500 transition-colors"
         >
           <Share2 className="w-5 h-5" />
-          <span>{copied ? 'Copied!' : 'Share'}</span>
+          <span>
+            {copied ? 'Copied!' : copyError ? 'Failed to copy' : 'Share'}
+          </span>
         </button>
       </div>
 


### PR DESCRIPTION
## Description
`navigator.clipboard.writeText` in `handleShare` (SocialInteractions.tsx, lines 20-25) was awaited without a try/catch. In an insecure context (non-HTTPS) or when clipboard permission is denied, the promise rejects unhandled and the "Copied!" confirmation never appears, leaving the user with no feedback that the copy failed.

Wrapped the clipboard write in try/catch and added a `copyError` state. On failure, the button now shows "Failed to copy" instead of silently doing nothing. Both the success and error messages auto-clear after 2 seconds.

## Related Issue
Closes #1041

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently
- [x] Responsive design implemented
- [ ] Starknet best practices followed