### PR TITLE
fix(signature): gate onChange emission behind requireAccept flag

### DIFF
--- a/src/components/assignments/SignatureCapture.tsx
+++ b/src/components/assignments/SignatureCapture.tsx
@@ -106,9 +106,11 @@ export const SignatureCapture = forwardRef<SignatureCaptureHandle, SignatureCapt
       if (!drawingRef.current) return;
       drawingRef.current = false;
       setHasStrokes(true);
-      const url = canvasRef.current?.toDataURL('image/png') ?? null;
-      onChange?.(url);
-    }, [onChange]);
+      if (!requireAccept) {
+        const url = canvasRef.current?.toDataURL('image/png') ?? null;
+        onChange?.(url);
+      }
+    }, [onChange, requireAccept]);
 
     const clear = useCallback(() => {
       const c = canvasRef.current;


### PR DESCRIPTION
## Description

The `end()` stroke handler in `SignatureCapture` was emitting `onChange(dataUrl)` on every stroke regardless of the `requireAccept` prop. This allowed parent components to receive and commit the signature before the user pressed the "Accept" button, bypassing the approval gate entirely.

## Fix

- The `end` callback now only calls `onChange` when `requireAccept` is `false` or `undefined`.
- When `requireAccept` is `true`, only the explicit "Accept" button click handler (`handleAccept`) emits the data URL.
- Added `requireAccept` to the `end` callback's dependency array for correctness.

## Testing

- With `requireAccept={true}`: signatures are only committed via the Accept button.
- With `requireAccept={false}` or omitted: signatures emit on every stroke as before (no breaking change for existing callers).

Closes #1040