### PR TITLE
perf(collaboration): update presence via awareness fields without socket tear down

### DIFF
--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useRef, useState } from 'react';
 import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
@@ -141,7 +140,16 @@ export function useCollaboration(roomId: string, user: CollaborationUser, websoc
       strokesRef.current = null;
       chatRef.current = null;
     };
-  }, [roomId, user.id, user.name, user.avatar, user.color, websocketEndpoint]);
+  }, [roomId, user.id, websocketEndpoint]);
+
+  useEffect(() => {
+    const provider = providerRef.current;
+    if (!provider) return;
+    provider.awareness.setLocalStateField('user', {
+      ...user,
+      isActive: true,
+    });
+  }, [user.name, user.avatar, user.color]);
 
   const updateText = (value: string) => {
     if (!yTextRef.current) {


### PR DESCRIPTION
## Description

The main `useEffect` in `useCollaboration` was depending on `user.name`, `user.avatar`, and `user.color`. Because these user profile properties trigger frequent reference updates, the entire WebSocket connection (`Y.Doc` + `WebsocketProvider`) was being disconnected and rebuilt constantly, wiping out local awareness and forcing a full resync on every profile change.

## Fix

- Removed `user.name`, `user.avatar`, and `user.color` from the main connection `useEffect` dependency array. The main effect now only depends on the core connection keys: `roomId`, `user.id`, and `websocketEndpoint`.
- The provider instance was already stored in `providerRef` (a `useRef`), which persists across renders — no additional ref was needed.
- Added a second, dedicated `useEffect` that watches `user.name`, `user.avatar`, and `user.color`. When these change, it updates presence dynamically via `provider.awareness.setLocalStateField('user', { ... })` without rebuilding the provider or tearing down the WebSocket connection.
- Removed the `// @ts-nocheck` pragma since the code now has full type safety.

## Testing

- `npx tsc --noEmit` passes with zero errors.
- Profile changes now update awareness fields in-place rather than triggering a full reconnect.
- Existing collaboration features (editor sync, cursors, chat, whiteboard) continue to work unchanged.

Closes #908