### PR TITLE
Feat: Use next/image for course thumbnails in SearchResults

### DIFF
--- a/src/app/components/search/SearchResults.tsx
+++ b/src/app/components/search/SearchResults.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Star, Clock, User, ArrowRight, SearchX } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
 import clsx from 'clsx';
 import { EmptyState } from '@/components';
@@ -119,14 +120,14 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
           >
             {/* Course Image */}
             <div className="relative h-40 bg-linear-to-br from-gray-200 dark:from-gray-700 to-gray-300 dark:to-gray-800 overflow-hidden">
-              <picture>
-                <img
-                  src={course.image}
-                  alt={course.title}
-                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                  loading="lazy"
-                />
-              </picture>
+              <Image
+                src={course.image}
+                alt={course.title}
+                fill
+                sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                className="object-cover group-hover:scale-105 transition-transform duration-300"
+                loading="lazy"
+              />
               {course.tag && (
                 <span className="absolute top-3 right-3 bg-yellow-400 dark:bg-yellow-500 text-gray-900 dark:text-gray-800 px-3 py-1 rounded-full text-xs font-bold">
                   {course.tag}


### PR DESCRIPTION
## Summary

Replaced the raw `<img>` tag for course thumbnails in `SearchResults.tsx` with `next/image` (`fill` + responsive `sizes`), matching the pattern already used in `VirtualizedCourseList.tsx`. This enables automatic resizing, format negotiation (AVIF/WebP), and CDN optimization instead of shipping full-size external images — improving LCP on the search results page.

No `next.config.ts` changes were needed; the relevant image hosts are already whitelisted under `images.remotePatterns`.

Fixes #940
