### PR TITLE
feat: Generate per-course metadata in courses/[courseId] instead of s…

### DIFF
--- a/src/app/courses/[courseId]/page.tsx
+++ b/src/app/courses/[courseId]/page.tsx
@@ -21,17 +21,30 @@ export async function generateMetadata({ params }: CoursePageProps): Promise<Met
   return {
     title: `${course.title} | TeachLink`,
     description: course.description,
+    alternates: {
+      canonical: `/courses/${courseId}`,
+    },
     openGraph: {
       title: `${course.title} | TeachLink`,
       description: course.description,
       type: 'website',
       siteName: 'TeachLink',
+      url: `/courses/${courseId}`,
+      images: course.thumbnailUrl
+        ? [
+            {
+              url: course.thumbnailUrl,
+              alt: course.title,
+            },
+          ]
+        : undefined,
     },
     twitter: {
       card: 'summary_large_image',
       site: '@teachlink',
       title: `${course.title} | TeachLink`,
       description: course.description,
+      images: course.thumbnailUrl ? [course.thumbnailUrl] : undefined,
     },
   };
 }


### PR DESCRIPTION
Generate per-course metadata in courses/[courseId]
Summary

Fixes #926

generateMetadata in courses/[courseId]/page.tsx was missing a per-course Open Graph image and canonical URL (title/description were already dynamic from an earlier commit).
Adds alternates.canonical and openGraph.url pointing to /courses/${courseId}, resolved against the existing metadataBase in src/app/layout.tsx.
Adds openGraph.images and twitter.images sourced from course.thumbnailUrl, omitted when a course has no thumbnail.
Changes
src/app/courses/[courseId]/page.tsx

   return {
     title: `${course.title} | TeachLink`,
     description: course.description,
+    alternates: {
+      canonical: `/courses/${courseId}`,
+    },
     openGraph: {
       title: `${course.title} | TeachLink`,
       description: course.description,
       type: 'website',
       siteName: 'TeachLink',
+      url: `/courses/${courseId}`,
+      images: course.thumbnailUrl
+        ? [{ url: course.thumbnailUrl, alt: course.title }]
+        : undefined,
     },
     twitter: {
       card: 'summary_large_image',
       site: '@teachlink',
       title: `${course.title} | TeachLink`,
       description: course.description,
+      images: course.thumbnailUrl ? [course.thumbnailUrl] : undefined,
     },
   };
Test plan
 npm install then npx tsc --noEmit (not run here — node_modules not installed in this environment)
 npm run dev, visit /courses/<id> for a course with and without thumbnailUrl, inspect <head> for og:image, og:url, and <link rel="canonical">
 Confirm Course Not Found case still returns the generic fallback metadata