### PR TITLE
feat(dashboard): drive learning progress from fetched data

### DIFF
--- a/src/app/api/user/learning-progress/__tests__/route.test.ts
+++ b/src/app/api/user/learning-progress/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { withRateLimit } from '@/lib/ratelimit';
+
+vi.mock('@/lib/ratelimit', () => ({
+  withRateLimit: vi.fn(() => ({
+    addHeaders: (response: Response) => response,
+    rateLimitResponse: null,
+  })),
+}));
+
+vi.mock('@/../infra/edge-config', () => ({
+  edgeLog: vi.fn(),
+}));
+
+describe('/api/user/learning-progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns learning progress for in-progress courses', async () => {
+    const request = new Request('http://localhost/api/user/learning-progress');
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data.length).toBeGreaterThan(0);
+
+    const item = json.data[0];
+    expect(item).toHaveProperty('courseId');
+    expect(item).toHaveProperty('title');
+    expect(item.progress).toBeGreaterThan(0);
+    expect(item.progress).toBeLessThanOrEqual(100);
+    expect(item.timeRemaining).toBeDefined();
+    expect(item.totalLessons).toBeGreaterThanOrEqual(0);
+    expect(item.category).toBeDefined();
+  });
+
+  it('excludes courses with zero progress', async () => {
+    const request = new Request('http://localhost/api/user/learning-progress');
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(json.data.length).toBeGreaterThan(0);
+    for (const item of json.data) {
+      expect(item.progress).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns rate limited response when limit exceeded', async () => {
+    const rateLimitResponse = new Response('rate limited', { status: 429 });
+    vi.mocked(withRateLimit).mockReturnValueOnce({
+      addHeaders: (response: Response) => response,
+      rateLimitResponse,
+    });
+
+    const request = new Request('http://localhost/api/user/learning-progress');
+    const response = await GET(request);
+
+    expect(response.status).toBe(429);
+  });
+});

--- a/src/app/api/user/learning-progress/route.ts
+++ b/src/app/api/user/learning-progress/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import type { ApiResponse, LearningProgressItem } from '@/types/api';
+import { withRateLimit } from '@/lib/ratelimit';
+import { edgeLog } from '@/../infra/edge-config';
+import { getAllCourses } from '@/lib/course-config';
+
+export const runtime = 'edge';
+
+export async function GET(request: Request) {
+  edgeLog('info', '/api/user/learning-progress', 'GET request received');
+  const { addHeaders, rateLimitResponse } = withRateLimit(request, 'READ');
+  if (rateLimitResponse) {
+    return rateLimitResponse as NextResponse<ApiResponse<LearningProgressItem[]>>;
+  }
+
+  const items: LearningProgressItem[] = getAllCourses()
+    .filter((course) => course.progress > 0)
+    .map((course) => ({
+      courseId: course.id,
+      title: course.title,
+      progress: course.progress,
+      timeRemaining: (course.timeRemaining ?? course.duration).replace(/ remaining$/, ''),
+      totalLessons: course.totalLessons,
+      category: course.category,
+    }));
+
+  return addHeaders(
+    NextResponse.json({
+      success: true,
+      data: items,
+    }),
+  );
+}

--- a/src/app/components/dashboard/LearningProgressList.tsx
+++ b/src/app/components/dashboard/LearningProgressList.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React from 'react';
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+import { useInternationalization } from '@/hooks/useInternationalization';
+import { ListSkeleton } from '@/components/ui/LoadingSkeleton';
+
+const ACCENT_COLORS = ['blue', 'green', 'purple', 'amber', 'rose', 'teal'] as const;
+
+const ACCENT_BORDER = {
+  blue: 'border-blue-500',
+  green: 'border-green-500',
+  purple: 'border-purple-500',
+  amber: 'border-amber-500',
+  rose: 'border-rose-500',
+  teal: 'border-teal-500',
+} as const;
+
+const ACCENT_TEXT_HOVER = {
+  blue: 'group-hover:text-blue-600',
+  green: 'group-hover:text-green-600',
+  purple: 'group-hover:text-purple-600',
+  amber: 'group-hover:text-amber-600',
+  rose: 'group-hover:text-rose-600',
+  teal: 'group-hover:text-teal-600',
+} as const;
+
+const ACCENT_BAR = {
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+  purple: 'bg-purple-500',
+  amber: 'bg-amber-500',
+  rose: 'bg-rose-500',
+  teal: 'bg-teal-500',
+} as const;
+
+export const LearningProgressList: React.FC = () => {
+  const { items, isLoading, error, refetch } = useLearningProgress();
+  const { t } = useInternationalization();
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border dark:border-gray-800 p-8">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-8">
+        {t('dashboard.learningProgress')}
+      </h2>
+
+      {isLoading && <ListSkeleton count={3} />}
+
+      {!isLoading && error && (
+        <div role="alert">
+          <p className="text-sm text-red-600 dark:text-red-400">{t('errors.network')}</p>
+          <button
+            onClick={refetch}
+            className="mt-4 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+          >
+            {t('common.retry')}
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !error && items.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t('dashboard.noCoursesInProgress')}
+        </p>
+      )}
+
+      {!isLoading && !error && items.length > 0 && (
+        <div className="space-y-8">
+          {items.map((item, index) => {
+            const color = ACCENT_COLORS[index % ACCENT_COLORS.length];
+            return (
+              <div key={item.courseId} className={`border-s-4 ${ACCENT_BORDER[color]} ps-6 group`}>
+                <h3
+                  className={`text-lg font-bold text-gray-900 dark:text-white ${ACCENT_TEXT_HOVER[color]} transition-colors`}
+                >
+                  {item.title}
+                </h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  {t('dashboard.progressStatus', {
+                    percent: item.progress,
+                    remaining: item.timeRemaining,
+                  })}
+                </p>
+                <div className="mt-4 w-full bg-gray-100 dark:bg-gray-800 rounded-full h-3">
+                  <div
+                    className={`${ACCENT_BAR[color]} h-3 rounded-full transition-all duration-1000 ease-out`}
+                    style={{ width: `${item.progress}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/components/dashboard/__tests__/LearningProgressList.test.tsx
+++ b/src/app/components/dashboard/__tests__/LearningProgressList.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LearningProgressList } from '../LearningProgressList';
+import type { LearningProgressItem } from '@/types/api';
+
+vi.mock('@/hooks/useLearningProgress', () => ({
+  useLearningProgress: vi.fn(),
+}));
+
+vi.mock('@/hooks/useInternationalization', async () => {
+  const translations = (await import('@/locales/en.json')).default;
+  const read = (key: string) =>
+    key.split('.').reduce<unknown>((value, part) => {
+      if (value && typeof value === 'object' && part in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[part];
+      }
+      return key;
+    }, translations);
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const value = read(key);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => String(params[paramKey] ?? ''));
+  };
+
+  return {
+    useInternationalization: () => ({
+      language: 'en',
+      t,
+      formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+        new Intl.NumberFormat('en-US', options).format(value),
+      formatPercentage: (value: number, decimals = 0) =>
+        new Intl.NumberFormat('en-US', {
+          style: 'percent',
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(value / 100),
+    }),
+  };
+});
+
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+
+const mockItems: LearningProgressItem[] = [
+  {
+    courseId: '1',
+    title: 'Web3 UX Design Principles',
+    progress: 68,
+    timeRemaining: '12h',
+    totalLessons: 12,
+    category: 'Design',
+  },
+  {
+    courseId: '2',
+    title: 'Smart Contract Security Best Practices',
+    progress: 45,
+    timeRemaining: '18h',
+    totalLessons: 18,
+    category: 'Security',
+  },
+];
+
+describe('LearningProgressList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the section heading', () => {
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: mockItems,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<LearningProgressList />);
+    expect(screen.getByText('Learning Progress')).toBeInTheDocument();
+  });
+
+  it('renders each course with its progress status', () => {
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: mockItems,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<LearningProgressList />);
+
+    expect(screen.getByText('Web3 UX Design Principles')).toBeInTheDocument();
+    expect(screen.getByText('Smart Contract Security Best Practices')).toBeInTheDocument();
+    expect(screen.getByText('68% complete • 12h remaining')).toBeInTheDocument();
+    expect(screen.getByText('45% complete • 18h remaining')).toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton while fetching', () => {
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: [],
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<LearningProgressList />);
+    expect(screen.getByRole('heading', { name: 'Learning Progress' })).toBeInTheDocument();
+    expect(screen.queryByText('Web3 UX Design Principles')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message with a retry button when the request fails', () => {
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: [],
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: vi.fn(),
+    });
+
+    render(<LearningProgressList />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('calls refetch when the retry button is clicked', () => {
+    const refetch = vi.fn();
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: [],
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch,
+    });
+
+    render(<LearningProgressList />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an empty state when there are no courses in progress', () => {
+    vi.mocked(useLearningProgress).mockReturnValue({
+      items: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<LearningProgressList />);
+    expect(
+      screen.getByText('You have no courses in progress yet.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { useDashboardData } from '@/hooks/useDashboardData';
-import { CardSkeleton, ListSkeleton } from '@/components/ui/LoadingSkeleton';
 import { OfflineStatusIndicator } from '@/components/offline/OfflineStatusIndicator';
 import { DownloadManager } from '@/components/offline/DownloadManager';
-import { useInternationalization } from '@/hooks/useInternationalization';
 import { SidebarNavigation } from '@/components/navigation/SidebarNavigation';
 import { AnalyticsErrorDisplay } from '@/components/dashboard/AnalyticsErrorDisplay';
-import { useAnalyticsErrorTracking } from '@/hooks/useAnalyticsErrorTracking';
+import { LearningProgressList } from '@/app/components/dashboard/LearningProgressList';
 
 export default function Dashboard() {
-  const { isLoading, errors, hasErrors, dismissError, clearAllErrors } = useDashboardData();
-  const { t } = useInternationalization();
+  const { hasErrors, errors, dismissError, clearAllErrors } = useDashboardData();
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
@@ -38,65 +35,7 @@ export default function Dashboard() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Main Content */}
           <div className="lg:col-span-2 space-y-8">
-            {isLoading ? (
-              <>
-                <CardSkeleton />
-                <CardSkeleton />
-              </>
-            ) : (
-              <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border dark:border-gray-800 p-8">
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-8">
-                  {t('dashboard.learningProgress')}
-                </h2>
-
-                <div className="space-y-8">
-                  <div className="border-s-4 border-blue-500 ps-6 group">
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-white group-hover:text-blue-600 transition-colors">
-                      Web3 UX Design Principles
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                      {t('dashboard.progressStatus', { percent: 68, remaining: '12h' })}
-                    </p>
-                    <div className="mt-4 w-full bg-gray-100 dark:bg-gray-800 rounded-full h-3">
-                      <div
-                        className="bg-blue-500 h-3 rounded-full transition-all duration-1000 ease-out"
-                        style={{ width: '68%' }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="border-s-4 border-green-500 ps-6 group">
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-white group-hover:text-green-600 transition-colors">
-                      Smart Contract Security
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                      {t('dashboard.progressStatus', { percent: 45, remaining: '18h' })}
-                    </p>
-                    <div className="mt-4 w-full bg-gray-100 dark:bg-gray-800 rounded-full h-3">
-                      <div
-                        className="bg-green-500 h-3 rounded-full transition-all duration-1000 ease-out"
-                        style={{ width: '45%' }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="border-s-4 border-purple-500 ps-6 group">
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-white group-hover:text-purple-600 transition-colors">
-                      Scaling DAPps on Starknet
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                      {t('dashboard.progressStatus', { percent: 12, remaining: '32h' })}
-                    </p>
-                    <div className="mt-4 w-full bg-gray-100 dark:bg-gray-800 rounded-full h-3">
-                      <div
-                        className="bg-purple-500 h-3 rounded-full transition-all duration-1000 ease-out"
-                        style={{ width: '12%' }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
+            <LearningProgressList />
           </div>
 
           {/* Sidebar */}

--- a/src/hooks/__tests__/useLearningProgress.test.tsx
+++ b/src/hooks/__tests__/useLearningProgress.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import React, { useEffect } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { useLearningProgress } from '../useLearningProgress';
+import type { UseLearningProgressReturn } from '../useLearningProgress';
+import { apiClient } from '@/lib/api';
+import type { ApiResponse, LearningProgressItem } from '@/types/api';
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+const mockItems: LearningProgressItem[] = [
+  {
+    courseId: '1',
+    title: 'Web3 UX Design Principles',
+    progress: 68,
+    timeRemaining: '12h',
+    totalLessons: 12,
+    category: 'Design',
+  },
+  {
+    courseId: '2',
+    title: 'Smart Contract Security Best Practices',
+    progress: 45,
+    timeRemaining: '18h',
+    totalLessons: 18,
+    category: 'Security',
+  },
+];
+
+const mockResponse: ApiResponse<LearningProgressItem[]> = {
+  success: true,
+  data: mockItems,
+};
+
+const TestHarness: React.FC<{ onReady: (api: UseLearningProgressReturn) => void }> = ({
+  onReady,
+}) => {
+  const api = useLearningProgress();
+  useEffect(() => {
+    onReady(api);
+  });
+  return null;
+};
+
+describe('useLearningProgress', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('fetches learning progress items on mount', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse);
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/user/learning-progress');
+    expect(api!.items).toEqual(mockItems);
+    expect(api!.isLoading).toBe(false);
+    expect(api!.error).toBeNull();
+  });
+
+  it('returns empty items and clears loading when no data', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ success: true, data: [] });
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    expect(api!.items).toEqual([]);
+    expect(api!.isLoading).toBe(false);
+    expect(api!.error).toBeNull();
+  });
+
+  it('surfaces the error when the request fails', async () => {
+    const networkError = new Error('Network error');
+    vi.mocked(apiClient.get).mockRejectedValue(networkError);
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    expect(api!.items).toEqual([]);
+    expect(api!.isLoading).toBe(false);
+    expect(api!.error).toBe(networkError);
+  });
+
+  it('refetches items when refetch is called', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(mockResponse);
+    const updatedResponse: ApiResponse<LearningProgressItem[]> = {
+      success: true,
+      data: [mockItems[0]],
+    };
+    vi.mocked(apiClient.get).mockResolvedValueOnce(updatedResponse);
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await api!.refetch();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+    expect(api!.items).toEqual([mockItems[0]]);
+  });
+});

--- a/src/hooks/useLearningProgress.ts
+++ b/src/hooks/useLearningProgress.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { apiClient } from '@/lib/api';
+import type { ApiResponse, LearningProgressItem } from '@/types/api';
+
+export interface UseLearningProgressReturn {
+  items: LearningProgressItem[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useLearningProgress(): UseLearningProgressReturn {
+  const [items, setItems] = useState<LearningProgressItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    if (mountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const response = await apiClient.get<ApiResponse<LearningProgressItem[]>>(
+        '/api/user/learning-progress',
+      );
+      if (mountedRef.current) {
+        setItems(response.data);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { items, isLoading, error, refetch: load };
+}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -17,7 +17,8 @@
     "submit": "إرسال",
     "confirm": "تأكيد",
     "yes": "نعم",
-    "no": "لا"
+    "no": "لا",
+    "retry": "إعادة المحاولة"
   },
   "navigation": {
     "home": "الرئيسية",
@@ -190,7 +191,8 @@
           "neutral": "ثابت"
         }
       }
-    }
+    },
+    "noCoursesInProgress": "لا توجد دورات قيد التقدم بعد."
   },
   "profile": {
     "editProfile": "تعديل الملف الشخصي",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,8 @@
     "submit": "Submit",
     "confirm": "Confirm",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "retry": "Retry"
   },
   "navigation": {
     "home": "Home",
@@ -190,7 +191,8 @@
           "neutral": "Flat"
         }
       }
-    }
+    },
+    "noCoursesInProgress": "You have no courses in progress yet."
   },
   "profile": {
     "editProfile": "Edit Profile",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -17,7 +17,8 @@
     "submit": "Enviar",
     "confirm": "Confirmar",
     "yes": "Sí",
-    "no": "No"
+    "no": "No",
+    "retry": "[MISSING TRANSLATION] Retry"
   },
   "navigation": {
     "home": "Inicio",
@@ -190,7 +191,8 @@
           "neutral": "Estable"
         }
       }
-    }
+    },
+    "noCoursesInProgress": "[MISSING TRANSLATION] You have no courses in progress yet."
   },
   "profile": {
     "editProfile": "Editar Perfil",

--- a/src/schemas/progress.schema.ts
+++ b/src/schemas/progress.schema.ts
@@ -21,3 +21,14 @@ export const CourseProgressSchema = z.object({
 });
 
 export type CourseProgress = z.infer<typeof CourseProgressSchema>;
+
+export const LearningProgressItemSchema = z.object({
+  courseId: z.string().min(1),
+  title: z.string().min(1),
+  progress: z.number().min(0).max(100),
+  timeRemaining: z.string().min(1),
+  totalLessons: z.number().int().nonnegative(),
+  category: z.string().min(1),
+});
+
+export type LearningProgressItem = z.infer<typeof LearningProgressItemSchema>;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -2,7 +2,11 @@ import { User as ZodUser, UserRole as ZodUserRole } from '@/schemas/user.schema'
 import { Course as ZodCourse } from '@/schemas/course.schema';
 import { AuthResponse as ZodAuthResponse } from '@/schemas/auth.schema';
 import { AnalyticsEventPayload as ZodAnalyticsEventPayload } from '@/schemas/analytics.schema';
-import { UserProgress as ZodUserProgress, CourseProgress as ZodCourseProgress } from '@/schemas/progress.schema';
+import {
+  UserProgress as ZodUserProgress,
+  CourseProgress as ZodCourseProgress,
+  LearningProgressItem as ZodLearningProgressItem,
+} from '@/schemas/progress.schema';
 import {
   VideoBookmark as ZodVideoBookmark,
   VideoNote as ZodVideoNote,
@@ -95,6 +99,7 @@ export type VideoNote = ZodVideoNote;
 
 export type UserProgress = ZodUserProgress;
 export type CourseProgress = ZodCourseProgress;
+export type LearningProgressItem = ZodLearningProgressItem;
 
 // ---------------------------------------------------------------------------
 // Video analytics


### PR DESCRIPTION
## Summary

Closes #937

Replaces the hardcoded learning-progress courses in `src/app/dashboard/page.tsx` with a self-contained `LearningProgressList` component that renders data fetched from a new **GET `/api/user/learning-progress`** endpoint, backed by the course catalog. The dashboard static shell now simply mounts the fetched-data component.

### Changes
- **API**: `GET /api/user/learning-progress` returns in-progress courses (`progress > 0`) from `getAllCourses()` as `LearningProgressItem[]` (edge runtime, rate limited, logged).
- **Schema/type**: added `LearningProgressItemSchema` + `LearningProgressItem` in `src/schemas/progress.schema.ts`, re-exported from `src/types/api.ts`.
- **Hook**: `useLearningProgress` (`src/hooks/useLearningProgress.ts`) fetches via `apiClient` and exposes `{ items, isLoading, error, refetch }`.
- **Component**: `LearningProgressList` (`src/app/components/dashboard/LearningProgressList.tsx`) handles loading skeleton, error + retry, empty state, and the progress list with accent-colored borders/bars.
- **Dashboard page**: now renders `<LearningProgressList />` instead of the hardcoded JSX.
- **i18n**: added `common.retry` and `dashboard.noCoursesInProgress` to en/es/ar.
- **Tests**: route, hook, and component tests (13 total) following existing repo conventions.

### Verification
- `pnpm vitest run` for the 3 new test files: 13/13 passing
- `pnpm lint` (next lint --max-warnings=0): clean
- `node scripts/check-locales.mjs` and `check-i18n.cjs`: clean