### PR TITLE
fix(dashboard): validate imported widget config shape

### DIFF
--- a/src/app/hooks/__tests__/useDashboardWidgets.test.tsx
+++ b/src/app/hooks/__tests__/useDashboardWidgets.test.tsx
@@ -70,6 +70,99 @@ describe('useDashboardWidgets', () => {
     expect(saved.length).toBe(api.widgets.length);
   });
 
+  it('imports a valid widget config and persists it', async () => {
+    let api: any;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    const config = {
+      widgets: [
+        {
+          id: 'stat-revenue',
+          type: 'progress-summary',
+          title: 'Total Revenue',
+          size: 'small',
+          position: 0,
+          isCollapsed: false,
+          settings: { statType: 'revenue' },
+        },
+      ],
+      version: '1.0.0',
+    };
+
+    let imported = false;
+    await act(async () => {
+      imported = api.importWidgetConfig(config);
+    });
+    expect(imported).toBe(true);
+    expect(api.widgets).toEqual(config.widgets);
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    const saved = JSON.parse(localStorage.getItem('dashboard-widgets') || '[]');
+    expect(saved).toEqual(config.widgets);
+  });
+
+  it('rejects a widget config with malformed entries', async () => {
+    let api: any;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    const malformed = {
+      widgets: [
+        {
+          id: 'broken',
+          type: 'progress-summary',
+          title: 'Broken',
+          // missing size and position
+          isCollapsed: false,
+          settings: {},
+        },
+      ],
+    };
+
+    let imported = true;
+    await act(async () => {
+      imported = api.importWidgetConfig(malformed);
+    });
+    expect(imported).toBe(false);
+    expect(api.widgets.some((w: any) => w.id === 'broken')).toBe(false);
+  });
+
+  it('rejects a non-array widget config', async () => {
+    let api: any;
+    await act(async () => {
+      root.render(
+        <TestHarness
+          onReady={(a) => {
+            api = a;
+          }}
+        />,
+      );
+    });
+
+    let imported = true;
+    await act(async () => {
+      imported = api.importWidgetConfig({ widgets: { id: 'not-an-array' } });
+    });
+    expect(imported).toBe(false);
+  });
+
   it('adds, reorders, updates, collapses, resizes, and removes widgets', async () => {
     let api: any;
     await act(async () => {

--- a/src/app/hooks/useDashboardWidgets.tsx
+++ b/src/app/hooks/useDashboardWidgets.tsx
@@ -1,6 +1,7 @@
 import { createLogger } from '@/lib/logging';
 const logger = createLogger('use-dashboard-widgets');
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { z } from 'zod';
 
 interface Widget {
   id: string;
@@ -11,6 +12,18 @@ interface Widget {
   isCollapsed: boolean;
   settings: Record<string, unknown>;
 }
+
+const widgetSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  title: z.string().min(1),
+  size: z.enum(['small', 'medium', 'large']),
+  position: z.number().int().nonnegative(),
+  isCollapsed: z.boolean(),
+  settings: z.record(z.string(), z.unknown()),
+});
+
+const widgetListSchema = z.array(widgetSchema);
 
 // Default widgets matching Figma design — single source of truth
 const DEFAULT_WIDGETS: Widget[] = [
@@ -256,12 +269,21 @@ export const useDashboardWidgets = () => {
   const importWidgetConfig = useCallback(
     (config: { widgets?: Widget[] }) => {
       try {
-        if (config.widgets && Array.isArray(config.widgets)) {
-          setWidgets(config.widgets);
-          saveWidgetLayout(config.widgets);
-          return true;
+        if (!Array.isArray(config.widgets)) {
+          return false;
         }
-        return false;
+
+        const result = widgetListSchema.safeParse(config.widgets);
+        if (!result.success) {
+          logger.error('Failed to import widget config: malformed widgets', {
+            errors: result.error.issues,
+          });
+          return false;
+        }
+
+        setWidgets(result.data);
+        saveWidgetLayout(result.data);
+        return true;
       } catch (error) {
         logger.error('Failed to import widget config', { error });
         return false;


### PR DESCRIPTION
## Description

`importWidgetConfig` in `src/app/hooks/useDashboardWidgets.tsx` previously accepted any value where `config.widgets` was an array, then stored the raw entries into state and `localStorage`. Malformed entries (missing `type`/`size`/`position`, etc.) flowed into `DashboardGrid` and could crash the dashboard on next load since the layout is persisted.

This PR validates each imported widget against the `Widget` shape using a zod schema (`widgetSchema` / `widgetListSchema`) before accepting the import. Invalid configs are rejected, logged, and left out of state/persisted layout. Unit tests cover valid imports, malformed entries, and non-array configs.

## Related Issue

Closes #939

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently
- [x] Responsive design implemented
- [x] Starknet best practices followed
