### PR TITLE
perf(notifications): memoize NotificationProvider context value (#893)

### DIFF
--- a/src/providers/Notificationprovider.tsx
+++ b/src/providers/Notificationprovider.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
   useCallback,
+  useMemo,
   ReactNode,
 } from 'react';
 import {
@@ -134,19 +135,26 @@ export function NotificationProvider({
     serviceRef.current?.send('notification_clear', { all: true });
   }, []);
 
-  return (
-    <NotificationContext.Provider
-      value={{
-        notifications,
-        unreadCount,
-        connectionState,
-        markAsRead,
-        markAllAsRead,
-        clearNotification,
-        clearAll,
-      }}
-    >
-      {children}
-    </NotificationContext.Provider>
+  const value = useMemo(
+    () => ({
+      notifications,
+      unreadCount,
+      connectionState,
+      markAsRead,
+      markAllAsRead,
+      clearNotification,
+      clearAll,
+    }),
+    [
+      notifications,
+      unreadCount,
+      connectionState,
+      markAsRead,
+      markAllAsRead,
+      clearNotification,
+      clearAll,
+    ],
   );
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
 }


### PR DESCRIPTION
Closes #893

## Summary
Memoize the NotificationProvider context value to eliminate needless re-renders across all useNotifications() consumers.
Problem
The context value was passed as a fresh inline object on every render, so any provider re-render cascaded to the entire consumer tree even when nothing relevant changed.

## Solution
Wrapped the value in useMemo with a complete dependency list. Since all callbacks were already stable via useCallback, the change is behavior-preserving.

## Files Changed
- src/providers/Notificationprovider.tsx

## Verification
- Prettier
- Type-check
- Lint
- Unit tests (3 passed)
- Build