### PR TITLE
perf(perf-monitoring): memoize usePerformanceMonitoringState return v…

### DIFF
--- a/src/hooks/usePerformanceMonitoring.tsx
+++ b/src/hooks/usePerformanceMonitoring.tsx
@@ -117,14 +117,17 @@ function usePerformanceMonitoringState(
     toastDedupeRef.current.clear();
   }, []);
 
-  return {
-    metrics,
-    alerts,
-    suggestions,
-    trend,
-    clearAlerts,
-    refreshTrendFromStorage,
-  };
+  return useMemo(
+    () => ({
+      metrics,
+      alerts,
+      suggestions,
+      trend,
+      clearAlerts,
+      refreshTrendFromStorage,
+    }),
+    [metrics, alerts, suggestions, trend, clearAlerts, refreshTrendFromStorage],
+  );
 }
 
 const providerEnableToasts =


### PR DESCRIPTION
## Description
Memoize the value returned by usePerformanceMonitoringState in src/hooks/usePerformanceMonitoring.tsx by wrapping it in useMemo. The returned container object was previously created fresh on every render, causing every usePerformanceMonitoring() consumer to re-render needlessly whenever the provider rendered. Since suggestions, clearAlerts, and refreshTrendFromStorage were already memoized, the container object now only receives a new identity when its actual dependencies change — eliminating the re-render cascade while preserving behavior.

Closes #894

Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update

## Checklist
- Code follows project style guidelines
- Self-review completed
- No console errors
- Uses Lucide icons consistently
- Responsive design implemented
- Starknet best practices followed