### PR TITLE
fix(memoize): stabilize FeatureFlagProvider context value and toggle #892

### DIFF
--- a/src/components/shared/FeatureFlagProvider.tsx
+++ b/src/components/shared/FeatureFlagProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useCallback, useMemo, useState } from 'react';
 import { getAllFlags, type FeatureFlag } from '@/lib/featureFlags';
 import { Settings, X } from 'lucide-react';
 
@@ -14,10 +14,12 @@ const FeatureFlagContext = createContext<{
 export function FeatureFlagProvider({ children }: { children: React.ReactNode }) {
   const [flags, setFlags] = useState<FlagState>(getAllFlags);
 
-  const toggle = (flag: FeatureFlag) => setFlags((prev) => ({ ...prev, [flag]: !prev[flag] }));
+  const toggle = useCallback((flag: FeatureFlag) => setFlags((prev) => ({ ...prev, [flag]: !prev[flag] })), []);
+
+  const value = useMemo(() => ({ flags, toggle }), [flags, toggle]);
 
   return (
-    <FeatureFlagContext.Provider value={{ flags, toggle }}>
+    <FeatureFlagContext.Provider value={value}>
       {children}
       {process.env.NODE_ENV === 'development' && (
         <FeatureFlagAdminPanel flags={flags} toggle={toggle} />


### PR DESCRIPTION
## Overview
Memoize FeatureFlagProvider context value and stabilize 	oggle to prevent unnecessary re-renders across all components using useFeatureFlag().

## Related Issue
Closes #892

## Changes

### 📦 Context Stability
-   **[MODIFY]** src/components/shared/FeatureFlagProvider.tsx
    -   Wrap 	oggle in useCallback(() => ..., []) so its reference is stable across renders.
    -   Memoize the context alue object via useMemo(() => ({ flags, toggle }), [flags, toggle]).

## Verification Results
`
pnpm run type-check
✅ Type check passed
`

Acceptance Criteria

Status

Provider no longer creates a new object on every render

✅ Context value is memoized with useMemo

	oggle reference is stable across renders

✅ Wrapped in useCallback with empty dependency array

Components using useFeatureFlag() no longer re-render unnecessarily

✅ Eliminated by stable context value and stable toggle reference