### PR TITLE
feat(breadcrumbs): add A/B testing framework for Breadcrumbs #375

### DIFF
--- a/src/components/ui/ABTestBreadcrumbs.tsx
+++ b/src/components/ui/ABTestBreadcrumbs.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from './Breadcrumbs';
+import { useABTest } from '@/hooks/useABTest';
+
+export interface ABTestBreadcrumbsProps extends BreadcrumbsProps {
+  experimentId?: string;
+}
+
+const VARIANT_CLASSES = {
+  standard: {
+    container: 'text-sm gap-1',
+    item: 'px-2 py-1',
+  },
+  compact: {
+    container: 'text-xs gap-0.5',
+    item: 'px-1.5 py-0.5',
+  },
+  minimal: {
+    container: 'text-sm gap-1.5',
+    item: 'px-2 py-0.5',
+  },
+};
+
+export function ABTestBreadcrumbs({
+  experimentId = 'breadcrumbs_layout',
+  className = '',
+  items,
+  ...props
+}: ABTestBreadcrumbsProps) {
+  const { variant, trackExposure } = useABTest({
+    experimentId,
+    variants: [
+      { id: 'standard', label: 'Standard Breadcrumbs', weight: 50 },
+      { id: 'compact', label: 'Compact Breadcrumbs', weight: 30 },
+      { id: 'minimal', label: 'Minimal Breadcrumbs', weight: 20 },
+    ],
+  });
+
+  const variantClasses = VARIANT_CLASSES[variant.id as keyof typeof VARIANT_CLASSES] || VARIANT_CLASSES.standard;
+
+  const enhancedItems = items.map((item) => ({
+    ...item,
+    className: [item.className, variantClasses.item].filter(Boolean).join(' '),
+  }));
+
+  const exposureTracked = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!exposureTracked.current) {
+      trackExposure();
+      exposureTracked.current = true;
+    }
+  }, [trackExposure]);
+
+  return (
+    <Breadcrumbs
+      {...props}
+      items={enhancedItems}
+      className={`${variantClasses.container} ${className}`}
+    />
+  );
+}
+
+ABTestBreadcrumbs.displayName = 'ABTestBreadcrumbs';

--- a/src/components/ui/Breadcrumbs.tsx
+++ b/src/components/ui/Breadcrumbs.tsx
@@ -30,6 +30,8 @@ export interface BreadcrumbItem {
   current?: boolean;
   /** Optional click handler (for custom navigation) */
   onClick?: (e: React.MouseEvent) => void;
+  /** Additional CSS classes for the breadcrumb item */
+  className?: string;
 }
 
 export interface BreadcrumbsProps {
@@ -80,6 +82,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
         href: undefined,
         current: i === 2,
         isSkeleton: true,
+        className: '',
       }));
     }
 
@@ -115,6 +118,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
                 <span
                   className={`
                     inline-flex items-center gap-1.5 px-2 py-1 rounded-md
+                    ${item.className ?? ''}
                   `}
                 >
                   <span className={`${skeletonPulse} h-4 w-16`}></span>
@@ -130,6 +134,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
                     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
                     transition-colors duration-200
                     ${isCollapsed ? 'cursor-default pointer-events-none' : ''}
+                    ${item.className ?? ''}
                   `}
                   aria-current={item.current ? 'page' : undefined}
                   onClick={item.onClick}
@@ -147,6 +152,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
                         ? 'text-gray-900 dark:text-gray-100 font-semibold'
                         : 'text-gray-600 dark:text-gray-400'
                     }
+                    ${item.className ?? ''}
                   `}
                   aria-current={item.current ? 'page' : undefined}
                 >

--- a/src/components/ui/__tests__/ABTestBreadcrumbs.test.tsx
+++ b/src/components/ui/__tests__/ABTestBreadcrumbs.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ABTestBreadcrumbs } from '../ABTestBreadcrumbs';
+import type { BreadcrumbItem } from '../Breadcrumbs';
+
+describe('ABTestBreadcrumbs', () => {
+  let localStorageData: Record<string, string> = {};
+
+  const items: BreadcrumbItem[] = [
+    { label: 'Home', href: '/' },
+    { label: 'Dashboard', href: '/dashboard' },
+    { label: 'Analytics', current: true },
+  ];
+
+  beforeEach(() => {
+    localStorageData = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageData[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageData[key] = value;
+      }),
+      clear: vi.fn(() => {
+        for (const key in localStorageData) delete localStorageData[key];
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageData[key];
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders breadcrumb items', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-render';
+    localStorageData['ab_test_breadcrumbs_layout'] = '2500';
+    render(<ABTestBreadcrumbs items={items} />);
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+  });
+
+  it('applies standard variant classes by default', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-standard';
+    localStorageData['ab_test_breadcrumbs_layout'] = '2500';
+    const { container } = render(<ABTestBreadcrumbs items={items} />);
+
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveClass('text-sm', 'gap-1');
+  });
+
+  it('applies compact variant classes when bucket falls in compact range', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-compact';
+    localStorageData['ab_test_breadcrumbs_layout'] = '6500';
+    const { container } = render(<ABTestBreadcrumbs items={items} />);
+
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveClass('text-xs', 'gap-0.5');
+  });
+
+  it('applies minimal variant classes when bucket falls in minimal range', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-minimal';
+    localStorageData['ab_test_breadcrumbs_layout'] = '9000';
+    const { container } = render(<ABTestBreadcrumbs items={items} />);
+
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveClass('text-sm', 'gap-1.5');
+  });
+
+  it('tracks exposure on render', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    localStorageData['ab_test_anon_id'] = 'test-user-exposure';
+    localStorageData['ab_test_breadcrumbs_layout'] = '2500';
+
+    render(<ABTestBreadcrumbs items={items} />);
+
+    await waitFor(() => {
+      expect(localStorageData['ab_test_breadcrumbs_layout_exposed']).toBeTruthy();
+    });
+
+    const exposure = JSON.parse(localStorageData['ab_test_breadcrumbs_layout_exposed']);
+    expect(exposure.variantId).toBe('standard');
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+    );
+  });
+
+  it('uses a custom experimentId when provided', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    localStorageData['ab_test_anon_id'] = 'test-user-custom';
+    localStorageData['ab_test_custom_experiment'] = '2500';
+
+    render(<ABTestBreadcrumbs items={items} experimentId="custom_experiment" />);
+
+    await waitFor(() => {
+      expect(localStorageData['ab_test_custom_experiment_exposed']).toBeTruthy();
+    });
+
+    const exposure = JSON.parse(localStorageData['ab_test_custom_experiment_exposed']);
+    expect(exposure.variantId).toBe('standard');
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+    );
+  });
+
+  it('passes additional props through to Breadcrumbs', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-props';
+    localStorageData['ab_test_breadcrumbs_layout'] = '2500';
+    render(<ABTestBreadcrumbs items={items} ariaLabel="Custom navigation" showHomeIcon />);
+
+    const nav = screen.getByRole('navigation', { name: /custom navigation/i });
+    expect(nav).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ export {
   type BreadcrumbItem,
   type BreadcrumbsProps,
 } from './Breadcrumbs';
+export { ABTestBreadcrumbs, type ABTestBreadcrumbsProps } from './ABTestBreadcrumbs';
 export { Badge, badgeVariants } from './Badge';
 export type { BadgeProps } from './Badge';
 export { Button } from './Button';

--- a/src/hooks/__tests__/useABTest.test.ts
+++ b/src/hooks/__tests__/useABTest.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useABTest } from '../useABTest';
+
+describe('useABTest', () => {
+  let localStorageData: Record<string, string> = {};
+
+  beforeEach(() => {
+    localStorageData = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageData[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageData[key] = value;
+      }),
+      clear: vi.fn(() => {
+        for (const key in localStorageData) delete localStorageData[key];
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageData[key];
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when given an empty variants array', () => {
+    expect(() =>
+      renderHook(() =>
+        useABTest({
+          experimentId: 'test_empty',
+          variants: [],
+        }),
+      ),
+    ).toThrow('must have at least one variant');
+  });
+
+  it('assigns a single variant deterministically', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-1';
+    const { result } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_single',
+        variants: [{ id: 'only', label: 'Only', weight: 1 }],
+      }),
+    );
+
+    expect(result.current.variant.id).toBe('only');
+    expect(result.current.isResolved).toBe(true);
+    expect(typeof result.current.trackExposure).toBe('function');
+  });
+
+  it('persists assignment across re-renders', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-persist';
+    const { result, rerender } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_persist',
+        variants: [
+          { id: 'a', label: 'A', weight: 50 },
+          { id: 'b', label: 'B', weight: 50 },
+        ],
+      }),
+    );
+
+    const firstVariant = result.current.variant.id;
+    rerender();
+    expect(result.current.variant.id).toBe(firstVariant);
+  });
+
+  it('returns the same variant for the same stored bucket', () => {
+    localStorageData['ab_test_anon_id'] = 'test-user-same-bucket';
+    localStorageData['ab_test_test_same_bucket'] = '2500';
+
+    const { result: first } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_same_bucket',
+        variants: [
+          { id: 'a', label: 'A', weight: 50 },
+          { id: 'b', label: 'B', weight: 50 },
+        ],
+      }),
+    );
+
+    const { result: second } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_same_bucket',
+        variants: [
+          { id: 'a', label: 'A', weight: 50 },
+          { id: 'b', label: 'B', weight: 50 },
+        ],
+      }),
+    );
+
+    expect(first.current.variant.id).toBe(second.current.variant.id);
+  });
+
+  it('tracks exposure and stores it in localStorage', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    localStorageData['ab_test_anon_id'] = 'test-user-exposure';
+    localStorageData['ab_test_test_exposure'] = '2500';
+
+    const { result } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_exposure',
+        variants: [
+          { id: 'control', label: 'Control', weight: 50 },
+          { id: 'variant', label: 'Variant', weight: 50 },
+        ],
+      }),
+    );
+
+    result.current.trackExposure();
+
+    expect(localStorageData['ab_test_test_exposure_exposed']).toBeTruthy();
+    const exposure = JSON.parse(localStorageData['ab_test_test_exposure_exposed']);
+    expect(exposure.variantId).toBe(result.current.variant.id);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+    );
+  });
+
+  it('does not dispatch exposure event twice', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    localStorageData['ab_test_anon_id'] = 'test-user-no-double';
+    localStorageData['ab_test_test_no_double'] = '2500';
+
+    const { result } = renderHook(() =>
+      useABTest({
+        experimentId: 'test_no_double',
+        variants: [{ id: 'only', label: 'Only', weight: 1 }],
+      }),
+    );
+
+    result.current.trackExposure();
+    result.current.trackExposure();
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useABTest.ts
+++ b/src/hooks/useABTest.ts
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ABTestVariant {
+  /** Unique identifier for this variant */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Traffic weight (relative, not percentage). E.g. [50, 50] for a 50/50 split. */
+  weight: number;
+}
+
+export interface ABTestConfig {
+  /** Unique experiment identifier (used as storage key) */
+  experimentId: string;
+  /** Available variants (must include at least one) */
+  variants: ABTestVariant[];
+}
+
+export interface ABTestResult {
+  /** The variant assigned to the current user */
+  variant: ABTestVariant;
+  /** All available variants */
+  variants: ABTestVariant[];
+  /** Whether the variant was resolved (not from default fallback) */
+  isResolved: boolean;
+  /** Call this when the variant is rendered to track exposure */
+  trackExposure: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function djb2Hash(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return hash >>> 0;
+}
+
+function getBucket(experimentId: string, userId: string): number {
+  const hash = djb2Hash(`${experimentId}:${userId}`);
+  return hash % 10000; // 0-9999 for sub-percent precision
+}
+
+function resolveVariant(
+  config: ABTestConfig,
+  bucket: number,
+): ABTestVariant {
+  const totalWeight = config.variants.reduce((sum, v) => sum + v.weight, 0);
+  if (totalWeight <= 0) return config.variants[0];
+
+  const bucketScaled = (bucket / 10000) * totalWeight;
+  let cumulative = 0;
+
+  for (const variant of config.variants) {
+    cumulative += variant.weight;
+    if (bucketScaled < cumulative) return variant;
+  }
+
+  return config.variants[config.variants.length - 1];
+}
+
+const STORAGE_PREFIX = 'ab_test_';
+const EXPOSURE_SUFFIX = '_exposed';
+
+function getStoredAssignment(experimentId: string): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(`${STORAGE_PREFIX}${experimentId}`);
+    if (stored !== null) {
+      const parsed = parseInt(stored, 10);
+      return Number.isNaN(parsed) ? null : parsed;
+    }
+  } catch {
+    // localStorage unavailable (SSR, privacy settings, etc.)
+  }
+  return null;
+}
+
+function storeAssignment(experimentId: string, bucket: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${experimentId}`, String(bucket));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+function trackExposureEvent(experimentId: string, variantId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const key = `${STORAGE_PREFIX}${experimentId}${EXPOSURE_SUFFIX}`;
+    const existing = localStorage.getItem(key);
+    if (existing) return; // already exposed
+
+    localStorage.setItem(key, JSON.stringify({
+      variantId,
+      exposedAt: new Date().toISOString(),
+    }));
+
+    // Dispatch a custom event for analytics consumers
+    window.dispatchEvent(
+      new CustomEvent('ab-test:exposure', {
+        detail: { experimentId, variantId },
+      }),
+    );
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+function getStableUserId(): string {
+  if (typeof window === 'undefined') return 'server';
+
+  try {
+    const ANON_KEY = 'ab_test_anon_id';
+    let anonId = localStorage.getItem(ANON_KEY);
+    if (anonId) return anonId;
+
+    // Generate a stable anonymous ID
+    anonId = `anon_${Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36)}${Date.now().toString(36)}`;
+    localStorage.setItem(ANON_KEY, anonId);
+    return anonId;
+  } catch {
+    return 'anonymous';
+  }
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * useABTest — deterministic client-side A/B testing hook.
+ *
+ * Assigns users to variants based on a stable hash so the same user
+ * always sees the same variant (within the same experiment).
+ *
+ * @example
+ * ```tsx
+ * const { variant, trackExposure } = useABTest({
+ *   experimentId: 'breadcrumbs_layout',
+ *   variants: [
+ *     { id: 'control', label: 'Standard', weight: 50 },
+ *     { id: 'compact', label: 'Compact', weight: 50 },
+ *   ],
+ * });
+ *
+ * // Use variant.id to render different layouts
+ * if (variant.id === 'compact') return <CompactBreadcrumbs ... />;
+ * return <Breadcrumbs ... />;
+ * ```
+ */
+export function useABTest(config: ABTestConfig): ABTestResult {
+  const { experimentId, variants } = config;
+
+  // Validate: must have at least one variant
+  if (variants.length === 0) {
+    throw new Error(`useABTest: experiment "${experimentId}" must have at least one variant`);
+  }
+
+  const userId = useMemo(() => getStableUserId(), []);
+
+  const [assignedBucket] = useState<number>(() => {
+    // First check for an existing assignment (stable across re-renders)
+    const existing = getStoredAssignment(experimentId);
+    if (existing !== null) return existing;
+
+    // Otherwise compute a new assignment
+    const bucket = getBucket(experimentId, userId);
+    storeAssignment(experimentId, bucket);
+    return bucket;
+  });
+
+  const variant = useMemo(
+    () => resolveVariant(config, assignedBucket),
+    [config, assignedBucket],
+  );
+
+  const trackExposure = useCallback(() => {
+    trackExposureEvent(experimentId, variant.id);
+  }, [experimentId, variant.id]);
+
+  return {
+    variant,
+    variants,
+    isResolved: true,
+    trackExposure,
+  };
+}


### PR DESCRIPTION
## Overview
This PR adds an A/B Testing Framework for the Breadcrumbs component to improve overall application quality and user satisfaction through data-driven variant testing.

## Related Issue
Closes #375

## Changes

### [ADD] `src/hooks/useABTest.ts`
- New deterministic client-side A/B testing hook with stable user bucketing
- localStorage persistence for consistent variant assignment across sessions
- Exposure tracking with custom events for analytics integration

### [ADD] `src/components/ui/ABTestBreadcrumbs.tsx`
- New `ABTestBreadcrumbs` component wrapping `Breadcrumbs` with A/B testing
- Three visual variants: `standard` (50%), `compact` (30%), `minimal` (20%)
- Automatic exposure tracking on render

### [MODIFY] `src/components/ui/Breadcrumbs.tsx`
- Added optional `className` to `BreadcrumbItem` interface for variant-specific styling
- Applied item-level className in skeleton, link, and span rendering paths

### [ADD] Tests
- `src/hooks/__tests__/useABTest.test.ts` — 6 tests covering bucket persistence, exposure tracking, and edge cases
- `src/components/ui/__tests__/ABTestBreadcrumbs.test.tsx` — 7 tests covering variant classes, custom experiment IDs, and prop forwarding

## Verification Results
```
pnpm test -- src/hooks/__tests__/useABTest.test.ts src/components/ui/__tests__/ABTestBreadcrumbs.test.tsx src/components/ui/__tests__/Breadcrumbs.test.tsx
✅ 40/40 passed

pnpm run type-check
✅ TypeScript validation passed
```

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Breadcrumbs properly implements A/B Testing Framework | ✅ |
| All related tests pass | ✅ |
| No regression in existing functionality | ✅ |
| Code follows project coding standards | ✅ |
| Documentation updated if required | ✅ |
| Performance impact is minimal | ✅ |
| Accessibility guidelines are followed | ✅ |
| Security considerations are addressed | ✅ |
