### PR TITLE
feat(accessibility): add VPAT CDN integration

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -2,6 +2,12 @@
 
 This app ships a layered accessibility toolkit aimed at **WCAG 2.1 Level AA** patterns. Automated checks catch common failures; they do **not** replace testing with screen readers and keyboard-only navigation.
 
+## VPAT CDN delivery
+
+Published VPAT JSON reports are served from the read-only route `/api/accessibility/vpat/:version.json` and are safe to cache at a CDN because the version is part of the URL. Set `VPAT_REPORT_JSON` to the validated report JSON during deployment. The artifact's `version` must match the URL; invalid or missing artifacts return `404`.
+
+For a separate CDN origin, set `NEXT_PUBLIC_VPAT_CDN_URL` to its base URL. `getVPATCDNUrl(version)` then produces a versioned URL such as `https://cdn.example.com/api/accessibility/vpat/1.2.3.json`. Reports are delivered with one-year immutable browser and edge caching, `nosniff`, and inline JSON content disposition. Never place personal data or credentials in a VPAT report.
+
 ## Architecture
 
 | Piece                   | Role                                                                                                                                      |

--- a/src/app/api/accessibility/vpat/[version]/__tests__/route.test.ts
+++ b/src/app/api/accessibility/vpat/[version]/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { GET } from '../route';
+
+const report = JSON.stringify({
+  id: 'vpat-1.2.3',
+  productName: 'TeachLink',
+  version: '1.2.3',
+  generatedAt: '2026-08-25T00:00:00.000Z',
+  findings: [
+    { criterionId: '1.1.1', level: 'supports', remark: 'Alternative text is provided.' },
+  ],
+});
+
+afterEach(() => {
+  delete process.env.VPAT_REPORT_JSON;
+});
+
+describe('GET /api/accessibility/vpat/[version]', () => {
+  it('serves the matching deployment artifact with immutable CDN headers', async () => {
+    process.env.VPAT_REPORT_JSON = report;
+
+    const response = await GET(new Request('https://example.com'), {
+      params: Promise.resolve({ version: '1.2.3.json' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=31536000, s-maxage=31536000, immutable',
+    );
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    await expect(response.json()).resolves.toMatchObject({ version: '1.2.3' });
+  });
+
+  it('returns 404 when the artifact is missing or has another version', async () => {
+    process.env.VPAT_REPORT_JSON = report;
+
+    const response = await GET(new Request('https://example.com'), {
+      params: Promise.resolve({ version: '1.2.4.json' }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'VPAT report not found' });
+  });
+
+  it('returns 404 for malformed encoded versions', async () => {
+    const response = await GET(new Request('https://example.com'), {
+      params: Promise.resolve({ version: '%E0%A4%A.json' }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/accessibility/vpat/[version]/route.ts
+++ b/src/app/api/accessibility/vpat/[version]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import {
+  VPAT_CDN_CACHE_CONTROL,
+  parsePublishedVPATReport,
+} from '@/lib/accessibilityReporting';
+
+export const runtime = 'edge';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ version: string }> },
+): Promise<NextResponse> {
+  const { version: rawVersion } = await params;
+  let version: string;
+  try {
+    version = decodeURIComponent(rawVersion).replace(/\.json$/, '');
+  } catch {
+    return NextResponse.json({ error: 'VPAT report not found' }, { status: 404 });
+  }
+  const reportJson = process.env.VPAT_REPORT_JSON;
+  const report = reportJson ? parsePublishedVPATReport(reportJson, version) : null;
+
+  if (!report) {
+    return NextResponse.json({ error: 'VPAT report not found' }, { status: 404 });
+  }
+
+  const response = NextResponse.json(report, {
+    headers: {
+      'Cache-Control': VPAT_CDN_CACHE_CONTROL,
+      'Content-Disposition': `inline; filename="vpat-${version}.json"`,
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+  response.headers.set('CDN-Cache-Control', VPAT_CDN_CACHE_CONTROL);
+  response.headers.set('Surrogate-Control', VPAT_CDN_CACHE_CONTROL);
+  return response;
+}

--- a/src/lib/__tests__/accessibilityReporting.test.ts
+++ b/src/lib/__tests__/accessibilityReporting.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  VPAT_CDN_CACHE_CONTROL,
+  getVPATCDNUrl,
+  parsePublishedVPATReport,
+} from '../accessibilityReporting';
+
+const report = JSON.stringify({
+  id: 'vpat-mly8g4c0',
+  productName: 'TeachLink',
+  version: '1.2.3',
+  generatedAt: '2026-08-25T00:00:00.000Z',
+  findings: [
+    {
+      criterionId: '1.1.1',
+      level: 'supports',
+      remark: 'Images have alternative text.',
+    },
+  ],
+});
+
+describe('VPAT CDN integration', () => {
+  it('builds a versioned relative CDN URL', () => {
+    expect(getVPATCDNUrl('1.2.3')).toBe('/api/accessibility/vpat/1.2.3.json');
+  });
+
+  it('supports a configured CDN origin and preserves its path', () => {
+    expect(getVPATCDNUrl('2026.08', 'https://cdn.example.com/compliance')).toBe(
+      'https://cdn.example.com/compliance/api/accessibility/vpat/2026.08.json',
+    );
+  });
+
+  it('rejects path traversal and unsafe CDN origins', () => {
+    expect(() => getVPATCDNUrl('../latest')).toThrow();
+    expect(() => getVPATCDNUrl('1.0', 'javascript:alert(1)')).toThrow();
+  });
+
+  it('parses only a report matching the requested immutable version', () => {
+    expect(parsePublishedVPATReport(report, '1.2.3')?.productName).toBe('TeachLink');
+    expect(parsePublishedVPATReport(report, '1.2.4')).toBeNull();
+    expect(parsePublishedVPATReport('{"version":"1.2.3"}', '1.2.3')).toBeNull();
+  });
+
+  it('uses immutable cache directives for versioned reports', () => {
+    expect(VPAT_CDN_CACHE_CONTROL).toContain('immutable');
+    expect(VPAT_CDN_CACHE_CONTROL).toContain('s-maxage=31536000');
+  });
+});

--- a/src/lib/accessibilityReporting.ts
+++ b/src/lib/accessibilityReporting.ts
@@ -37,6 +37,75 @@ export interface VPATReport {
   findings: AccessibilityFinding[];
 }
 
+export const VPAT_CDN_CACHE_CONTROL =
+  'public, max-age=31536000, s-maxage=31536000, immutable';
+
+const VPAT_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export function isValidVPATVersion(version: string): boolean {
+  return VPAT_VERSION_PATTERN.test(version);
+}
+
+export function getVPATCDNUrl(
+  version: string,
+  cdnBaseUrl = process.env.NEXT_PUBLIC_VPAT_CDN_URL,
+): string {
+  if (!isValidVPATVersion(version)) {
+    throw new Error('VPAT CDN: version must contain only letters, numbers, dots, underscores, or hyphens');
+  }
+
+  const assetPath = `/api/accessibility/vpat/${encodeURIComponent(version)}.json`;
+  if (!cdnBaseUrl) return assetPath;
+
+  const base = new URL(cdnBaseUrl);
+  if (base.protocol !== 'https:' && base.protocol !== 'http:') {
+    throw new Error('VPAT CDN: base URL must use HTTP or HTTPS');
+  }
+  base.pathname = `${base.pathname.replace(/\/$/, '')}${assetPath}`;
+  base.search = '';
+  base.hash = '';
+  return base.toString();
+}
+
+export function parsePublishedVPATReport(raw: string, version: string): VPATReport | null {
+  if (!isValidVPATVersion(version)) return null;
+
+  try {
+    const report: unknown = JSON.parse(raw);
+    if (!report || typeof report !== 'object') return null;
+    const candidate = report as Partial<VPATReport>;
+    if (
+      typeof candidate.id !== 'string' ||
+      !candidate.id.trim() ||
+      candidate.version !== version ||
+      typeof candidate.productName !== 'string' ||
+      typeof candidate.generatedAt !== 'string' ||
+      !Array.isArray(candidate.findings)
+    ) {
+      return null;
+    }
+    for (const finding of candidate.findings) {
+      if (
+        !finding ||
+        typeof finding !== 'object' ||
+        typeof finding.criterionId !== 'string' ||
+        !CRITERION_INDEX.has(finding.criterionId) ||
+        typeof finding.level !== 'string' ||
+        !['supports', 'partially-supports', 'does-not-support', 'not-applicable'].includes(
+          finding.level,
+        ) ||
+        typeof finding.remark !== 'string' ||
+        !finding.remark.trim()
+      ) {
+        return null;
+      }
+    }
+    return candidate as VPATReport;
+  } catch {
+    return null;
+  }
+}
+
 export const WCAG_CRITERIA: WCAGCriterion[] = [
   { id: '1.1.1', name: 'Non-text Content', level: 'A' },
   { id: '1.3.1', name: 'Info and Relationships', level: 'A' },


### PR DESCRIPTION
## Summary

Closes #367

Adds production-ready CDN delivery for Voluntary Product Accessibility Template (VPAT) JSON reports.

## What changed

- Added versioned VPAT CDN URL generation with strict input validation.
- Added a read-only edge route at `/api/accessibility/vpat/:version.json`.
- Added deployment-artifact validation so the URL version must match the published report version.
- Added immutable one-year browser and edge cache headers, `nosniff`, and inline JSON content disposition.
- Added support for an optional `NEXT_PUBLIC_VPAT_CDN_URL` origin while retaining a relative route fallback.
- Documented `VPAT_REPORT_JSON` and CDN deployment configuration in the accessibility guide.

## Security and accessibility

- Rejects path traversal, unsafe URL schemes, malformed encodings, invalid criteria, invalid conformance levels, and empty remarks.
- The endpoint is read-only and does not accept report uploads or user-controlled cache keys.
- Reports should contain no personal data or credentials; this requirement is documented for deployment.
- JSON responses include `X-Content-Type-Options: nosniff`.

## Verification

- `pnpm vitest run src/lib/__tests__/accessibilityReporting.test.ts 'src/app/api/accessibility/vpat/[version]/__tests__/route.test.ts'`
- `pnpm type-check`
- Focused ESLint run completed with no errors; the repository emits existing `.eslintignore` deprecation/ignored-file warnings.
- `git diff --check`

## Deployment notes

Set `VPAT_REPORT_JSON` to the exported report artifact at deployment time. For a dedicated CDN origin, set `NEXT_PUBLIC_VPAT_CDN_URL`; the generated URL remains versioned so old reports can be cached safely and new versions can be released without stale content.