### PR TITLE
refactor(markdown-renderer): implement line-clustering algorithm for markdown parsing

### DIFF
--- a/src/components/shared/MarkdownRenderer.test.ts
+++ b/src/components/shared/MarkdownRenderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { markdownToHtml } from './MarkdownRenderer';
+import { markdownToHtml, clusterMarkdownLines } from './MarkdownRenderer';
 
 // Tests cover the pure markdownToHtml function (no DOM/React needed).
 
@@ -193,5 +193,119 @@ describe('markdownToHtml', () => {
     const html = markdownToHtml(md);
     expect(html).toContain('<th>A</th>');
     expect(html).toContain('<td>1</td>');
+  });
+});
+
+// ── Clustering algorithm ───────────────────────────────────────────────────
+//
+// markdownToHtml partitions the source into typed line clusters (heading,
+// list, table, code, paragraph, ...) before any inline formatting is
+// applied. These tests exercise the clustering step directly, plus the
+// cluster-isolation bug it fixes: a whole-document regex chain lets rules
+// meant for prose (bold/italic/inline-code/links) leak into fenced code
+// blocks that happen to contain the same characters.
+
+describe('clusterMarkdownLines', () => {
+  it('groups consecutive unordered list lines into a single cluster', () => {
+    const clusters = clusterMarkdownLines('- Alpha\n- Beta\n- Gamma');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]).toMatchObject({
+      type: 'unordered-list',
+      lines: ['- Alpha', '- Beta', '- Gamma'],
+    });
+  });
+
+  it('splits a heading, a list, and a paragraph into separate clusters', () => {
+    const clusters = clusterMarkdownLines('# Title\n- item one\n- item two\n\nSome text');
+    expect(clusters.map((c) => c.type)).toEqual(['heading', 'unordered-list', 'blank', 'paragraph']);
+  });
+
+  it('keeps a fenced code block as a single cluster distinct from surrounding paragraphs', () => {
+    const md = 'before\n\n```js\nconst x = 1;\n```\n\nafter';
+    const clusters = clusterMarkdownLines(md);
+    const codeCluster = clusters.find((c) => c.type === 'code');
+    expect(codeCluster).toBeDefined();
+    expect(codeCluster!.lines).toEqual(['```js', 'const x = 1;', '```']);
+  });
+
+  it('classifies task list lines separately from plain unordered list lines', () => {
+    const clusters = clusterMarkdownLines('- [ ] task\n- plain item');
+    expect(clusters.map((c) => c.type)).toEqual(['task-list', 'unordered-list']);
+  });
+
+  it('treats a single pipe-containing line without a separator row as a paragraph, not a table', () => {
+    const clusters = clusterMarkdownLines('Cost is $5 | discount available');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].type).toBe('paragraph');
+  });
+
+  it('merges a stray pipe line back into a surrounding paragraph run', () => {
+    // "Second" ends up briefly mis-classified as a failed table candidate;
+    // it must still end up in the same paragraph as its neighbors so the
+    // rendered output matches a single run of text with no blank line breaks.
+    const clusters = clusterMarkdownLines('First line\nSecond | line\nThird line');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]).toMatchObject({
+      type: 'paragraph',
+      lines: ['First line', 'Second | line', 'Third line'],
+    });
+  });
+
+  it('recognizes a valid GFM table as one cluster', () => {
+    const md = '| Name | Age |\n| --- | --- |\n| Alice | 30 |';
+    const clusters = clusterMarkdownLines(md);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].type).toBe('table');
+  });
+});
+
+describe('markdownToHtml — cluster isolation regression tests', () => {
+  it('does not apply inline code formatting to backticks inside a fenced code block', () => {
+    const md = '```\nUse `x` here\n```';
+    const html = markdownToHtml(md);
+    expect(html).toBe('<pre><code>Use `x` here</code></pre>');
+    expect(html).not.toContain('<code>x</code>');
+  });
+
+  it('does not apply bold/italic formatting inside a fenced code block', () => {
+    const md = '```\nconst bold = **not bold**;\nconst em = _not em_;\n```';
+    const html = markdownToHtml(md);
+    expect(html).toContain('**not bold**');
+    expect(html).toContain('_not em_');
+    expect(html).not.toContain('<strong>');
+    expect(html).not.toContain('<em>');
+  });
+
+  it('does not turn link syntax inside a fenced code block into an anchor tag', () => {
+    const md = '```md\n[label](https://example.com)\n```';
+    const html = markdownToHtml(md);
+    expect(html).not.toContain('<a href=');
+    expect(html).toContain('[label](https://example.com)');
+  });
+
+  it('still applies inline formatting to a paragraph following a code block', () => {
+    const md = '```\ncode\n```\n\nThis is **bold** after code.';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('renders a heading immediately followed by a list without losing either', () => {
+    const md = '## Section\n- one\n- two';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<h2>Section</h2>');
+    expect(html).toContain('<ul><li>one</li><li>two</li></ul>');
+  });
+
+  it('applies inline formatting inside table cells', () => {
+    const md = '| Name |\n| --- |\n| **Alice** |';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<td><strong>Alice</strong></td>');
+  });
+
+  it('handles an unterminated fenced code block by escaping its content instead of leaving it unprocessed', () => {
+    const md = '```\n<script>evil()</script>';
+    const html = markdownToHtml(md);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
   });
 });

--- a/src/components/shared/MarkdownRenderer.tsx
+++ b/src/components/shared/MarkdownRenderer.tsx
@@ -23,123 +23,232 @@ import { useMemo } from 'react';
  * - Horizontal rules: `---`
  * - Paragraphs: blank-line separated runs of text
  *
+ * Conversion works in two stages:
+ * 1. Clustering — `clusterMarkdownLines` walks the source line-by-line and
+ *    groups consecutive lines into typed clusters (heading, list, table,
+ *    code, paragraph, ...). Clustering happens before any inline formatting
+ *    is applied, so each cluster is rendered in isolation with only the
+ *    rules that apply to its type. This is what keeps, e.g., fenced code
+ *    content from being re-processed by the bold/italic/inline-code rules
+ *    meant for prose (a real bug in a single whole-document regex chain).
+ * 2. Rendering — each cluster is converted to its HTML block.
+ *
  * Output is sanitized with DOMPurify before rendering.
  */
+
+type ClusterType =
+  | 'code'
+  | 'heading'
+  | 'hr'
+  | 'blockquote'
+  | 'unordered-list'
+  | 'ordered-list'
+  | 'task-list'
+  | 'table'
+  | 'paragraph'
+  | 'blank';
+
+export interface MarkdownCluster {
+  type: ClusterType;
+  lines: string[];
+}
+
+const FENCE_RE = /^```/;
+const HEADING_RE = /^(#{1,3})\s+(.+)$/;
+const HR_RE = /^---$/;
+const BLOCKQUOTE_RE = /^> (.+)$/;
+const TASK_RE = /^[*-] \[( |x)\] (.+)$/;
+const UNORDERED_RE = /^[*-] (.+)$/;
+const ORDERED_RE = /^\d+\. (.+)$/;
+const TABLE_SEPARATOR_RE = /^[\s|:-]+$/;
+
+function classifyLine(line: string): ClusterType {
+  if (line.trim() === '') return 'blank';
+  if (HR_RE.test(line)) return 'hr';
+  if (HEADING_RE.test(line)) return 'heading';
+  if (TASK_RE.test(line)) return 'task-list';
+  if (UNORDERED_RE.test(line)) return 'unordered-list';
+  if (ORDERED_RE.test(line)) return 'ordered-list';
+  if (BLOCKQUOTE_RE.test(line)) return 'blockquote';
+  if (line.includes('|')) return 'table';
+  return 'paragraph';
+}
+
+/**
+ * Partitions Markdown source into typed line clusters (the "clustering"
+ * step of the renderer). Each cluster is a contiguous run of lines that
+ * share a block type, ready to be rendered independently.
+ */
+export function clusterMarkdownLines(markdown: string): MarkdownCluster[] {
+  const lines = markdown.split('\n');
+  const clusters: MarkdownCluster[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code blocks are consumed verbatim up to the closing fence (or
+    // end of input) so their contents never reach the inline-formatting step.
+    if (FENCE_RE.test(line)) {
+      const fenceLines = [line];
+      i++;
+      while (i < lines.length && !FENCE_RE.test(lines[i])) {
+        fenceLines.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) {
+        fenceLines.push(lines[i]);
+        i++;
+      }
+      clusters.push({ type: 'code', lines: fenceLines });
+      continue;
+    }
+
+    const type = classifyLine(line);
+
+    // Single-line cluster types never merge with neighbors.
+    if (type === 'blank' || type === 'hr' || type === 'heading') {
+      clusters.push({ type, lines: [line] });
+      i++;
+      continue;
+    }
+
+    if (type === 'table') {
+      const tableLines = [line];
+      i++;
+      while (i < lines.length && lines[i].includes('|')) {
+        tableLines.push(lines[i]);
+        i++;
+      }
+      const isValidTable = tableLines.length >= 2 && TABLE_SEPARATOR_RE.test(tableLines[1].trim());
+      clusters.push({ type: isValidTable ? 'table' : 'paragraph', lines: tableLines });
+      continue;
+    }
+
+    // Remaining grouping types: blockquote, unordered-list, ordered-list,
+    // task-list, paragraph — merge consecutive lines of the same type.
+    const groupLines = [line];
+    i++;
+    while (i < lines.length && !FENCE_RE.test(lines[i]) && classifyLine(lines[i]) === type) {
+      groupLines.push(lines[i]);
+      i++;
+    }
+    clusters.push({ type, lines: groupLines });
+  }
+
+  return mergeAdjacentParagraphs(clusters);
+}
+
+// A table candidate that fails validation falls back to 'paragraph', which
+// may leave two paragraph clusters sitting next to each other with no blank
+// line between them (e.g. plain text followed directly by a line containing
+// a stray "|"). Merge those back into one paragraph, matching how a single
+// run of non-blank text is treated everywhere else.
+function mergeAdjacentParagraphs(clusters: MarkdownCluster[]): MarkdownCluster[] {
+  const merged: MarkdownCluster[] = [];
+  for (const cluster of clusters) {
+    const prev = merged[merged.length - 1];
+    if (cluster.type === 'paragraph' && prev?.type === 'paragraph') {
+      prev.lines.push(...cluster.lines);
+    } else {
+      merged.push({ type: cluster.type, lines: [...cluster.lines] });
+    }
+  }
+  return merged;
+}
+
+function applyInline(text: string): string {
+  let out = text;
+  out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  out = out.replace(/__(.+?)__/g, '<strong>$1</strong>');
+  out = out.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
+  out = out.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, '<em>$1</em>');
+  out = out.replace(/~~(.+?)~~/g, '<del>$1</del>');
+  out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+  out = out.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />');
+  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  return out;
+}
+
+function renderCodeCluster(lines: string[]): string {
+  const openMatch = lines[0].match(/^```([^\n]*)$/);
+  const lang = openMatch ? openMatch[1].trim() : '';
+  const hasClosingFence = lines.length > 1 && FENCE_RE.test(lines[lines.length - 1]);
+  const codeLines = hasClosingFence ? lines.slice(1, -1) : lines.slice(1);
+  const langAttr = lang ? ` class="language-${lang}"` : '';
+  return `<pre><code${langAttr}>${escapeHtml(codeLines.join('\n').trimEnd())}</code></pre>`;
+}
+
+function renderTableCluster(lines: string[]): string {
+  const isSeparator = (l: string) => TABLE_SEPARATOR_RE.test(l.trim());
+  const parseRow = (line: string) =>
+    line
+      .trim()
+      .replace(/^\||\|$/g, '')
+      .split('|')
+      .map((cell) => applyInline(cell.trim()));
+
+  const headers = parseRow(lines[0]);
+  const thead = `<thead><tr>${headers.map((h) => `<th>${h}</th>`).join('')}</tr></thead>`;
+  const bodyRows = lines
+    .slice(2)
+    .filter((l) => l.trim() && !isSeparator(l))
+    .map((l) => `<tr>${parseRow(l).map((c) => `<td>${c}</td>`).join('')}</tr>`)
+    .join('');
+  return `<table>${thead}<tbody>${bodyRows}</tbody></table>`;
+}
+
+function renderTaskItem(line: string): string {
+  const match = line.match(TASK_RE);
+  if (!match) return '';
+  const [, checkedMark, label] = match;
+  const attrs = checkedMark === 'x' ? ' checked disabled' : ' disabled';
+  return `<li class="task-item"><input type="checkbox"${attrs} /> ${applyInline(label)}</li>`;
+}
+
+function renderCluster(cluster: MarkdownCluster): string {
+  switch (cluster.type) {
+    case 'blank':
+      return '';
+    case 'code':
+      return renderCodeCluster(cluster.lines);
+    case 'hr':
+      return '<hr />';
+    case 'heading': {
+      const match = cluster.lines[0].match(HEADING_RE)!;
+      const level = match[1].length;
+      return `<h${level}>${applyInline(match[2])}</h${level}>`;
+    }
+    case 'blockquote':
+      return cluster.lines
+        .map((l) => `<blockquote>${applyInline(l.replace(/^> /, ''))}</blockquote>`)
+        .join('\n');
+    case 'unordered-list':
+      return `<ul>${cluster.lines
+        .map((l) => `<li>${applyInline(l.replace(/^[*-] /, ''))}</li>`)
+        .join('')}</ul>`;
+    case 'ordered-list':
+      return `<ol>${cluster.lines
+        .map((l) => `<li>${applyInline(l.replace(/^\d+\. /, ''))}</li>`)
+        .join('')}</ol>`;
+    case 'task-list':
+      return `<ul class="task-list">${cluster.lines.map(renderTaskItem).join('')}</ul>`;
+    case 'table':
+      return renderTableCluster(cluster.lines);
+    case 'paragraph':
+      return `<p>${applyInline(cluster.lines.join('\n')).replace(/\n/g, '<br />')}</p>`;
+    default:
+      return '';
+  }
+}
+
 export function markdownToHtml(markdown: string): string {
   if (!markdown) return '';
 
-  let html = markdown;
-
-  // Fenced code blocks (must run before inline code to avoid nested matches)
-  html = html.replace(/```([^\n]*)\n([\s\S]*?)```/g, (_match, lang, code) => {
-    const langAttr = lang.trim() ? ` class="language-${lang.trim()}"` : '';
-    return `<pre><code${langAttr}>${escapeHtml(code.trimEnd())}</code></pre>`;
-  });
-
-  // GFM tables — must run before other block rules
-  html = html.replace(/((?:^[^\n]*\|[^\n]*(?:\n|$))+)/gm, (block) => {
-    const lines = block.trim().split('\n');
-    if (lines.length < 2) return block;
-    const isSeparator = (l: string) => /^[\s|:-]+$/.test(l);
-    const sepIdx = lines.findIndex(isSeparator);
-    if (sepIdx < 1) return block;
-
-    const parseRow = (line: string) =>
-      line
-        .replace(/^\||\|$/g, '')
-        .split('|')
-        .map((cell) => cell.trim());
-
-    const headers = parseRow(lines[0]);
-    const thead = `<thead><tr>${headers.map((h) => `<th>${h}</th>`).join('')}</tr></thead>`;
-    const bodyRows = lines
-      .slice(sepIdx + 1)
-      .filter((l) => l.trim() && !isSeparator(l))
-      .map(
-        (l) =>
-          `<tr>${parseRow(l)
-            .map((c) => `<td>${c}</td>`)
-            .join('')}</tr>`,
-      )
-      .join('');
-    return `<table>${thead}<tbody>${bodyRows}</tbody></table>`;
-  });
-
-  // Task lists — must run before unordered list rule
-  html = html.replace(/^[*-] \[( |x)\] (.+)$/gm, (_m, checked, label) => {
-    const attrs = checked === 'x' ? ' checked disabled' : ' disabled';
-    return `<li class="task-item"><input type="checkbox"${attrs} /> ${label}</li>`;
-  });
-
-  // Wrap consecutive task-list <li> items in <ul class="task-list">
-  html = html.replace(/((?:<li class="task-item">.*<\/li>\n?)+)/g, (block) => {
-    return `<ul class="task-list">${block}</ul>`;
-  });
-
-  // Headings
-  html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
-  html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
-  html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
-
-  // Horizontal rules
-  html = html.replace(/^---$/gm, '<hr />');
-
-  // Blockquotes
-  html = html.replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>');
-
-  // Unordered lists — group consecutive `- ` or `* ` lines
-  html = html.replace(/((?:^[*-] .+\n?)+)/gm, (block) => {
-    const items = block
-      .trim()
-      .split('\n')
-      .map((line) => `<li>${line.replace(/^[*-] /, '')}</li>`)
-      .join('');
-    return `<ul>${items}</ul>`;
-  });
-
-  // Ordered lists — group consecutive `N. ` lines
-  html = html.replace(/((?:^\d+\. .+\n?)+)/gm, (block) => {
-    const items = block
-      .trim()
-      .split('\n')
-      .map((line) => `<li>${line.replace(/^\d+\. /, '')}</li>`)
-      .join('');
-    return `<ol>${items}</ol>`;
-  });
-
-  // Bold (** or __)
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-  html = html.replace(/__(.+?)__/g, '<strong>$1</strong>');
-
-  // Italic (* or _) — exclude already-processed ** / __
-  html = html.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
-  html = html.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, '<em>$1</em>');
-
-  // Strikethrough (GFM)
-  html = html.replace(/~~(.+?)~~/g, '<del>$1</del>');
-
-  // Inline code
-  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
-
-  // Images (before links so they're not confused)
-  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />');
-
-  // Links
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-
-  // Paragraphs: wrap lines not already inside a block element
-  html = html
-    .split(/\n{2,}/)
-    .map((block) => {
-      const trimmed = block.trim();
-      if (!trimmed) return '';
-      const isBlock = /^<(h[1-6]|ul|ol|li|blockquote|pre|hr)/.test(trimmed);
-      return isBlock ? trimmed : `<p>${trimmed.replace(/\n/g, '<br />')}</p>`;
-    })
-    .filter(Boolean)
+  return clusterMarkdownLines(markdown)
+    .map(renderCluster)
+    .filter((html) => html !== '')
     .join('\n');
-
-  return html;
 }
 
 function escapeHtml(raw: string): string {


### PR DESCRIPTION
Closes #371

## Summary

Implements a clustering algorithm for `MarkdownRenderer`'s markdown-to-HTML conversion, replacing the previous whole-document regex-chain approach with a two-stage pipeline:

1. **Clustering** — `clusterMarkdownLines()` walks the markdown source line-by-line and groups consecutive lines into typed clusters: `heading`, `hr`, `blockquote`, `unordered-list`, `ordered-list`, `task-list`, `table`, `code`, `paragraph`, `blank`.
2. **Rendering** — each cluster is converted to its HTML block in isolation (`renderCluster`), applying only the formatting rules relevant to that cluster's type.

This fixes a real bug in the previous implementation: because the old code ran a single sequential chain of regex replacements over the entire document string, inline formatting rules (bold, italic, inline code, links) could incorrectly match and alter content sitting inside fenced code blocks (e.g. `**not bold**` inside a code fence would get converted to `<strong>`). Clustering isolates fenced code content from the inline-formatting pass entirely, since it's captured verbatim before any other rule runs.

## Implementation details

- `clusterMarkdownLines(markdown: string): MarkdownCluster[]` (exported) — the core clustering step. Handles:
  - Fenced code blocks consumed verbatim between opening/closing ``` fences (or to end of input if unterminated).
  - Single-line cluster types (`blank`, `hr`, `heading`) that never merge with neighbors.
  - GFM tables — validated by checking the second line matches a table separator (`---`/`:--`/etc.); invalid pipe-containing lines fall back to `paragraph`.
  - Grouping types (`blockquote`, `unordered-list`, `ordered-list`, `task-list`, `paragraph`) that merge consecutive lines of the same classified type.
  - `mergeAdjacentParagraphs()` — merges paragraph clusters that end up adjacent after a failed table candidate falls back to `paragraph`, so a stray `|` in prose doesn't introduce a spurious line break.
- `classifyLine(line: string): ClusterType` — classifies a single line by testing it against per-type regexes (`HEADING_RE`, `HR_RE`, `TASK_RE`, `UNORDERED_RE`, `ORDERED_RE`, `BLOCKQUOTE_RE`, and a pipe-check for tables).
- `applyInline(text: string): string` — inline formatting (bold, italic, strikethrough, inline code, images, links), applied only to cluster content that should receive it (not to code cluster contents).
- `renderCluster(cluster: MarkdownCluster): string` — dispatches each cluster to its own render function (`renderCodeCluster`, `renderTableCluster`, `renderTaskItem`, plus inline cases for heading/blockquote/lists/paragraph/hr/blank).
- `markdownToHtml(markdown: string): string` — now simply clusters the input and maps/joins the rendered output, replacing the old ~90-line sequential regex-replacement chain.
- `MarkdownCluster` (exported interface) — `{ type: ClusterType; lines: string[] }`.

No changes to the public `MarkdownRenderer` component API (`content`, `className` props) or to DOMPurify sanitization — output HTML shape for previously-supported syntax is preserved (existing test cases for headings, lists, tables, etc. still pass unmodified against the new implementation).

## Files changed

**Modified:**
- `src/components/shared/MarkdownRenderer.tsx` — core clustering algorithm and renderer implementation.
- `src/components/shared/MarkdownRenderer.test.ts` — new test coverage for the clustering step and cluster-isolation behavior (existing tests unchanged).

No new files were added; the clustering logic lives alongside the existing renderer in the same module and is exported (`clusterMarkdownLines`, `MarkdownCluster`) for direct testing.

## Tests added

New `describe('clusterMarkdownLines', ...)` block:
- Groups consecutive unordered-list lines into a single cluster.
- Splits a heading, a list, and a paragraph into separate clusters.
- Keeps a fenced code block as a single cluster distinct from surrounding paragraphs.
- Classifies task-list lines separately from plain unordered-list lines.
- Treats a single pipe-containing line without a separator row as a paragraph, not a table.
- Merges a stray pipe line back into a surrounding paragraph run (via `mergeAdjacentParagraphs`).
- Recognizes a valid GFM table as one cluster.

New `describe('markdownToHtml — cluster isolation regression tests', ...)` block:
- Inline code formatting is not applied to backticks inside a fenced code block.
- Bold/italic formatting is not applied inside a fenced code block.
- Link syntax inside a fenced code block is not converted to an anchor tag.
- Inline formatting still applies to a paragraph immediately following a code block.
- A heading immediately followed by a list renders both correctly.
- Inline formatting is applied inside table cells.
- An unterminated fenced code block has its content escaped rather than left unprocessed.

All 43 tests in `MarkdownRenderer.test.ts` pass (`npx vitest run src/components/shared/MarkdownRenderer.test.ts`), and `tsc --noEmit` reports no type errors.

## How to test

1. `pnpm install` (if not already done)
2. `npx vitest run src/components/shared/MarkdownRenderer.test.ts` — verifies all clustering and rendering behavior, including the isolation regression tests.
3. `npx tsc --noEmit` — verifies no type regressions.
4. Manually: render `<MarkdownRenderer content="..." />` with markdown containing a fenced code block whose content includes `**`, `` ` ``, or `[label](url)` sequences, and confirm they render as literal text inside `<pre><code>` rather than being converted to `<strong>`/`<code>`/`<a>`.