### PR TITLE
fix: define missing variables in courses list route

### DIFF
--- a/src/app/api/courses/__tests__/route.test.ts
+++ b/src/app/api/courses/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { resetCourseListConfig } from '@/lib/course-config';
+
+function makeRequest(query = ''): Request {
+  return new Request(`http://localhost/api/courses${query}`, {
+    headers: { 'x-forwarded-for': `10.20.30.${Math.floor(Math.random() * 254) + 1}` },
+  });
+}
+
+describe('/api/courses GET', () => {
+  beforeEach(() => {
+    resetCourseListConfig();
+  });
+
+  it('returns 200 with a paginated list of courses', async () => {
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data.length).toBeGreaterThan(0);
+    expect(json.total).toBe(6);
+  });
+
+  it('paginates using limit and cursor', async () => {
+    const first = await GET(makeRequest('?limit=2'));
+    const firstJson = await first.json();
+
+    expect(firstJson.data).toHaveLength(2);
+    expect(firstJson.nextCursor).toBe('2');
+
+    const second = await GET(makeRequest(`?limit=2&cursor=${firstJson.nextCursor}`));
+    const secondJson = await second.json();
+
+    expect(secondJson.data).toHaveLength(2);
+    expect(secondJson.nextCursor).toBe('4');
+  });
+
+  it('filters by the featured flag', async () => {
+    const response = await GET(makeRequest('?featured=true'));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.length).toBeGreaterThan(0);
+    for (const course of json.data) {
+      expect(course.featured).toBe(true);
+    }
+  });
+
+  it('excludes non-featured courses when featured=false', async () => {
+    const response = await GET(makeRequest('?featured=false'));
+    const json = await response.json();
+
+    for (const course of json.data) {
+      expect(course.featured).toBe(false);
+    }
+  });
+
+  it('omits nextCursor on the last page', async () => {
+    const response = await GET(makeRequest('?limit=100'));
+    const json = await response.json();
+
+    expect(json.nextCursor).toBeUndefined();
+  });
+
+  it('returns all required variables declared and typed correctly', async () => {
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(json).toHaveProperty('data');
+    expect(json).toHaveProperty('total');
+    expect(typeof json.total).toBe('number');
+  });
+});

--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -4,6 +4,7 @@ import { edgeLog, CDN_CACHE_HEADERS } from '@/../infra/edge-config';
 import { validateQuery } from '@/lib/validation';
 import { CourseListQuerySchema } from '@/types/api/courses.dto';
 import type { CourseListResponseDTO } from '@/types/api/courses.dto';
+import { getPaginatedCourses } from '@/lib/course-config';
 import {
   withSecurityHeaders,
   validateQuerySafety,
@@ -36,17 +37,21 @@ export async function GET(request: Request): Promise<NextResponse<CourseListResp
   const result = validateQuery(CourseListQuerySchema, searchParams);
   if (!result.ok)
     return withSecurityHeaders(addHeaders(result.error)) as NextResponse<CourseListResponseDTO>;
-  const { limit, cursor } = result.data as { limit: number; cursor?: string };
+  const { limit, cursor, featured } = result.data as {
+    limit: number;
+    cursor?: string;
+    featured?: boolean;
+  };
 
-  const paginated = getPaginatedCourses(limit, cursor, { featured });
+  const { data: courses, total, nextCursor } = getPaginatedCourses(limit, cursor, { featured });
 
-  const sanitizedPage = sanitizeObject(page);
+  const sanitizedPage = sanitizeObject(courses);
 
   const response = withSecurityHeaders(
     addHeaders(
       NextResponse.json({
         data: sanitizedPage,
-        total: courses.length,
+        total,
         nextCursor,
       }),
     ),


### PR DESCRIPTION
## Description

The `/api/courses` GET handler referenced several undefined variables and an undefined function, causing every request to throw a runtime error.

## Changes

- Import `getPaginatedCourses` from `src/lib/course-config`, which already implements cursor-based pagination and featured filtering
- Destructure `featured` from the validated query result instead of referencing an undefined variable
- Destructure `courses`, `total`, and `nextCursor` from the `getPaginatedCourses` return value instead of referencing undefined variables
- Add integration tests covering pagination, the featured filter, and response shape

## Testing

- Added `src/app/api/courses/__tests__/route.test.ts` covering pagination, cursor advancement, the featured filter, and response shape

Closes #702