### PR TITLE
feat: add AudioWaveform visualization component

### DIFF
--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { AccessibleLoading } from '@/app/components/accessibility/ScreenReaderOptimizer'; // reuse existing loading component
+import { AudioWaveform } from './AudioWaveform';
 
 export interface AudioPlayerProps {
   /** URL of the audio source */
@@ -9,6 +10,8 @@ export interface AudioPlayerProps {
   autoPlay?: boolean;
   /** Show native controls */
   controls?: boolean;
+  /** Show a live frequency-bar waveform above the native controls */
+  showWaveform?: boolean;
   /** Additional class names for wrapper */
   className?: string;
 }
@@ -23,11 +26,13 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
   src,
   autoPlay = false,
   controls = true,
+  showWaveform = true,
   className = '',
 }) => {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
+  const [isPlaying, setIsPlaying] = useState<boolean>(false);
 
   // Reset state when source changes
   useEffect(() => {
@@ -57,6 +62,23 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
       audio.removeEventListener('canplay', handleCanPlay);
       audio.removeEventListener('stalled', handleStalled);
       audio.removeEventListener('error', handleError);
+    };
+  }, [src]);
+
+  // Track play/pause state so the waveform animation only runs while audible.
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const handlePlay = () => setIsPlaying(true);
+    const handlePauseOrEnd = () => setIsPlaying(false);
+
+    audio.addEventListener('play', handlePlay);
+    audio.addEventListener('pause', handlePauseOrEnd);
+    audio.addEventListener('ended', handlePauseOrEnd);
+    return () => {
+      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('pause', handlePauseOrEnd);
+      audio.removeEventListener('ended', handlePauseOrEnd);
     };
   }, [src]);
 
@@ -117,6 +139,10 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
           </motion.div>
         )}
       </AnimatePresence>
+
+      {showWaveform && !hasError && (
+        <AudioWaveform audioRef={audioRef} isPlaying={isPlaying} className="mb-1" />
+      )}
 
       {/* Native audio element – always present but hidden behind the loader */}
       <audio

--- a/src/components/audio/AudioWaveform.tsx
+++ b/src/components/audio/AudioWaveform.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface AudioWaveformProps {
+  /** Ref to the <audio> element to visualize. */
+  audioRef: React.RefObject<HTMLAudioElement | null>;
+  /** Whether the audio is currently playing – drives the animation loop. */
+  isPlaying: boolean;
+  /** Number of bars rendered across the canvas width. */
+  barCount?: number;
+  /** Bar fill color (any valid canvas fillStyle). */
+  barColor?: string;
+  /** Additional class names for the canvas element. */
+  className?: string;
+}
+
+/**
+ * AudioWaveform – draws a live frequency-bar visualization for an <audio> element
+ * using the Web Audio API's AnalyserNode. Falls back to an empty canvas when the
+ * Web Audio API is unavailable (e.g. unsupported browsers or non-DOM test
+ * environments) instead of throwing.
+ */
+export const AudioWaveform: React.FC<AudioWaveformProps> = ({
+  audioRef,
+  isPlaying,
+  barCount = 32,
+  barColor = '#4f46e5',
+  className = '',
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  // Lazily set up the AudioContext/AnalyserNode graph once per audio element.
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || analyserRef.current) return;
+
+    const AudioContextClass =
+      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!AudioContextClass) return;
+
+    try {
+      const audioContext = new AudioContextClass();
+      const source = audioContext.createMediaElementSource(audio);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 128;
+      source.connect(analyser);
+      analyser.connect(audioContext.destination);
+
+      audioContextRef.current = audioContext;
+      analyserRef.current = analyser;
+    } catch {
+      // The element may already be attached to another AudioContext, or the
+      // browser may block AudioContext creation before a user gesture.
+      analyserRef.current = null;
+    }
+
+    return () => {
+      audioContextRef.current?.close().catch(() => undefined);
+      audioContextRef.current = null;
+      analyserRef.current = null;
+    };
+  }, [audioRef]);
+
+  // Draw loop – only runs while playing and the analyser graph is ready.
+  useEffect(() => {
+    const analyser = analyserRef.current;
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!isPlaying || !analyser || !canvas || !ctx) return;
+
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    const step = Math.max(1, Math.floor(bufferLength / barCount));
+
+    const draw = () => {
+      analyser.getByteFrequencyData(dataArray);
+
+      const { width, height } = canvas;
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = barColor;
+
+      const barWidth = width / barCount;
+      for (let i = 0; i < barCount; i++) {
+        const value = dataArray[i * step] ?? 0;
+        const barHeight = Math.max(2, (value / 255) * height);
+        ctx.fillRect(i * barWidth, height - barHeight, barWidth * 0.7, barHeight);
+      }
+
+      rafRef.current = requestAnimationFrame(draw);
+    };
+
+    rafRef.current = requestAnimationFrame(draw);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [isPlaying, barCount, barColor]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      role="img"
+      aria-label="Audio waveform visualization"
+      width={320}
+      height={48}
+      className={`w-full h-12 ${className}`}
+    />
+  );
+};

--- a/src/components/audio/__tests__/AudioWaveform.test.tsx
+++ b/src/components/audio/__tests__/AudioWaveform.test.tsx
@@ -1,0 +1,30 @@
+import React, { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AudioWaveform } from '../AudioWaveform';
+
+describe('AudioWaveform', () => {
+  it('renders a canvas with an accessible label', () => {
+    const audioRef = createRef<HTMLAudioElement>();
+    render(<AudioWaveform audioRef={audioRef} isPlaying={false} />);
+
+    expect(screen.getByRole('img', { name: 'Audio waveform visualization' })).toBeInTheDocument();
+  });
+
+  it('does not throw when the Web Audio API is unavailable (jsdom default)', () => {
+    const audioRef = createRef<HTMLAudioElement>();
+    expect(() => render(<AudioWaveform audioRef={audioRef} isPlaying />)).not.toThrow();
+  });
+
+  it('does not throw when audioRef.current is null', () => {
+    const audioRef = { current: null } as React.RefObject<HTMLAudioElement>;
+    expect(() => render(<AudioWaveform audioRef={audioRef} isPlaying={false} />)).not.toThrow();
+  });
+
+  it('applies a custom className to the canvas', () => {
+    const audioRef = createRef<HTMLAudioElement>();
+    render(<AudioWaveform audioRef={audioRef} isPlaying={false} className="custom-class" />);
+
+    expect(screen.getByRole('img')).toHaveClass('custom-class');
+  });
+});


### PR DESCRIPTION
## Description

No Audio Waveform component existed in the codebase. This adds a lightweight, dependency-free waveform visualization and wires it into the existing AudioPlayer.

## Changes

- New `AudioWaveform` component that draws a live frequency-bar visualization on a canvas using the Web Audio API's AnalyserNode
- Falls back to an empty canvas without throwing when the Web Audio API is unavailable (unsupported browsers, non-DOM test environments)
- Integrated into `AudioPlayer` behind a `showWaveform` prop (default `true`), driven by play/pause/ended state on the underlying audio element

## Testing

- Added `src/components/audio/__tests__/AudioWaveform.test.tsx` covering rendering, accessible labeling, graceful degradation without the Web Audio API, and a null audio ref

Closes #368