### PR TITLE
fix: correct recurring-event expansion in Calendar

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { Calendar as BigCalendar, dateFnsLocalizer, SlotInfo, Views } from 'react-big-calendar';
-import { format, parse, startOfWeek, getDay, addWeeks, addDays } from 'date-fns';
+import { format, parse, startOfWeek, getDay, addWeeks, addDays, addMonths } from 'date-fns';
 import { enUS } from 'date-fns/locale/en-US';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import type { CalendarEvent } from '@/types/event';
@@ -16,7 +16,7 @@ const localizer = dateFnsLocalizer({
 });
 
 /** Expand a recurring event into instances within a 6-month window */
-function expandRecurring(event: CalendarEvent): CalendarEvent[] {
+export function expandRecurring(event: CalendarEvent): CalendarEvent[] {
   if (!event.recurring || !event.recurrenceRule) return [event];
 
   const instances: CalendarEvent[] = [event];
@@ -27,9 +27,14 @@ function expandRecurring(event: CalendarEvent): CalendarEvent[] {
   const freq = freqMatch?.[1] ?? 'WEEKLY';
 
   let current = event.start;
-  for (let i = 1; i < 52; i++) {
+  let i = 1;
+  while (true) {
     current =
-      freq === 'DAILY' ? addDays(current, 1) : addWeeks(current, freq === 'MONTHLY' ? 4 : 1);
+      freq === 'DAILY'
+        ? addDays(current, 1)
+        : freq === 'MONTHLY'
+          ? addMonths(current, 1)
+          : addWeeks(current, 1);
     if (current > windowEnd) break;
     instances.push({
       ...event,
@@ -37,6 +42,7 @@ function expandRecurring(event: CalendarEvent): CalendarEvent[] {
       start: current,
       end: new Date(current.getTime() + duration),
     });
+    i++;
   }
   return instances;
 }

--- a/src/testing/events/recurrence.test.ts
+++ b/src/testing/events/recurrence.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// react-big-calendar pulls in CSS + heavy component code; mock it so we can import
+// the pure `expandRecurring` helper without rendering the calendar.
+vi.mock('react-big-calendar', () => ({
+  Calendar: () => null,
+  dateFnsLocalizer: () => ({}),
+  Views: {},
+}));
+
+import { expandRecurring } from '@/components/Calendar';
+import type { CalendarEvent } from '@/types/event';
+import { addMonths } from 'date-fns';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function makeEvent(overrides: Partial<CalendarEvent>): CalendarEvent {
+  const start = overrides.start ?? new Date(2026, 0, 5, 9, 0, 0);
+  const end = overrides.end ?? new Date(2026, 0, 5, 10, 0, 0);
+  return {
+    id: 'evt1',
+    title: 'Event',
+    start,
+    end,
+    recurring: true,
+    recurrenceRule: 'FREQ=WEEKLY',
+    ...overrides,
+  };
+}
+
+const gapDays = (a: Date, b: Date) => (b.getTime() - a.getTime()) / DAY;
+
+describe('expandRecurring', () => {
+  it('returns the single event when not recurring', () => {
+    const result = expandRecurring(makeEvent({ recurring: false }));
+    expect(result).toHaveLength(1);
+  });
+
+  it('does not expand when recurrenceRule is missing', () => {
+    expect(expandRecurring(makeEvent({ recurrenceRule: undefined }))).toHaveLength(1);
+  });
+
+  it('WEEKLY steps 7 days apart', () => {
+    const result = expandRecurring(makeEvent({ recurrenceRule: 'FREQ=WEEKLY' }));
+    expect(result.length).toBeGreaterThan(20);
+    expect(result[1].id).toBe('evt1_1');
+    expect(gapDays(result[1].start, result[2].start)).toBeCloseTo(7, 5);
+  });
+
+  it('DAILY is not truncated at the old 52-cap (covers the full ~26-week window)', () => {
+    const result = expandRecurring(makeEvent({ recurrenceRule: 'FREQ=DAILY' }));
+    expect(result.length).toBeGreaterThan(52);
+    expect(gapDays(result[1].start, result[2].start)).toBeCloseTo(1, 5);
+  });
+
+  it('MONTHLY steps by real calendar months (not a 28-day drift)', () => {
+    const start = new Date(2026, 0, 31, 9, 0, 0);
+    const result = expandRecurring(
+      makeEvent({
+        start,
+        end: new Date(2026, 0, 31, 10, 0, 0),
+        recurrenceRule: 'FREQ=MONTHLY',
+      }),
+    );
+    expect(result[1].start.getMonth()).toBe(1);
+    for (let i = 1; i < result.length - 1; i++) {
+      const expected = addMonths(result[i].start, 1);
+      expect(result[i + 1].start.getTime()).toBe(expected.getTime());
+    }
+    const gap = gapDays(result[1].start, result[2].start);
+    expect(gap).toBeGreaterThan(27);
+    expect(gap).toBeLessThan(32);
+  });
+});


### PR DESCRIPTION
Replace the 28-day MONTHLY step (addWeeks(current,4)) with addMonths(current,1) so month-end anchors keep their day-of-month, and bound the expansion loop by windowEnd instead of a fixed 52-iteration cap so DAILY fills the full ~26-week window.

## Description
Fixes #1046 `Calendar.expandRecurring` produced wrong instances for recurring events.
- **MONTHLY drift:** the step used `addWeeks(current, 4)` (a fixed 28 days), so a monthly event anchored on, e.g., Jan 31 landed on Feb 28 / Mar 31 instead of the same day each month. It now steps with `addMonths(current, 1)`, preserving the day-of-month (month-end dates clamp correctly, e.g. Jan 31 -> Feb 28).
- **DAILY truncation:** the loop was capped at a fixed `i < 52` iterations, which only yielded ~7 weeks for daily events. The loop is now bounded by `windowEnd` (`addWeeks(new Date(), 26)`), so daily events fill the full intended ~26-week window.
No new dependency `addMonths` already ships in date-fns v3. WEEKLY and non-recurring behavior are unchanged.
A focused unit test (`src/testing/events/recurrence.test.ts`) covers WEEKLY (7-day steps), DAILY (full window, 1-day steps), MONTHLY (real calendar months via `addMonths`), and non-recurring passthrough. `pnpm run type-check` and `pnpm run lint` pass; the new test passes 5/5.

## Related Issue
Closes #1046

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [x] Uses Lucide icons consistently (no new icons added; existing usage unchanged)
- [x] Responsive design implemented (logic-only change; no new UI/layout)
- [ ] Starknet best practices followed; N/A: teachLink is not a Starknet project (template artifact, left unchecked)