### PR TITLE
fix: refresh state during URL search synchronization

### DIFF
--- a/src/hooks/useSearchState.ts
+++ b/src/hooks/useSearchState.ts
@@ -192,8 +192,7 @@ export const useSearchState = () => {
     if (patch.sortBy && patch.sortBy !== query.sortBy)
       updateSort(patch.sortBy as SearchQuery['sortBy']);
     if (patch.filters) updateFilters(patch.filters as Partial<SearchFilters>);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  }, [query, searchParams, updateFilters, updateSearchText, updateSort]);
 
   // -------------------------------------------------------------------------
   // Share helper — returns the current canonical URL for sharing


### PR DESCRIPTION
## Description

Refresh the URL-to-state synchronization effect whenever the current search state changes. This prevents it from comparing incoming URL parameters against a stale query snapshot during browser navigation.

## Related Issue

Closes #900

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [ ] Full test suite (blocked by pre-existing failures outside this change)
- [ ] Dependency audit (reports existing high-severity dependency findings)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors introduced