### PR TITLE
feat(learning): optimistic progress updates with rollback

### DIFF
--- a/src/hooks/__tests__/useLearningProgress.test.tsx
+++ b/src/hooks/__tests__/useLearningProgress.test.tsx
@@ -6,6 +6,13 @@ import { act } from 'react-dom/test-utils';
 import { useLearningProgress } from '../useLearningProgress';
 import type { UseLearningProgressReturn } from '../useLearningProgress';
 import { apiClient } from '@/lib/api';
+import { offlineApi } from '@/services/offlineApi';
+
+vi.mock('@/services/offlineApi', () => ({
+  offlineApi: {
+    updateLearningProgress: vi.fn(),
+  },
+}));
 import type { ApiResponse, LearningProgressItem } from '@/types/api';
 
 vi.mock('@/lib/api', () => ({
@@ -123,6 +130,54 @@ describe('useLearningProgress', () => {
     expect(api!.items).toEqual([]);
     expect(api!.isLoading).toBe(false);
     expect(api!.error).toBe(networkError);
+  });
+
+  it('updates progress optimistically and reconciles the server response', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse);
+    vi.mocked(offlineApi.updateLearningProgress).mockResolvedValue({
+      success: true,
+      data: {
+        courseId: '1',
+        moduleId: '1',
+        progress: 72,
+        completed: false,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(<TestHarness onReady={(a) => (api = a)} />);
+    });
+
+    await act(async () => {
+      await api!.updateProgress('1', 70);
+    });
+
+    expect(offlineApi.updateLearningProgress).toHaveBeenCalledWith({
+      courseId: '1',
+      moduleId: '1',
+      progress: 70,
+      completed: false,
+    });
+    expect(api!.items[0].progress).toBe(72);
+  });
+
+  it('rolls back the optimistic update when saving fails', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse);
+    const error = new Error('Save failed');
+    vi.mocked(offlineApi.updateLearningProgress).mockRejectedValue(error);
+
+    let api: UseLearningProgressReturn | undefined;
+    await act(async () => {
+      root.render(<TestHarness onReady={(a) => (api = a)} />);
+    });
+
+    await expect(api!.updateProgress('1', 90)).rejects.toThrow('Save failed');
+    await act(async () => {});
+
+    expect(api!.items[0].progress).toBe(68);
+    expect(api!.error).toBe(error);
   });
 
   it('refetches items when refetch is called', async () => {

--- a/src/hooks/useLearningProgress.ts
+++ b/src/hooks/useLearningProgress.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '@/lib/api';
+import { offlineApi } from '@/services/offlineApi';
 import type { ApiResponse, LearningProgressItem } from '@/types/api';
 
 export interface UseLearningProgressReturn {
@@ -9,6 +10,7 @@ export interface UseLearningProgressReturn {
   isLoading: boolean;
   error: Error | null;
   refetch: () => void;
+  updateProgress: (courseId: string, progress: number) => Promise<void>;
 }
 
 export function useLearningProgress(): UseLearningProgressReturn {
@@ -17,11 +19,58 @@ export function useLearningProgress(): UseLearningProgressReturn {
   const [error, setError] = useState<Error | null>(null);
 
   const mountedRef = useRef(true);
+  const itemsRef = useRef(items);
+  const updateSequenceRef = useRef(new Map<string, number>());
+
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };
+  }, []);
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const updateProgress = useCallback(async (courseId: string, progress: number) => {
+    const previousItems = itemsRef.current;
+    const optimisticItems = previousItems.map((item) =>
+      item.courseId === courseId ? { ...item, progress } : item,
+    );
+    const requestId = (updateSequenceRef.current.get(courseId) ?? 0) + 1;
+    updateSequenceRef.current.set(courseId, requestId);
+
+    itemsRef.current = optimisticItems;
+    setItems(optimisticItems);
+    setError(null);
+
+    try {
+      const response = await offlineApi.updateLearningProgress({
+        courseId,
+        moduleId: courseId,
+        progress,
+        completed: progress >= 100,
+      });
+      if (!mountedRef.current || updateSequenceRef.current.get(courseId) !== requestId) return;
+      if (!response.success) {
+        throw new Error(response.message || 'Progress update failed');
+      }
+
+      const reconciledProgress = response.data.progress;
+      const reconciledItems = itemsRef.current.map((item) =>
+        item.courseId === courseId ? { ...item, progress: reconciledProgress } : item,
+      );
+      itemsRef.current = reconciledItems;
+      setItems(reconciledItems);
+    } catch (err) {
+      if (!mountedRef.current || updateSequenceRef.current.get(courseId) !== requestId) return;
+
+      itemsRef.current = previousItems;
+      setItems(previousItems);
+      setError(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
   }, []);
 
   const load = useCallback(async () => {
@@ -35,6 +84,7 @@ export function useLearningProgress(): UseLearningProgressReturn {
         '/api/user/learning-progress',
       );
       if (mountedRef.current) {
+        itemsRef.current = response.data;
         setItems(response.data);
       }
     } catch (err) {
@@ -52,5 +102,5 @@ export function useLearningProgress(): UseLearningProgressReturn {
     load();
   }, [load]);
 
-  return { items, isLoading, error, refetch: load };
+  return { items, isLoading, error, refetch: load, updateProgress };
 }

--- a/src/services/offlineApi.ts
+++ b/src/services/offlineApi.ts
@@ -45,7 +45,19 @@ export interface OfflineProgressSyncResponse {
   deduplicated?: boolean;
 }
 
+export interface LearningProgressUpdateResponse {
+  success: boolean;
+  message?: string;
+  data: OfflineProgressPayload;
+}
+
 export const offlineApi = {
+  updateLearningProgress: async (
+    progress: Pick<OfflineProgressPayload, 'courseId' | 'moduleId' | 'progress' | 'completed'>,
+  ): Promise<LearningProgressUpdateResponse> => {
+    return apiClient.post<LearningProgressUpdateResponse>('/api/user/progress', progress);
+  },
+
   syncLessonProgress: async (
     progress: OfflineProgressPayload,
   ): Promise<OfflineProgressSyncResponse> => {


### PR DESCRIPTION
## Summary

Implements optimistic learning-progress updates that apply changes to the UI immediately, reconcile with the server response, and gracefully roll back on failure. This delivers a snappy, responsive feel while keeping the client state in sync with the backend.

Closes #1222

---

## Problem

When a learner updates their course progress, the current flow makes a network request and waits for the response before updating the UI. This introduces noticeable lag — especially on slower connections — making the app feel sluggish. Users should see their progress reflected instantly.

---

## Solution

### Optimistic UI with Server Reconciliation

The `useLearningProgress` hook now exposes an `updateProgress(courseId, progress)` method that:

1. **Applies the change immediately** — The local `items` state is updated with the new progress value before the network call completes, giving the user instant visual feedback.
2. **Reconciles with the server** — After the POST to `/api/user/progress` succeeds, the client replaces the optimistic value with the server's authoritative response (`response.data.progress`). This ensures the UI always converges to the source of truth, even if the server clamps, rounds, or modifies the value.
3. **Rolls back on failure** — If the network call fails, the item reverts to its previous state and the error is surfaced through the hook's `error` state. The user sees a transient inconsistency rather than a persistent incorrect value.

### Race-Condition Safety

Multiple rapid updates to the same course (e.g., a user dragging a progress slider) are safely handled via a per-course request sequence counter (`updateSequenceRef`). Each call increments its own `requestId`; when the response arrives, it only applies if the counter still matches — stale responses from superseded calls are silently discarded.

### Unmounted-Component Guard

A `mountedRef` flag prevents state updates after the component unmounts, eliminating the classic React warning and potential memory leaks from stale async callbacks.

---

## Changes

### `src/services/offlineApi.ts`
- Added `LearningProgressUpdateResponse` type for the progress update endpoint.
- Added `offlineApi.updateLearningProgress()` — a thin wrapper around `apiClient.post('/api/user/progress', ...)` that sends the courseId, moduleId, progress, and completed flag.

### `src/hooks/useLearningProgress.ts`
- Imported `offlineApi` from `@/services/offlineApi`.
- Added `updateProgress` to the `UseLearningProgressReturn` interface.
- Added `itemsRef` to keep the latest items value accessible inside the async callback without adding it as a dependency.
- Added `updateSequenceRef` (a `Map<string, number>`) to track the latest request per course and discard stale responses.
- Implemented `updateProgress(courseId, progress)`:
  - Snapshot the current items as `previousItems`.
  - Apply optimistic update to both ref and state.
  - POST via `offlineApi.updateLearningProgress`.
  - On success: reconcile with `response.data.progress`.
  - On failure: restore `previousItems`, set error, rethrow.
  - Both paths check `mountedRef` and sequence counter before touching state.
- Updated `load()` to also sync `itemsRef` so that subsequent `updateProgress` calls always have the correct snapshot.
- Returned `updateProgress` from the hook.

### `src/hooks/__tests__/useLearningProgress.test.tsx`
- Added a mock for `@/services/offlineApi` (only `updateLearningProgress`).
- **New test: "updates progress optimistically and reconciles the server response"** — Verifies that the POST is called with the correct payload and that the final items reflect the server's reconciled value (72) rather than the optimistic value (70).
- **New test: "rolls back the optimistic update when saving fails"** — Verifies that on network failure, the items revert to the original value (68), the error is surfaced, and the promise rejects with the original error.

---

## Testing

All **6 tests pass** (`src/hooks/__tests__/useLearningProgress.test.tsx`). TypeScript type-checking passes cleanly with no errors.

```
✓ src/hooks/__tests__/useLearningProgress.test.tsx (6 tests) 30ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

---

## Edge Cases Handled

| Scenario | Behavior |
|---|---|
| Rapid updates to same course | Per-course request sequencing discards stale responses |
| Component unmounts during flight | `mountedRef` prevents state updates; no React warnings |
| Server returns different value than sent | UI reconciles to server value (e.g., 70 → 72) |
| Network failure | Optimistic change rolls back, error surfaced |
| `response.success === false` (server-side rejection) | Treated as failure, rolls back with error message |

---

## Follow-up Considerations

- **Offline queueing**: This PR covers the real-time optimistic path. The existing `syncLessonProgress` endpoint in `offlineApi` can be layered on top for offline-to-online replay when the network is unavailable.
- **Toast/notification on rollback**: A UX enhancement to briefly show an undo-style notification when an optimistic update rolls back could improve transparency.
- **Debounced slider input**: If `updateProgress` is called from a draggable slider, debouncing at the call site (outside this hook) is recommended to avoid flooding the server.