### PR TITLE
clean up keyboard shortcut

### DIFF
--- a/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useRef, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFocusTrap } from '../useFocusTrap';
 
 function FocusTrapHarness() {
@@ -27,6 +28,18 @@ function FocusTrapHarness() {
 }
 
 describe('useFocusTrap', () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+    removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('focuses the requested element, wraps Tab navigation, and restores the opener', () => {
     render(<FocusTrapHarness />);
 
@@ -47,5 +60,27 @@ describe('useFocusTrap', () => {
 
     fireEvent.click(closeButton);
     expect(document.activeElement).toBe(opener);
+  });
+
+  it('removes focus trap listeners when the dialog closes', () => {
+    render(<FocusTrapHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'focusin',
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('focusin', expect.any(Function));
   });
 });

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useKeyboardShortcuts, type ShortcutCommand } from '../useKeyboardShortcuts';
+
+describe('useKeyboardShortcuts', () => {
+  const keydownListeners = new Set<EventListenerOrEventListenerObject>();
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addEventListenerSpy = vi
+      .spyOn(document, 'addEventListener')
+      .mockImplementation(
+        ((
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: AddEventListenerOptions | boolean,
+        ) => {
+          if (type === 'keydown') {
+            keydownListeners.add(listener);
+          }
+
+          EventTarget.prototype.addEventListener.call(document, type, listener, options);
+        }) as typeof document.addEventListener,
+      );
+
+    removeEventListenerSpy = vi
+      .spyOn(document, 'removeEventListener')
+      .mockImplementation(
+        ((
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: EventListenerOptions | boolean,
+        ) => {
+          if (type === 'keydown') {
+            keydownListeners.delete(listener);
+          }
+
+          EventTarget.prototype.removeEventListener.call(document, type, listener, options);
+        }) as typeof document.removeEventListener,
+      );
+  });
+
+  afterEach(() => {
+    keydownListeners.clear();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('removes the keyboard listener on unmount and does not duplicate handlers after remount', () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    const firstCommands: ShortcutCommand[] = [
+      {
+        id: 'openCommandPalette',
+        title: 'Open command palette',
+        description: 'Opens the command palette',
+        run: firstHandler,
+      },
+    ];
+
+    const secondCommands: ShortcutCommand[] = [
+      {
+        id: 'openCommandPalette',
+        title: 'Open command palette',
+        description: 'Opens the command palette',
+        run: secondHandler,
+      },
+    ];
+
+    const firstRender = renderHook(({ commands }) => useKeyboardShortcuts(commands), {
+      initialProps: { commands: firstCommands },
+    });
+
+    expect(keydownListeners.size).toBe(1);
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    });
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+
+    firstRender.unmount();
+
+    expect(keydownListeners.size).toBe(0);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    renderHook(({ commands }) => useKeyboardShortcuts(commands), {
+      initialProps: { commands: secondCommands },
+    });
+
+    expect(keydownListeners.size).toBe(1);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    });
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -25,6 +25,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
     if (!isActive || !containerRef.current) return;
 
     const container = containerRef.current;
+    const listenerController = new AbortController();
     previouslyFocusedRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
@@ -77,12 +78,13 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
       if (!container.contains(event.target as Node)) focusInitialElement();
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('keydown', handleKeyDown, { signal: listenerController.signal });
+    document.addEventListener('focusin', handleFocusIn, { signal: listenerController.signal });
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('focusin', handleFocusIn);
+      listenerController.abort();
       if (restoreFocus && previouslyFocusedRef.current?.isConnected) {
         previouslyFocusedRef.current.focus();
       }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -204,6 +204,8 @@ export function useKeyboardShortcuts(
   useEffect(() => {
     if (!enabled) return;
 
+    const listenerController = new AbortController();
+
     const listener = (event: KeyboardEvent) => {
       if (isInputLike(event.target)) return;
       const pressed = eventToBinding(event);
@@ -220,8 +222,11 @@ export function useKeyboardShortcuts(
       if (handler) handler();
     };
 
-    document.addEventListener('keydown', listener);
-    return () => document.removeEventListener('keydown', listener);
+    document.addEventListener('keydown', listener, { signal: listenerController.signal });
+    return () => {
+      document.removeEventListener('keydown', listener);
+      listenerController.abort();
+    };
   }, [enabled]);
 
   const setShortcutBinding = useCallback((id: ShortcutActionId, binding: string) => {


### PR DESCRIPTION
- Closes #1203 

Clean up keyboard-shortcut and focus-trap listeners on unmount
- 
- ## Summary
- Ensure document-level keyboard shortcut and focus trap listeners are cleaned up when their hooks unmount.
- Prevent listener leakage across route changes that could otherwise cause duplicate handlers to fire.
- Add focused regression tests covering unmount/remount cleanup behavior.
- 
- ## Changes
- Update useKeyboardShortcuts to register its keydown listener with an AbortController and abort it during effect cleanup.
- Update useFocusTrap to register both keydown and focusin listeners with an AbortController and abort them during effect cleanup.
- Add a new hook test that verifies useKeyboardShortcuts removes listeners on unmount and does not leave stale handlers behind after remount.
- Extend the existing useFocusTrap test to verify listeners are removed when the trap closes.
- 
- ## Testing
- pnpm test src/hooks/__tests__/useKeyboardShortcuts.test.ts src/hooks/__tests__/useFocusTrap.test.tsx