### PR TITLE
fix: memoize WalletProvider context value

### DIFF
--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -3,6 +3,7 @@
 import React, {
   createContext,
   useContext,
+  useMemo,
   useState,
   useCallback,
   useEffect,
@@ -155,12 +156,15 @@ export function WalletProvider({ children }: WalletProviderProps) {
     }
   }, [state.isConnected]);
 
-  const value: WalletContextType = {
-    ...state,
-    connect,
-    disconnect,
-    clearError,
-  };
+  const value = useMemo<WalletContextType>(
+    () => ({
+      ...state,
+      connect,
+      disconnect,
+      clearError,
+    }),
+    [state, connect, disconnect, clearError],
+  );
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }


### PR DESCRIPTION
Closes #891

Summary
Memoize the WalletProvider context value to prevent unnecessary consumer re-renders when wallet state has not changed.

Changes
Added useMemo to WalletProvider.
Memoized the context value using wallet state and stable callbacks as dependencies.
Preserved existing wallet behavior and public APIs.
Validation
TypeScript check passed.
Focused ESLint check passed.
git diff --check passed.