### PR TITLE
feat(api-versioning): warn when calling unversioned API paths

### DIFF
--- a/src/lib/__tests__/apiVersioning.test.ts
+++ b/src/lib/__tests__/apiVersioning.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for API versioning helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getApiDeprecationInfo, getVersionedApiPath } from '../apiVersioning';
+
+describe('getApiDeprecationInfo', () => {
+  describe('versioned API paths — no warning', () => {
+    it('returns null for /api/v1/* paths', () => {
+      expect(getApiDeprecationInfo('/api/v1/notes')).toBeNull();
+    });
+
+    it('returns null for any valid version segment', () => {
+      expect(getApiDeprecationInfo('/api/v2/posts')).toBeNull();
+      expect(getApiDeprecationInfo('/api/v10/posts')).toBeNull();
+    });
+
+    it('returns null for a bare version root like /api/v1', () => {
+      expect(getApiDeprecationInfo('/api/v1')).toBeNull();
+    });
+  });
+
+  describe('non-API paths — no warning', () => {
+    it('returns null for paths outside /api', () => {
+      expect(getApiDeprecationInfo('/notes')).toBeNull();
+      expect(getApiDeprecationInfo('/admin/dashboard')).toBeNull();
+    });
+  });
+
+  describe('unversioned API paths — warning emitted', () => {
+    it('suggests the versioned equivalent for /api/notes', () => {
+      const info = getApiDeprecationInfo('/api/notes');
+
+      expect(info).not.toBeNull();
+      expect(info?.deprecatedPath).toBe('/api/notes');
+      expect(info?.versionedPath).toBe('/api/v1/notes');
+      expect(info?.message).toContain('/api/notes');
+      expect(info?.message).toContain('/api/v1/notes');
+    });
+
+    it('handles the bare /api root', () => {
+      expect(getApiDeprecationInfo('/api')?.versionedPath).toBe('/api/v1');
+      expect(getApiDeprecationInfo('/api/')?.versionedPath).toBe('/api/v1/');
+    });
+
+    it('preserves sub-paths when constructing the target', () => {
+      const info = getApiDeprecationInfo('/api/courses/123/lessons?foo=bar');
+      expect(info?.versionedPath).toBe('/api/v1/courses/123/lessons?foo=bar');
+    });
+  });
+
+  describe('malformed version segments — warning emitted', () => {
+    it('warns for alphabetic segment (vABC)', () => {
+      const info = getApiDeprecationInfo('/api/vABC/posts');
+      expect(info?.deprecatedPath).toBe('/api/vABC/posts');
+      expect(info?.versionedPath).toBe('/api/v1/vABC/posts');
+    });
+
+    it('warns for dotted segment (v1.2)', () => {
+      expect(getApiDeprecationInfo('/api/v1.2/posts')).not.toBeNull();
+    });
+
+    it('warns for purely numeric segment (123)', () => {
+      expect(getApiDeprecationInfo('/api/123/posts')).not.toBeNull();
+    });
+
+    it('warns for an empty version segment (/api/v/)', () => {
+      expect(getApiDeprecationInfo('/api/v/posts')).not.toBeNull();
+    });
+  });
+});
+
+describe('getVersionedApiPath', () => {
+  it('upgrades unversioned /api/* paths', () => {
+    expect(getVersionedApiPath('/api/courses')).toBe('/api/v1/courses');
+  });
+
+  it('leaves versioned paths unchanged', () => {
+    expect(getVersionedApiPath('/api/v1/courses')).toBe('/api/v1/courses');
+  });
+
+  it('leaves non-API paths unchanged', () => {
+    expect(getVersionedApiPath('/courses')).toBe('/courses');
+  });
+});

--- a/src/lib/apiVersioning.ts
+++ b/src/lib/apiVersioning.ts
@@ -10,6 +10,30 @@ function isVersionedApiPath(path: string): boolean {
   return path.startsWith(`${API_ROOT}/v`);
 }
 
+export interface ApiDeprecationInfo {
+  deprecatedPath: string;
+  versionedPath: string;
+  message: string;
+}
+
+export function getApiDeprecationInfo(path: string): ApiDeprecationInfo | null {
+  if (!path.startsWith(API_ROOT)) {
+    return null;
+  }
+
+  const versionSegment = path.slice(API_ROOT.length + 1).split('/')[0] ?? '';
+  if (/^v\d+$/.test(versionSegment)) {
+    return null;
+  }
+
+  const versionedPath = `${VERSIONED_API_ROOT}${path.slice(API_ROOT.length)}`;
+  return {
+    deprecatedPath: path,
+    versionedPath,
+    message: `Unversioned API path "${path}" is deprecated. Use "${versionedPath}" instead.`,
+  };
+}
+
 export function getVersionedApiPath(url: string): string {
   try {
     const base = new URL(url, 'http://localhost');

--- a/src/middleware/__tests__/logger.test.ts
+++ b/src/middleware/__tests__/logger.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for request logging middleware (deprecation warning emission).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+import { withRequestLogging } from '../logger';
+import { queryLogs } from '@/lib/logging';
+
+class MockNextUrl {
+  pathname: string;
+  search: string;
+  href: string;
+
+  constructor(pathname = '/', search = '') {
+    this.pathname = pathname;
+    this.search = search;
+    this.href = `http://localhost${pathname}${search}`;
+  }
+}
+
+function createMockRequest(pathname: string, headers: Record<string, string> = {}): NextRequest {
+  return {
+    nextUrl: new MockNextUrl(pathname),
+    url: `http://localhost${pathname}`,
+    method: 'GET',
+    headers: {
+      get: (key: string) => headers[key.toLowerCase()] ?? null,
+    },
+    cookies: {
+      get: () => undefined,
+      getAll: () => [],
+      has: () => false,
+      delete: vi.fn(),
+      set: vi.fn(),
+    },
+  } as unknown as NextRequest;
+}
+
+describe('withRequestLogging API versioning warnings', () => {
+  beforeEach(() => {
+    globalThis.__TEACHLINK_LOG_RECORDS__ = [];
+    globalThis.__TEACHLINK_METRICS__ = [];
+  });
+
+  it('emits a deprecation warning for unversioned API requests', async () => {
+    const request = createMockRequest('/api/notes');
+    await withRequestLogging(request, 'logger.test', async () => 42);
+
+    const warnings = queryLogs({ level: 'warn', scope: 'logger.test' });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain('deprecated');
+    expect(warnings[0]?.context).toMatchObject({
+      deprecatedPath: '/api/notes',
+      versionedPath: '/api/v1/notes',
+    });
+  });
+
+  it('does not warn for versioned API requests', async () => {
+    const request = createMockRequest('/api/v1/notes');
+    await withRequestLogging(request, 'logger.test', async () => 42);
+
+    const warnings = queryLogs({ level: 'warn', scope: 'logger.test' });
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('does not warn for non-API requests', async () => {
+    const request = createMockRequest('/dashboard');
+    await withRequestLogging(request, 'logger.test', async () => 42);
+
+    const warnings = queryLogs({ level: 'warn', scope: 'logger.test' });
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('warns before executing the handler and surfaces the versioned target', async () => {
+    let handlerRan = false;
+    const request = createMockRequest('/api/courses/123');
+
+    await withRequestLogging(request, 'logger.test', async () => {
+      handlerRan = true;
+      const warnings = queryLogs({ level: 'warn', scope: 'logger.test' });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.context?.versionedPath).toBe('/api/v1/courses/123');
+      return true;
+    });
+
+    expect(handlerRan).toBe(true);
+  });
+});

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
+import { getApiDeprecationInfo } from '@/lib/apiVersioning';
 import { createCounterMetric, recordMetric } from '@/lib/logging/performance';
-import { createLogger, runWithLogContext } from '@/lib/logging';
+import { type AppLogger, createLogger, runWithLogContext } from '@/lib/logging';
 
 function createRequestId(): string {
   return `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -12,6 +13,20 @@ function getResponseStatus(result: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+function warnIfUnversionedApi(log: AppLogger, pathname: string) {
+  const deprecation = getApiDeprecationInfo(pathname);
+  if (!deprecation) {
+    return;
+  }
+
+  log.warn(deprecation.message, {
+    context: {
+      deprecatedPath: deprecation.deprecatedPath,
+      versionedPath: deprecation.versionedPath,
+    },
+  });
 }
 
 export function createRequestLogger(
@@ -51,6 +66,7 @@ export async function withRequestLogging<T>(
   const start = globalThis.performance?.now?.() ?? Date.now();
 
   log.info('Request started', { requestId, correlationId, traceId });
+  warnIfUnversionedApi(log, request.nextUrl.pathname);
 
   try {
     const result = await runWithLogContext({ requestId, correlationId, traceId }, () =>


### PR DESCRIPTION
## Description

Requests to unversioned API endpoints (e.g. `/api/notes`) are currently upgraded to the default version silently, giving callers no signal that they are on a legacy path. This PR emits a deprecation warning when an unversioned API path is called so callers can migrate to the versioned equivalent (`/api/v1/notes`).

Changes:
- `src/lib/apiVersioning.ts` — added `getApiDeprecationInfo(path)`, a pure helper that detects unversioned `/api/*` paths (skips valid versioned paths per the middleware's `/^v\d+$/` rule) and returns the deprecated path, the target `/api/v1/...` path, and a migration message.
- `src/middleware/logger.ts` — `withRequestLogging` now emits a `warn`-level log with the deprecation message and both paths in context when the request targets an unversioned API path (covers internal requests flagged `X-Internal-Api-Request` that bypass the middleware rewrite).
- Added unit tests for the helper and integration tests for the logger warning.

## Related Issue

Closes #1220

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently
- [ ] Responsive design implemented
- [ ] Starknet best practices followed