### PR TITLE
Harden URL sanitization and reuse date formatters

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,59 +1,40 @@
 import DOMPurify from 'dompurify';
 import { ALLOWED_LINK_DOMAINS } from '@/constants/app.constants';
 
-const SAFE_URL_SCHEMES = ['http:', 'https:'];
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:']);
 
-/**
- * Returns true when the hostname belongs to (or is a subdomain of) an allowlisted domain.
- * e.g. "www.youtube.com" matches "youtube.com".
- */
 const isAllowedDomain = (hostname: string): boolean =>
   ALLOWED_LINK_DOMAINS.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
 
-// Register the DOMPurify hook once at module load time.
-// It strips `href` attributes whose absolute URLs don't pass domain validation.
-// Relative URLs (e.g. "/about", "#section") are left untouched — they resolve to the same origin.
-let _hookRegistered = false;
-if (typeof window !== 'undefined' && !_hookRegistered) {
-  _hookRegistered = true;
+const isSafeUrl = (value: string): boolean => {
+  const scheme = value.match(/^([a-z][a-z\d+.-]*):/i)?.[1]?.toLowerCase();
+  if (scheme && !SAFE_URL_SCHEMES.has(`${scheme}:`)) return false;
+
+  try {
+    const parsed = new URL(value);
+    return SAFE_URL_SCHEMES.has(parsed.protocol) && isAllowedDomain(parsed.hostname);
+  } catch {
+    return true;
+  }
+};
+
+let hookRegistered = false;
+if (typeof window !== 'undefined' && !hookRegistered) {
+  hookRegistered = true;
   DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     const href = node.getAttribute('href');
-    if (href === null) return;
-    try {
-      const parsed = new URL(href);
-      if (!SAFE_URL_SCHEMES.includes(parsed.protocol) || !isAllowedDomain(parsed.hostname)) {
-        node.removeAttribute('href');
-      }
-    } catch {
-      // new URL() throws for relative URLs — allow them (they stay on the same origin)
-    }
-  });
+    if (href !== null && !isSafeUrl(href)) node.removeAttribute('href');
 
-  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     if (node.tagName === 'IFRAME') {
       const src = node.getAttribute('src');
-      if (src === null) return;
       let allowed = false;
       try {
-        const parsed = new URL(src);
-        // Only allow YouTube nocookie domain
-        if (
-          SAFE_URL_SCHEMES.includes(parsed.protocol) &&
-          parsed.hostname.endsWith('youtube-nocookie.com')
-        ) {
-          allowed = true;
-        }
+        const parsed = new URL(src ?? '');
+        allowed = SAFE_URL_SCHEMES.has(parsed.protocol) && parsed.hostname.endsWith('youtube-nocookie.com');
       } catch {
-        // Invalid URL – not allowed
+        // Invalid iframe source.
       }
-      if (!allowed) {
-        node.remove();
-        return;
-      }
-      // Preserve allowfullscreen if present on allowed iframe
-      if (node.hasAttribute('allowfullscreen')) {
-        node.setAttribute('allowfullscreen', '');
-      }
+      if (!allowed) node.remove();
     }
   });
 }
@@ -68,12 +49,12 @@ export const sanitizeHtml = (html: string): string => {
 
 export const sanitizeUrl = (url: string): string | null => {
   const trimmed = url.trim();
-  if (!trimmed) return null;
+  if (!trimmed || !isSafeUrl(trimmed)) return null;
   try {
     const parsed = new URL(trimmed);
-    if (!SAFE_URL_SCHEMES.includes(parsed.protocol)) return null;
-    if (!isAllowedDomain(parsed.hostname)) return null;
-    return parsed.toString();
+    return SAFE_URL_SCHEMES.has(parsed.protocol) && isAllowedDomain(parsed.hostname)
+      ? parsed.toString()
+      : null;
   } catch {
     return null;
   }

--- a/src/utils/socialUtils.ts
+++ b/src/utils/socialUtils.ts
@@ -1,45 +1,15 @@
-export interface Topic {
-  slug: string;
-  name: string;
-  description?: string;
-  postCount: number;
-  followerCount: number;
-  isFollowing?: boolean;
-}
+import { getDateTimeFormat } from './intlCache';
 
-export interface TopicPost {
-  id: string;
-  authorId: string;
-  authorName: string;
-  authorAvatar?: string;
-  title: string;
-  body: string;
-  topicSlug: string;
-  likes: number;
-  commentCount: number;
-  createdAt: Date;
-  tags?: string[];
-}
+export interface Topic { slug: string; name: string; description?: string; postCount: number; followerCount: number; isFollowing?: boolean; }
+export interface TopicPost { id: string; authorId: string; authorName: string; authorAvatar?: string; title: string; body: string; topicSlug: string; likes: number; commentCount: number; createdAt: Date; tags?: string[]; }
+export interface Activity { id: string; actorId: string; actorName: string; actorAvatar?: string; action: string; targetId?: string; targetTitle?: string; createdAt: Date; }
 
-export interface Activity {
-  id: string;
-  actorId: string;
-  actorName: string;
-  actorAvatar?: string;
-  action: string;
-  targetId?: string;
-  targetTitle?: string;
-  createdAt: Date;
-}
-
-/** Format large numbers: 1200 → "1.2K", 1_500_000 → "1.5M" */
 export function formatFollowerCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
   return String(n);
 }
 
-/** Returns a human-readable relative time string: "2 hours ago", "just now", etc. */
 export function getRelativeTime(date: Date): string {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
   if (seconds < 60) return 'just now';
@@ -57,18 +27,16 @@ export function getRelativeTime(date: Date): string {
   return `${years} year${years === 1 ? '' : 's'} ago`;
 }
 
-/** Groups activities by calendar date label ("Today", "Yesterday", or "MMM D, YYYY"). */
 export function groupActivitiesByDate(activities: Activity[]): Record<string, Activity[]> {
   const today = new Date();
   const yesterday = new Date(today);
   yesterday.setDate(today.getDate() - 1);
-
-  const label = (d: Date): string => {
-    if (d.toDateString() === today.toDateString()) return 'Today';
-    if (d.toDateString() === yesterday.toDateString()) return 'Yesterday';
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const dateFormatter = getDateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const label = (date: Date): string => {
+    if (date.toDateString() === today.toDateString()) return 'Today';
+    if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    return dateFormatter.format(date);
   };
-
   return activities.reduce<Record<string, Activity[]>>((acc, activity) => {
     const key = label(new Date(activity.createdAt));
     (acc[key] ??= []).push(activity);


### PR DESCRIPTION
## Summar
reject dangerous URL schemes before parsing and sanitizing HTML links\n- reuse the cached Intl date formatter for social activity grouping
Closes #1204 
Closes #1205 
Closes #1206 
## Verification\n- pnpm exec tsc --noEmit\n- targeted utility tests: 52 passed\n- git diff --check