### PR TITLE
feat: abort pending requests on unmount in useApi hook

### DIFF
--- a/src/hooks/__tests__/useAbortController.test.ts
+++ b/src/hooks/__tests__/useAbortController.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAbortController } from '../useAbortController';
+
+describe('useAbortController', () => {
+  it('returns stable getSignal and abort functions', () => {
+    const { result, rerender } = renderHook(() => useAbortController());
+
+    const firstGetSignal = result.current.getSignal;
+    const firstAbort = result.current.abort;
+
+    rerender();
+
+    expect(result.current.getSignal).toBe(firstGetSignal);
+    expect(result.current.abort).toBe(firstAbort);
+  });
+
+  it('generates a fresh signal that can be aborted', () => {
+    const { result } = renderHook(() => useAbortController());
+    const signal = result.current.getSignal();
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+
+    result.current.abort();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('aborts the previous signal when getSignal is called again', () => {
+    const { result } = renderHook(() => useAbortController());
+    const signal1 = result.current.getSignal();
+    expect(signal1.aborted).toBe(false);
+
+    const signal2 = result.current.getSignal();
+    expect(signal1.aborted).toBe(true);
+    expect(signal2.aborted).toBe(false);
+  });
+
+  it('aborts the active signal automatically on unmount', () => {
+    const { result, unmount } = renderHook(() => useAbortController());
+    const signal = result.current.getSignal();
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useApi.test.ts
+++ b/src/hooks/__tests__/useApi.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useApi } from '../useApi';
+import { clearDedupeCache } from '@/lib/api/dedupe';
+
+describe('useApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearDedupeCache();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('loads data successfully', async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: 'test-data' }),
+    }));
+    vi.stubGlobal('fetch', mockFetch as any);
+
+    const { result } = renderHook(() => useApi<any>('/api/data'));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({ value: 'test-data' });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error state when request fails', async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    }));
+    vi.stubGlobal('fetch', mockFetch as any);
+
+    const { result } = renderHook(() => useApi<any>('/api/fail'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toContain('Request failed: 500');
+  });
+
+  it('aborts the fetch request automatically on unmount', async () => {
+    let passedSignal: AbortSignal | undefined;
+    const mockFetch = vi.fn(async (url, init) => {
+      passedSignal = init?.signal;
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            ok: true,
+            json: async () => ({ value: 'test' }),
+          });
+        }, 100);
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch as any);
+
+    const { result, unmount } = renderHook(() => useApi<any>('/api/unmount'));
+
+    // Wait a brief tick to let useEffect trigger fetchData
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(passedSignal).toBeDefined();
+    expect(passedSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(passedSignal?.aborted).toBe(true);
+  });
+
+  it('aborts the previous signal when a dependency changes', async () => {
+    const signals: AbortSignal[] = [];
+    const mockFetch = vi.fn(async (url, init) => {
+      if (init?.signal) {
+        signals.push(init.signal);
+      }
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            ok: true,
+            json: async () => ({ value: url }),
+          });
+        }, 100);
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch as any);
+
+    const { result, rerender } = renderHook(
+      ({ url }) => useApi<any>(url),
+      { initialProps: { url: '/api/first' } }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(signals.length).toBe(1);
+    expect(signals[0].aborted).toBe(false);
+
+    // Change dependency URL, triggering a new request
+    rerender({ url: '/api/second' });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(signals.length).toBe(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('ignores AbortError and does not update state', async () => {
+    const mockFetch = vi.fn(async (url, init) => {
+      return new Promise((resolve, reject) => {
+        const checkAborted = () => {
+          if (init?.signal?.aborted) {
+            reject(new DOMException('The user aborted a request.', 'AbortError'));
+          } else {
+            setTimeout(checkAborted, 10);
+          }
+        };
+        checkAborted();
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch as any);
+
+    const { result, unmount } = renderHook(() => useApi<any>('/api/abort-state'));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+
+    // The component should unmount and not trigger state updates with AbortError.
+    // We wait to make sure any asynchronous rejection resolves and does not throw uncaught errors.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+});

--- a/src/hooks/useAbortController.ts
+++ b/src/hooks/useAbortController.ts
@@ -16,11 +16,15 @@ export function useAbortController() {
     return controllerRef.current.signal;
   }, []);
 
+  const abort = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
   useEffect(() => {
     return () => {
       controllerRef.current?.abort();
     };
   }, []);
 
-  return { getSignal };
+  return { getSignal, abort };
 }

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { buildDedupeKey, dedupe, cancelDedupe } from '@/lib/api/dedupe';
+import { useAbortController } from './useAbortController';
 
 export type ApiState<T> = {
   data: T | null;
@@ -28,6 +29,8 @@ export function useApi<T>(
 ): ApiState<T> & { refetch: () => void } {
   const { skip = false, body, ...fetchOptions } = options;
   const method = fetchOptions.method ?? 'GET';
+
+  const { getSignal } = useAbortController();
 
   // Serialize body and fetchOptions values using refs to keep identity stable
   // unless their deep or stringified contents actually change.
@@ -60,6 +63,7 @@ export function useApi<T>(
     const currentBody = bodyRef.current;
     const currentOptions = fetchOptionsRef.current;
     const currentMethod = currentOptions.method ?? 'GET';
+    const signal = getSignal();
 
     const key = buildDedupeKey(currentMethod, url, currentBody);
 
@@ -72,6 +76,7 @@ export function useApi<T>(
         fetch(url, {
           ...currentOptions,
           method: currentMethod,
+          signal,
           ...(currentBody ? { body: JSON.stringify(currentBody) } : {}),
         }).then((res) => {
           if (!res.ok) throw new Error(`Request failed: ${res.status} ${res.statusText}`);
@@ -84,6 +89,9 @@ export function useApi<T>(
       }
     } catch (err) {
       if (mountedRef.current) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          return;
+        }
         setState({
           data: null,
           loading: false,
@@ -91,7 +99,7 @@ export function useApi<T>(
         });
       }
     }
-  }, [url, method, serializedBody, serializedOptions]);
+  }, [url, method, serializedBody, serializedOptions, getSignal]);
 
   useEffect(() => {
     if (!skip) {


### PR DESCRIPTION
closes #1200 

Integrate Request Abortion: Added useAbortController inside the useApi hook to retrieve an AbortSignal for each fetch request. This automatically aborts any in-flight request on unmount or when a new fetch is initiated.
Exposed Abort Control: Modified useAbortController to expose a stable manual abort() callback to allow manual request cancellation.
Error Handling: Configured useApi to catch and ignore AbortError so that cancelled requests do not trigger state updates on active or unmounting components.
Unit Testing: Added 9 new unit tests under src/hooks/__tests__/ to verify abortion on unmount, abortion on dependency changes, and correct error handling.