### PR TITLE
feat(a11y): add skip-to-content link and main-content id in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -101,9 +101,16 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-gray-900 transition-colors duration-200 dark:bg-gray-950 dark:text-gray-50 flex flex-col min-h-screen`}
       >
+        {/* Skip-to-content link — visually hidden until focused, satisfies WCAG 2.4.1 */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[9999] focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:ring-2 focus:ring-blue-500 focus:outline-none dark:focus:bg-gray-900 dark:focus:text-gray-50"
+        >
+          Skip to main content
+        </a>
         <RootProviders defaultTheme={defaultTheme} defaultLocale={locale}>
           <EnvironmentBanner />
-          <main className="flex-grow">{children}</main>
+          <main id="main-content" className="flex-grow">{children}</main>
           <Footer />
         </RootProviders>
 


### PR DESCRIPTION
feat(a11y): add skip-to-content link and main-content target id — closes #953

Summary
Keyboard and screen-reader users were forced to tab through the entire header and nav on every page load because <main> had no id and there was no bypass mechanism. This PR adds the standard skip-navigation pattern to fix that.

What changed
Single file touched: 
layout.tsx

1. Skip link — inserted as the very first focusable element inside <body>, before <RootProviders>:

<a
  href="#main-content"
  className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[9999] focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:ring-2 focus:ring-blue-500 focus:outline-none dark:focus:bg-gray-900 dark:focus:text-gray-50"
>
  Skip to main content
</a>
Hidden from sighted users via sr-only until focused
Appears as a visible pill in the top-left corner on first Tab keypress
z-[9999] ensures it renders above the nav/header
Dark mode aware
2. Main content target — id="main-content" added to the existing <main> element:

<main id="main-content" className="flex-grow">{children}</main>
Accessibility compliance
Satisfies WCAG 2.1 SC 2.4.1 — Bypass Blocks (Level A)
No layout shift or visual change for mouse and touch users
Works with VoiceOver, NVDA, JAWS, and any browser that supports anchor navigation
What was tested
No runtime code changed beyond the two targeted edits
TypeScript reports no diagnostics on the updated file
Visually confirmed: skip link is invisible at rest, visible on focus, and navigates focus to <main> on activation.


closes #953