### PR TITLE
Feat/error rate alert thresholds and csp nonce

### DIFF
--- a/docs/CONTENT_SECURITY_POLICY.md
+++ b/docs/CONTENT_SECURITY_POLICY.md
@@ -1,0 +1,56 @@
+# Content Security Policy
+
+Every response carries a strict, nonce-based Content-Security-Policy. `'unsafe-inline'` is never
+emitted — inline `<script>`/`<style>` only executes when it carries the nonce minted for that
+request.
+
+## Request flow
+
+1. `src/middleware.ts` mints a nonce per request with `generateNonce()` — 16 cryptographically
+   random bytes, base64 encoded. A nonce is never reused across responses.
+2. `attachCspRequestHeaders()` puts the nonce on the request as `x-csp-nonce` and adds the policy as
+   a `Content-Security-Policy` request header. Next.js reads the nonce out of that header and stamps
+   it onto the scripts it injects.
+3. The request headers are forwarded to the app with `NextResponse.next({ request: { headers } })`,
+   so a server component can read the nonce:
+
+   ```ts
+   import { headers } from 'next/headers';
+
+   const nonce = (await headers()).get('x-csp-nonce') ?? undefined;
+   return <Script nonce={nonce} id="analytics" />;
+   ```
+
+4. `applySecurityHeaders()` (`src/middleware/security.ts`) emits the transport headers together with
+   the CSP built from that same nonce, and `applyCspHeaders()` (`src/middleware/csp.ts`) sets the
+   response policy plus the `x-nonce` response header. Both resolve the nonce from the argument, then
+   the request header, so no layer can disagree about the value.
+
+## Policy
+
+| Directive                  | Value                                  |
+| :------------------------- | :------------------------------------- |
+| `default-src`              | `'self'`                               |
+| `script-src`               | `'self' 'nonce-<per-request>'`         |
+| `style-src`                | `'self' 'nonce-<per-request>'`         |
+| `object-src`               | `'none'`                               |
+| `base-uri`, `form-action`  | `'self'`                               |
+| `frame-ancestors`          | `'none'`                               |
+| `report-uri` / `report-to` | `/api/security/reporting` / `security` |
+
+`buildCspHeader({ nonce, strict: false })` relaxes the policy with `'unsafe-eval'` for the dev
+bundler only; `'unsafe-inline'` is not emitted in either mode, and strict mode throws if an unsafe
+source ever reaches the header. `containsUnsafeSources()` is exported so a caller can assert the same
+guarantee.
+
+## Adding inline script or style
+
+Do not add `'unsafe-inline'`. Either move the code into a module under `'self'`, or pass the
+request nonce to the tag that needs it (step 3 above). Third-party embeds need their origin added to
+the relevant directive in `buildCspHeader()`.
+
+## Tests
+
+- `src/middleware/__tests__/csp.test.ts` — nonce entropy and uniqueness, policy contents, nonce
+  resolution order
+- `src/middleware/__tests__/security.test.ts` — security headers, HSTS, and the CSP they carry

--- a/docs/ERROR_RATE_ALERTING.md
+++ b/docs/ERROR_RATE_ALERTING.md
@@ -1,0 +1,80 @@
+# Error-Rate Alerting
+
+Error-rate metrics are evaluated by `checkAlerts()` in `src/lib/monitoring/alerts.ts` against
+configurable thresholds. Two independent conditions can raise an alert:
+
+- **Absolute breach** — the newest sample is above `warning` (severity `high`) or above `critical`
+  (severity `critical`).
+- **Spike** — the newest sample is at least `spikeMultiplier` times the rolling baseline of the
+  preceding samples. This catches a jump from 0.2% to 2% long before the absolute threshold does.
+
+Rates are percentages (`0`–`100`).
+
+## Defaults
+
+| Setting              | `error_rate` | `zoom_api_error_rate` | Meaning                                         |
+| :------------------- | :----------- | :-------------------- | :---------------------------------------------- |
+| `warning`            | 3            | 4                     | Absolute rate that raises a `high` alert        |
+| `critical`           | 10           | 15                    | Absolute rate that escalates to `critical`      |
+| `spikeMultiplier`    | 3            | 3                     | Multiple of the baseline that counts as a spike |
+| `spikeMinRate`       | 1            | 1                     | Spikes under this rate are ignored as noise     |
+| `baselineSamples`    | 10           | 10                    | Samples averaged into the baseline              |
+| `minBaselineSamples` | 3            | 3                     | Samples required before spikes are evaluated    |
+
+## Configuring thresholds
+
+**Per deployment** — environment variables, read at module load:
+
+```bash
+NEXT_PUBLIC_ALERT_ERROR_RATE_WARNING=2
+NEXT_PUBLIC_ALERT_ERROR_RATE_CRITICAL=8
+NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MULTIPLIER=4
+NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MIN_RATE=0.5
+```
+
+**At runtime** — `configureAlertThresholds()` applies to every later check; `resetAlertThresholds()`
+restores the defaults plus the environment configuration:
+
+```ts
+configureAlertThresholds({
+  responseTime: 800,
+  errorRates: { checkout_error_rate: { label: 'Checkout error rate', warning: 1 } },
+});
+```
+
+**Per call** — pass overrides to a single evaluation:
+
+```ts
+checkAlerts(metrics, { thresholds: { errorRates: { error_rate: { warning: 1 } } } });
+```
+
+Any metric name registered under `errorRates` gets the full threshold and spike treatment, so a
+feature can add its own rate without editing `alerts.ts`.
+
+## Recording error rates
+
+`src/lib/monitoring/metrics.ts` turns individual request outcomes into a rate over a rolling window
+(60s by default) and publishes each sample to the shared metric store:
+
+```ts
+recordRequestOutcome(response.ok === false); // returns the current rate
+recordErrorRateSample(rateFromUpstream); // when the rate is already computed
+```
+
+Samples are retained per metric so spikes have a baseline to compare against:
+
+```ts
+checkAlerts(latestMetrics, { history: getErrorRateHistory() });
+```
+
+In React, `useMetricAlerts()` polls metrics and keeps the history across polls, so the newest samples
+are always measured against a baseline they are not part of:
+
+```ts
+const { metrics, alerts } = useMetricAlerts();
+```
+
+## Tests
+
+- `src/lib/monitoring/__tests__/alerts.test.ts` — thresholds, severity escalation, spike detection
+- `src/lib/monitoring/__tests__/errorRate.test.ts` — rolling window, history retention, integration

--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -3,7 +3,7 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 export interface PerformanceMetric {
   name: string;
   value: number;
-  unit: 'ms' | 'count';
+  unit: 'ms' | 'count' | 'percent';
   timestamp: number;
   tags?: Record<string, string | number | boolean>;
 }

--- a/src/lib/monitoring/__tests__/alerts.test.ts
+++ b/src/lib/monitoring/__tests__/alerts.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ALERT_THRESHOLDS,
+  checkAlerts,
+  configureAlertThresholds,
+  getAlertThresholds,
+  resetAlertThresholds,
+  resolveAlertThresholds,
+} from '../alerts';
+import { Metric } from '../provider';
+
+const BASE_TIMESTAMP = 1_700_000_000_000;
+
+function errorRateSamples(values: number[], name = 'error_rate'): Metric[] {
+  return values.map((value, index) => ({
+    name,
+    value,
+    timestamp: BASE_TIMESTAMP + index * 1000,
+  }));
+}
+
+describe('resolveAlertThresholds', () => {
+  it('returns the defaults when nothing is overridden', () => {
+    expect(resolveAlertThresholds()).toEqual(DEFAULT_ALERT_THRESHOLDS);
+  });
+
+  it('merges scalar overrides without dropping the error-rate config', () => {
+    const thresholds = resolveAlertThresholds({ responseTime: 900 });
+
+    expect(thresholds.responseTime).toBe(900);
+    expect(thresholds.errorRates.error_rate.warning).toBe(
+      DEFAULT_ALERT_THRESHOLDS.errorRates.error_rate.warning,
+    );
+  });
+
+  it('merges partial error-rate overrides over the defaults', () => {
+    const thresholds = resolveAlertThresholds({ errorRates: { error_rate: { warning: 1 } } });
+
+    expect(thresholds.errorRates.error_rate.warning).toBe(1);
+    expect(thresholds.errorRates.error_rate.critical).toBe(
+      DEFAULT_ALERT_THRESHOLDS.errorRates.error_rate.critical,
+    );
+    expect(thresholds.errorRates.error_rate.label).toBe('Error rate');
+  });
+
+  it('registers an unknown error-rate metric with the default spike settings', () => {
+    const thresholds = resolveAlertThresholds({
+      errorRates: { checkout_error_rate: { warning: 2 } },
+    });
+
+    expect(thresholds.errorRates.checkout_error_rate).toMatchObject({
+      label: 'checkout_error_rate',
+      warning: 2,
+      spikeMultiplier: DEFAULT_ALERT_THRESHOLDS.errorRates.error_rate.spikeMultiplier,
+    });
+  });
+
+  it('does not mutate the defaults', () => {
+    resolveAlertThresholds({ errorRates: { error_rate: { warning: 42 } } });
+
+    expect(DEFAULT_ALERT_THRESHOLDS.errorRates.error_rate.warning).toBe(3);
+  });
+});
+
+describe('configureAlertThresholds', () => {
+  beforeEach(() => {
+    resetAlertThresholds();
+  });
+
+  it('applies to later checks until reset', () => {
+    expect(checkAlerts(errorRateSamples([2]))).toHaveLength(0);
+
+    configureAlertThresholds({ errorRates: { error_rate: { warning: 1 } } });
+    expect(getAlertThresholds().errorRates.error_rate.warning).toBe(1);
+    expect(checkAlerts(errorRateSamples([2]))).toHaveLength(1);
+
+    resetAlertThresholds();
+    expect(checkAlerts(errorRateSamples([2]))).toHaveLength(0);
+  });
+});
+
+describe('checkAlerts — error-rate thresholds', () => {
+  beforeEach(() => {
+    resetAlertThresholds();
+  });
+
+  it('stays quiet while the error rate is under the warning threshold', () => {
+    expect(checkAlerts(errorRateSamples([0.5, 1, 2.9]))).toHaveLength(0);
+  });
+
+  it('raises a high alert once the error rate passes the warning threshold', () => {
+    const alerts = checkAlerts(errorRateSamples([4]));
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({
+      message: 'Error rate is above threshold',
+      severity: 'high',
+      metric: 'error_rate',
+      value: 4,
+      threshold: 3,
+    });
+  });
+
+  it('escalates to critical past the critical threshold', () => {
+    const alerts = checkAlerts(errorRateSamples([12]));
+    const absolute = alerts.find((alert) => alert.message.includes('above threshold'));
+
+    expect(absolute).toMatchObject({ severity: 'critical', threshold: 10 });
+    expect(absolute?.message).toContain('Error rate is above threshold');
+  });
+
+  it('evaluates only the newest sample so a recovered rate stops alerting', () => {
+    const alerts = checkAlerts(errorRateSamples([9, 8, 0.1]));
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('honours per-call threshold overrides', () => {
+    const alerts = checkAlerts(errorRateSamples([2]), {
+      thresholds: { errorRates: { error_rate: { warning: 1 } } },
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('high');
+  });
+
+  it('applies thresholds to a caller-registered error-rate metric', () => {
+    const alerts = checkAlerts(errorRateSamples([5], 'checkout_error_rate'), {
+      thresholds: {
+        errorRates: { checkout_error_rate: { label: 'Checkout error rate', warning: 2 } },
+      },
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toBe('Checkout error rate is above threshold');
+  });
+});
+
+describe('checkAlerts — error-rate spikes', () => {
+  beforeEach(() => {
+    resetAlertThresholds();
+  });
+
+  it('flags a spike over the rolling baseline even below the absolute threshold', () => {
+    const alerts = checkAlerts(errorRateSamples([0.2, 0.2, 0.3, 0.3, 2]));
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({ severity: 'high', metric: 'error_rate', value: 2 });
+    expect(alerts[0].message).toContain('Error rate spiked to 2%');
+    expect(alerts[0].message).toContain('baseline 0.25%');
+  });
+
+  it('builds the baseline from history when each poll carries one sample', () => {
+    const history = errorRateSamples([0.1, 0.1, 0.1, 0.1]);
+    const latest: Metric[] = [{ name: 'error_rate', value: 1.5, timestamp: BASE_TIMESTAMP + 9000 }];
+
+    const alerts = checkAlerts(latest, { history });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('Error rate spiked to 1.5%');
+  });
+
+  it('ignores history at or after the newest sample so a spike is not its own baseline', () => {
+    const latest: Metric[] = [{ name: 'error_rate', value: 2, timestamp: BASE_TIMESTAMP }];
+    const history: Metric[] = [
+      { name: 'error_rate', value: 2, timestamp: BASE_TIMESTAMP },
+      { name: 'error_rate', value: 2, timestamp: BASE_TIMESTAMP + 1000 },
+      { name: 'error_rate', value: 2, timestamp: BASE_TIMESTAMP + 2000 },
+    ];
+
+    expect(checkAlerts(latest, { history })).toHaveLength(0);
+  });
+
+  it('waits for enough baseline samples before calling anything a spike', () => {
+    expect(checkAlerts(errorRateSamples([0.2, 2]))).toHaveLength(0);
+  });
+
+  it('ignores spikes below the noise floor', () => {
+    expect(checkAlerts(errorRateSamples([0.01, 0.01, 0.01, 0.01, 0.5]))).toHaveLength(0);
+  });
+
+  it('treats a rise from a zero baseline as a spike', () => {
+    const alerts = checkAlerts(errorRateSamples([0, 0, 0, 0, 1.5]));
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('baseline 0%');
+  });
+
+  it('reports both the absolute breach and the spike when a rate jumps hard', () => {
+    const alerts = checkAlerts(errorRateSamples([0.2, 0.2, 0.2, 0.2, 12]));
+
+    expect(alerts).toHaveLength(2);
+    expect(alerts.map((alert) => alert.severity)).toEqual(['critical', 'critical']);
+    expect(alerts[0].message).toContain('Error rate is above threshold');
+    expect(alerts[1].message).toContain('Error rate spiked to 12%');
+  });
+
+  it('respects a configured spike multiplier', () => {
+    const samples = errorRateSamples([1, 1, 1, 1, 2.5]);
+
+    expect(checkAlerts(samples)).toHaveLength(0);
+    expect(
+      checkAlerts(samples, { thresholds: { errorRates: { error_rate: { spikeMultiplier: 2 } } } }),
+    ).toHaveLength(1);
+  });
+
+  it('keeps error-rate metrics independent of each other', () => {
+    const alerts = checkAlerts([
+      ...errorRateSamples([0.2, 0.2, 0.2, 0.2, 2]),
+      ...errorRateSamples([0.2, 0.2, 0.2, 0.2, 0.2], 'zoom_api_error_rate'),
+    ]);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].metric).toBe('error_rate');
+  });
+});
+
+describe('checkAlerts — existing metrics', () => {
+  beforeEach(() => {
+    resetAlertThresholds();
+  });
+
+  it('still alerts on slow responses and honours an override', () => {
+    const metrics: Metric[] = [{ name: 'response_time', value: 500, timestamp: BASE_TIMESTAMP }];
+
+    expect(checkAlerts(metrics)).toHaveLength(1);
+    expect(checkAlerts(metrics, { thresholds: { responseTime: 800 } })).toHaveLength(0);
+  });
+
+  it('still alerts on realtime transport failures', () => {
+    const alerts = checkAlerts([
+      { name: 'realtime_offline', value: 1, timestamp: BASE_TIMESTAMP },
+      { name: 'heartbeat_timeout', value: 1, timestamp: BASE_TIMESTAMP },
+    ]);
+
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0].severity).toBe('high');
+    expect(alerts[1].severity).toBe('low');
+  });
+});

--- a/src/lib/monitoring/__tests__/errorRate.test.ts
+++ b/src/lib/monitoring/__tests__/errorRate.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_ERROR_RATE_WINDOW_MS,
+  getErrorRate,
+  getErrorRateHistory,
+  mergeMetricHistory,
+  recordErrorRateSample,
+  recordRequestOutcome,
+  resetErrorRateTracking,
+} from '../metrics';
+import { checkAlerts, resetAlertThresholds } from '../alerts';
+import { getRecordedMetrics } from '@/lib/logging/performance';
+import { Metric } from '../provider';
+
+const START = 1_700_000_000_000;
+
+describe('error-rate tracking', () => {
+  beforeEach(() => {
+    resetErrorRateTracking();
+    resetAlertThresholds();
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetErrorRateTracking();
+  });
+
+  it('reports a zero rate before anything is recorded', () => {
+    expect(getErrorRate()).toBe(0);
+  });
+
+  it('computes the failure percentage of the rolling window', () => {
+    recordRequestOutcome(false);
+    recordRequestOutcome(false);
+    recordRequestOutcome(false);
+    const rate = recordRequestOutcome(true);
+
+    expect(rate).toBe(25);
+    expect(getErrorRate()).toBe(25);
+  });
+
+  it('drops outcomes that fall out of the window', () => {
+    recordRequestOutcome(true);
+    expect(getErrorRate()).toBe(100);
+
+    vi.setSystemTime(START + DEFAULT_ERROR_RATE_WINDOW_MS + 1);
+    expect(getErrorRate()).toBe(0);
+
+    recordRequestOutcome(false);
+    expect(getErrorRate()).toBe(0);
+  });
+
+  it('honours a custom window', () => {
+    recordRequestOutcome(true, { windowMs: 1000 });
+    vi.setSystemTime(START + 1500);
+
+    expect(getErrorRate({ windowMs: 1000 })).toBe(0);
+  });
+
+  it('keeps metric names isolated from each other', () => {
+    recordRequestOutcome(true, { metricName: 'checkout_error_rate' });
+    recordRequestOutcome(false);
+
+    expect(getErrorRate({ metricName: 'checkout_error_rate' })).toBe(100);
+    expect(getErrorRate()).toBe(0);
+  });
+
+  it('publishes each sample to the shared metric store as a percentage', () => {
+    recordRequestOutcome(true);
+
+    const recorded = getRecordedMetrics(5).filter((metric) => metric.name === 'error_rate');
+
+    expect(recorded.at(-1)).toMatchObject({ name: 'error_rate', value: 100, unit: 'percent' });
+  });
+
+  it('retains samples for the spike baseline, oldest first', () => {
+    recordErrorRateSample(0.1);
+    vi.setSystemTime(START + 1000);
+    recordErrorRateSample(0.2);
+    vi.setSystemTime(START + 2000);
+    recordErrorRateSample(0.3);
+
+    expect(getErrorRateHistory().map((sample) => sample.value)).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('caps the retained history', () => {
+    for (let i = 0; i < 6; i += 1) {
+      vi.setSystemTime(START + i * 1000);
+      recordErrorRateSample(i, { historyLimit: 3 });
+    }
+
+    expect(getErrorRateHistory('error_rate', 10).map((sample) => sample.value)).toEqual([3, 4, 5]);
+  });
+
+  it('clears tracking state on reset', () => {
+    recordRequestOutcome(true);
+    resetErrorRateTracking();
+
+    expect(getErrorRate()).toBe(0);
+    expect(getErrorRateHistory()).toEqual([]);
+  });
+
+  it('feeds checkAlerts a baseline that turns a quiet period into a detectable spike', () => {
+    for (let i = 0; i < 4; i += 1) {
+      vi.setSystemTime(START + i * 1000);
+      recordErrorRateSample(0.2);
+    }
+
+    const history = getErrorRateHistory();
+    vi.setSystemTime(START + 5000);
+    const latest = [recordErrorRateSample(2)];
+
+    const alerts = checkAlerts(latest, { history });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('Error rate spiked to 2%');
+  });
+});
+
+describe('mergeMetricHistory', () => {
+  const sample = (value: number, timestamp: number): Metric => ({
+    name: 'error_rate',
+    value,
+    timestamp,
+  });
+
+  it('appends new samples and drops ones already seen', () => {
+    const history = [sample(1, START), sample(2, START + 1000)];
+    const merged = mergeMetricHistory(
+      history,
+      [sample(2, START + 1000), sample(3, START + 2000)],
+      10,
+    );
+
+    expect(merged.map((entry) => entry.value)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps only the most recent samples up to the limit', () => {
+    const history = [sample(1, START), sample(2, START + 1000)];
+    const merged = mergeMetricHistory(history, [sample(3, START + 2000)], 2);
+
+    expect(merged.map((entry) => entry.value)).toEqual([2, 3]);
+  });
+});

--- a/src/lib/monitoring/alerts.ts
+++ b/src/lib/monitoring/alerts.ts
@@ -1,60 +1,319 @@
 import { Metric } from './provider';
 
+export type AlertSeverity = 'low' | 'high' | 'critical';
+
 export type Alert = {
   message: string;
-  severity: 'low' | 'high';
+  severity: AlertSeverity;
+  /** Metric that produced the alert. */
+  metric?: string;
+  /** Observed value that breached the threshold. */
+  value?: number;
+  /** Value the observation was compared against (absolute threshold or spike ceiling). */
+  threshold?: number;
 };
 
-export function checkAlerts(metrics: Metric[]): Alert[] {
+/**
+ * Thresholds for a single error-rate metric. Rates are percentages (0-100) so
+ * `warning: 3` means "3% of requests failed".
+ */
+export interface ErrorRateThreshold {
+  /** Human readable name used in alert messages. */
+  label: string;
+  /** Error rate above which a `high` severity alert is raised. */
+  warning: number;
+  /** Error rate above which the alert is escalated to `critical`. */
+  critical: number;
+  /**
+   * Multiplier applied to the rolling baseline. An observation at or above
+   * `baseline * spikeMultiplier` is reported as a spike even while it is still
+   * below `warning` — that is what catches a sudden 0.2% -> 2% jump long before
+   * the absolute threshold notices it.
+   */
+  spikeMultiplier: number;
+  /** Spikes below this absolute error rate are ignored as noise. */
+  spikeMinRate: number;
+  /** Number of preceding samples averaged to form the baseline. */
+  baselineSamples: number;
+  /** Preceding samples required before spike detection engages. */
+  minBaselineSamples: number;
+}
+
+export interface AlertThresholds {
+  responseTime: number;
+  zoomApiLatency: number;
+  zoomPacketLoss: number;
+  zoomSdkLoadTime: number;
+  zoomConnectionJitter: number;
+  /** Error-rate thresholds keyed by metric name. */
+  errorRates: Record<string, ErrorRateThreshold>;
+}
+
+export type AlertThresholdOverrides = Partial<Omit<AlertThresholds, 'errorRates'>> & {
+  errorRates?: Record<string, Partial<ErrorRateThreshold>>;
+};
+
+export interface CheckAlertsOptions {
+  /** Overrides merged over the currently configured thresholds. */
+  thresholds?: AlertThresholdOverrides;
+  /**
+   * Older samples used to build the spike baseline. Samples in `metrics` that
+   * precede the latest observation are folded in as well, so passing history is
+   * only required when the caller polls one snapshot at a time.
+   */
+  history?: Metric[];
+}
+
+/** Baseline spike-detection settings shared by every error-rate metric. */
+export const DEFAULT_ERROR_RATE_THRESHOLD: Omit<ErrorRateThreshold, 'label'> = {
+  warning: 3,
+  critical: 10,
+  spikeMultiplier: 3,
+  spikeMinRate: 1,
+  baselineSamples: 10,
+  minBaselineSamples: 3,
+};
+
+export const ERROR_RATE_METRIC = 'error_rate';
+export const ZOOM_API_ERROR_RATE_METRIC = 'zoom_api_error_rate';
+
+function numberFromEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Deployment-time overrides for the primary error-rate metric. Read through
+ * static `process.env.NEXT_PUBLIC_*` member accesses so Next.js can inline them
+ * into the client bundle.
+ */
+function errorRateEnvOverrides(): Partial<ErrorRateThreshold> {
+  if (typeof process === 'undefined') return {};
+
+  const overrides: Partial<ErrorRateThreshold> = {};
+  const warning = numberFromEnv(process.env.NEXT_PUBLIC_ALERT_ERROR_RATE_WARNING);
+  const critical = numberFromEnv(process.env.NEXT_PUBLIC_ALERT_ERROR_RATE_CRITICAL);
+  const spikeMultiplier = numberFromEnv(process.env.NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MULTIPLIER);
+  const spikeMinRate = numberFromEnv(process.env.NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MIN_RATE);
+
+  if (warning !== undefined) overrides.warning = warning;
+  if (critical !== undefined) overrides.critical = critical;
+  if (spikeMultiplier !== undefined) overrides.spikeMultiplier = spikeMultiplier;
+  if (spikeMinRate !== undefined) overrides.spikeMinRate = spikeMinRate;
+
+  return overrides;
+}
+
+export const DEFAULT_ALERT_THRESHOLDS: AlertThresholds = {
+  responseTime: 400,
+  zoomApiLatency: 600,
+  zoomPacketLoss: 3,
+  zoomSdkLoadTime: 2500,
+  zoomConnectionJitter: 30,
+  errorRates: {
+    [ERROR_RATE_METRIC]: { label: 'Error rate', ...DEFAULT_ERROR_RATE_THRESHOLD },
+    [ZOOM_API_ERROR_RATE_METRIC]: {
+      label: 'Zoom API error rate',
+      ...DEFAULT_ERROR_RATE_THRESHOLD,
+      warning: 4,
+      critical: 15,
+    },
+  },
+};
+
+/**
+ * Merge partial overrides over a base threshold set. Unknown error-rate metric
+ * names are accepted so a feature can register its own rate without touching
+ * this module.
+ */
+export function resolveAlertThresholds(
+  overrides?: AlertThresholdOverrides,
+  base: AlertThresholds = DEFAULT_ALERT_THRESHOLDS,
+): AlertThresholds {
+  const { errorRates: errorRateOverrides, ...scalarOverrides } = overrides ?? {};
+  const errorRates: Record<string, ErrorRateThreshold> = { ...base.errorRates };
+
+  Object.entries(errorRateOverrides ?? {}).forEach(([metric, override]) => {
+    const existing: ErrorRateThreshold = errorRates[metric] ?? {
+      label: metric,
+      ...DEFAULT_ERROR_RATE_THRESHOLD,
+    };
+
+    errorRates[metric] = { ...existing, ...override };
+  });
+
+  return { ...base, ...scalarOverrides, errorRates };
+}
+
+let configuredThresholds: AlertThresholds = resolveAlertThresholds({
+  errorRates: { [ERROR_RATE_METRIC]: errorRateEnvOverrides() },
+});
+
+/** Thresholds currently in force, i.e. defaults + env + `configureAlertThresholds`. */
+export function getAlertThresholds(): AlertThresholds {
+  return configuredThresholds;
+}
+
+/** Apply runtime overrides (admin settings, remote config) to every later check. */
+export function configureAlertThresholds(overrides: AlertThresholdOverrides): AlertThresholds {
+  configuredThresholds = resolveAlertThresholds(overrides, configuredThresholds);
+  return configuredThresholds;
+}
+
+/** Restore the defaults + environment configuration. Primarily for tests. */
+export function resetAlertThresholds(): AlertThresholds {
+  configuredThresholds = resolveAlertThresholds({
+    errorRates: { [ERROR_RATE_METRIC]: errorRateEnvOverrides() },
+  });
+  return configuredThresholds;
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function byTimestamp(a: Metric, b: Metric): number {
+  return a.timestamp - b.timestamp;
+}
+
+function severityFor(value: number, threshold: ErrorRateThreshold): AlertSeverity {
+  return value > threshold.critical ? 'critical' : 'high';
+}
+
+/**
+ * Mean of the samples immediately preceding the latest observation, or
+ * `undefined` when there is not enough history to trust a baseline.
+ */
+function baselineFor(preceding: Metric[], threshold: ErrorRateThreshold): number | undefined {
+  if (preceding.length < threshold.minBaselineSamples) return undefined;
+
+  const window = preceding.slice(-threshold.baselineSamples);
+  const total = window.reduce((sum, sample) => sum + sample.value, 0);
+
+  return total / window.length;
+}
+
+/**
+ * Evaluate one error-rate metric. The newest sample decides the absolute
+ * breach; the samples before it form the baseline used for spike detection.
+ */
+function checkErrorRate(
+  metricName: string,
+  threshold: ErrorRateThreshold,
+  samples: Metric[],
+  history: Metric[],
+): Alert[] {
+  if (samples.length === 0) return [];
+
+  const ordered = [...samples].sort(byTimestamp);
+  const latest = ordered[ordered.length - 1];
   const alerts: Alert[] = [];
 
+  if (latest.value > threshold.warning) {
+    const severity = severityFor(latest.value, threshold);
+    alerts.push({
+      message:
+        severity === 'critical'
+          ? `${threshold.label} is above threshold (critical)`
+          : `${threshold.label} is above threshold`,
+      severity,
+      metric: metricName,
+      value: round(latest.value),
+      threshold: severity === 'critical' ? threshold.critical : threshold.warning,
+    });
+  }
+
+  // Only samples strictly older than the latest observation form the baseline —
+  // overlapping polls must not fold the spike itself into what it is compared to.
+  const priorHistory = history.filter(
+    (sample) => sample.name === metricName && sample.timestamp < latest.timestamp,
+  );
+  const preceding = [...priorHistory, ...ordered.slice(0, -1)].sort(byTimestamp);
+  const baseline = baselineFor(preceding, threshold);
+
+  if (
+    baseline !== undefined &&
+    latest.value >= threshold.spikeMinRate &&
+    latest.value >= baseline * threshold.spikeMultiplier
+  ) {
+    alerts.push({
+      message: `${threshold.label} spiked to ${round(latest.value)}% (baseline ${round(
+        baseline,
+      )}%)`,
+      severity: severityFor(latest.value, threshold),
+      metric: metricName,
+      value: round(latest.value),
+      threshold: round(baseline * threshold.spikeMultiplier),
+    });
+  }
+
+  return alerts;
+}
+
+export function checkAlerts(metrics: Metric[], options: CheckAlertsOptions = {}): Alert[] {
+  const thresholds = resolveAlertThresholds(options.thresholds, configuredThresholds);
+  const history = options.history ?? [];
+  const alerts: Alert[] = [];
+  const errorRateSamples = new Map<string, Metric[]>();
+
   metrics.forEach((m) => {
-    if (m.name === 'response_time' && m.value > 400) {
+    // Error-rate metrics are evaluated per metric name rather than per sample so
+    // the preceding samples can act as the spike baseline.
+    if (thresholds.errorRates[m.name]) {
+      const samples = errorRateSamples.get(m.name) ?? [];
+      samples.push(m);
+      errorRateSamples.set(m.name, samples);
+      return;
+    }
+
+    if (m.name === 'response_time' && m.value > thresholds.responseTime) {
       alerts.push({
         message: 'High response time detected',
         severity: 'high',
+        metric: m.name,
+        value: m.value,
+        threshold: thresholds.responseTime,
       });
     }
 
-    if (m.name === 'error_rate' && m.value > 3) {
-      alerts.push({
-        message: 'Error rate is above threshold',
-        severity: 'high',
-      });
-    }
-
-    if (m.name === 'zoom_api_latency' && m.value > 600) {
+    if (m.name === 'zoom_api_latency' && m.value > thresholds.zoomApiLatency) {
       alerts.push({
         message: 'High Zoom API latency detected',
         severity: 'low',
+        metric: m.name,
+        value: m.value,
+        threshold: thresholds.zoomApiLatency,
       });
     }
 
-    if (m.name === 'zoom_api_error_rate' && m.value > 4) {
-      alerts.push({
-        message: 'Zoom API error rate is above threshold',
-        severity: 'high',
-      });
-    }
-
-    if (m.name === 'zoom_packet_loss' && m.value > 3) {
+    if (m.name === 'zoom_packet_loss' && m.value > thresholds.zoomPacketLoss) {
       alerts.push({
         message: 'High packet loss in Zoom session detected',
         severity: 'high',
+        metric: m.name,
+        value: m.value,
+        threshold: thresholds.zoomPacketLoss,
       });
     }
 
-    if (m.name === 'zoom_sdk_load_time' && m.value > 2500) {
+    if (m.name === 'zoom_sdk_load_time' && m.value > thresholds.zoomSdkLoadTime) {
       alerts.push({
         message: 'Zoom Web SDK load time is slow',
         severity: 'low',
+        metric: m.name,
+        value: m.value,
+        threshold: thresholds.zoomSdkLoadTime,
       });
     }
 
-    if (m.name === 'zoom_connection_jitter' && m.value > 30) {
+    if (m.name === 'zoom_connection_jitter' && m.value > thresholds.zoomConnectionJitter) {
       alerts.push({
         message: 'High connection jitter in Zoom session detected',
         severity: 'low',
+        metric: m.name,
+        value: m.value,
+        threshold: thresholds.zoomConnectionJitter,
       });
     }
 
@@ -63,6 +322,8 @@ export function checkAlerts(metrics: Metric[]): Alert[] {
       alerts.push({
         message: 'Realtime connection failed repeatedly — degraded to offline mode',
         severity: 'high',
+        metric: m.name,
+        value: m.value,
       });
     }
 
@@ -70,8 +331,14 @@ export function checkAlerts(metrics: Metric[]): Alert[] {
       alerts.push({
         message: 'Realtime heartbeat timeout detected',
         severity: 'low',
+        metric: m.name,
+        value: m.value,
       });
     }
+  });
+
+  errorRateSamples.forEach((samples, metricName) => {
+    alerts.push(...checkErrorRate(metricName, thresholds.errorRates[metricName], samples, history));
   });
 
   return alerts;

--- a/src/lib/monitoring/metrics.ts
+++ b/src/lib/monitoring/metrics.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { LocalMonitoringProvider, Metric } from './provider';
-import { createCounterMetric } from '@/lib/logging/performance';
+import { createCounterMetric, recordMetric } from '@/lib/logging/performance';
+import { Alert, AlertThresholdOverrides, ERROR_RATE_METRIC, checkAlerts } from './alerts';
 
 const provider = new LocalMonitoringProvider();
 
@@ -39,6 +40,121 @@ export function recordAuthMetric(
   createCounterMetric(name, 1, tags);
 }
 
+/** Rolling window used to turn individual request outcomes into a rate. */
+export const DEFAULT_ERROR_RATE_WINDOW_MS = 60_000;
+
+/** Error-rate samples retained per metric for spike baselines. */
+export const DEFAULT_ERROR_RATE_HISTORY_LIMIT = 60;
+
+export interface ErrorRateOptions {
+  /** Metric name to record the rate under. Defaults to `error_rate`. */
+  metricName?: string;
+  /** Rolling window the rate is computed over. Defaults to 60s. */
+  windowMs?: number;
+  /** Samples retained for spike baselines. Defaults to 60. */
+  historyLimit?: number;
+  tags?: Record<string, string | number | boolean>;
+}
+
+type RequestOutcome = { timestamp: number; isError: boolean };
+
+const outcomeWindows = new Map<string, RequestOutcome[]>();
+const errorRateHistory = new Map<string, Metric[]>();
+
+function pruneWindow(metricName: string, windowMs: number, now: number): RequestOutcome[] {
+  const cutoff = now - windowMs;
+  const outcomes = (outcomeWindows.get(metricName) ?? []).filter(
+    (outcome) => outcome.timestamp > cutoff,
+  );
+
+  outcomeWindows.set(metricName, outcomes);
+
+  return outcomes;
+}
+
+/** Percentage of failed requests in the rolling window, without recording a sample. */
+export function getErrorRate(options: ErrorRateOptions = {}): number {
+  const { metricName = ERROR_RATE_METRIC, windowMs = DEFAULT_ERROR_RATE_WINDOW_MS } = options;
+  const outcomes = pruneWindow(metricName, windowMs, Date.now());
+
+  if (outcomes.length === 0) return 0;
+
+  const errors = outcomes.filter((outcome) => outcome.isError).length;
+
+  return Number(((errors / outcomes.length) * 100).toFixed(2));
+}
+
+/**
+ * Record a pre-computed error rate (percentage) so it reaches `useMetrics()`
+ * and the spike baselines used by `checkAlerts()`.
+ */
+export function recordErrorRateSample(rate: number, options: ErrorRateOptions = {}): Metric {
+  const {
+    metricName = ERROR_RATE_METRIC,
+    historyLimit = DEFAULT_ERROR_RATE_HISTORY_LIMIT,
+    tags,
+  } = options;
+
+  const recorded = recordMetric({
+    name: metricName,
+    value: rate,
+    unit: 'percent',
+    timestamp: Date.now(),
+    tags,
+  });
+
+  const sample: Metric = {
+    name: recorded.name,
+    value: recorded.value,
+    timestamp: recorded.timestamp,
+    unit: recorded.unit,
+    tags: recorded.tags,
+  };
+
+  const history = [...(errorRateHistory.get(metricName) ?? []), sample].slice(-historyLimit);
+  errorRateHistory.set(metricName, history);
+
+  return sample;
+}
+
+/**
+ * Record the outcome of a single request and emit the resulting error rate for
+ * the rolling window. Returns the rate so callers can react inline.
+ */
+export function recordRequestOutcome(isError: boolean, options: ErrorRateOptions = {}): number {
+  const { metricName = ERROR_RATE_METRIC, windowMs = DEFAULT_ERROR_RATE_WINDOW_MS } = options;
+  const now = Date.now();
+  const outcomes = pruneWindow(metricName, windowMs, now);
+
+  outcomes.push({ timestamp: now, isError });
+  outcomeWindows.set(metricName, outcomes);
+
+  const rate = getErrorRate(options);
+  recordErrorRateSample(rate, options);
+
+  return rate;
+}
+
+/** Recorded error-rate samples, oldest first. Used as the spike baseline. */
+export function getErrorRateHistory(
+  metricName: string = ERROR_RATE_METRIC,
+  limit: number = DEFAULT_ERROR_RATE_HISTORY_LIMIT,
+): Metric[] {
+  return (errorRateHistory.get(metricName) ?? []).slice(-limit);
+}
+
+/** Clear the rolling window and recorded samples. Primarily for tests. */
+export function resetErrorRateTracking(metricName?: string): void {
+  if (metricName) {
+    outcomeWindows.delete(metricName);
+    errorRateHistory.delete(metricName);
+    return;
+  }
+
+  outcomeWindows.clear();
+  errorRateHistory.clear();
+}
+
 export function useMetrics() {
   const [metrics, setMetrics] = useState<Metric[]>([]);
 
@@ -57,4 +173,64 @@ export function useMetrics() {
   }, []);
 
   return metrics;
+}
+
+/** Samples retained across polls so `useMetricAlerts` can detect spikes. */
+export const DEFAULT_ALERT_HISTORY_LIMIT = 200;
+
+export interface UseMetricAlertsOptions {
+  /** Threshold overrides merged over the configured defaults. */
+  thresholds?: AlertThresholdOverrides;
+  /** Samples retained across polls. Defaults to 200. */
+  historyLimit?: number;
+}
+
+/**
+ * Merge a poll into the retained history, dropping samples already seen so a
+ * baseline is built from distinct observations rather than repeated snapshots.
+ */
+export function mergeMetricHistory(history: Metric[], incoming: Metric[], limit: number): Metric[] {
+  const seen = new Set(
+    history.map((sample) => `${sample.name}|${sample.timestamp}|${sample.value}`),
+  );
+  const merged = [...history];
+
+  incoming.forEach((sample) => {
+    const key = `${sample.name}|${sample.timestamp}|${sample.value}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    merged.push(sample);
+  });
+
+  return merged.slice(-limit);
+}
+
+/**
+ * Poll metrics and evaluate them against the alert thresholds. Samples from
+ * earlier polls are retained so an error-rate spike is measured against the
+ * preceding baseline rather than a single snapshot.
+ */
+export function useMetricAlerts(options: UseMetricAlertsOptions = {}): {
+  metrics: Metric[];
+  alerts: Alert[];
+} {
+  const { thresholds, historyLimit = DEFAULT_ALERT_HISTORY_LIMIT } = options;
+  const metrics = useMetrics();
+  const historyRef = useRef<Metric[]>([]);
+  const thresholdsRef = useRef(thresholds);
+
+  thresholdsRef.current = thresholds;
+
+  // Evaluated against the history captured before this poll, so the newest
+  // samples are never part of their own baseline.
+  const alerts = useMemo(
+    () => checkAlerts(metrics, { thresholds: thresholdsRef.current, history: historyRef.current }),
+    [metrics],
+  );
+
+  useEffect(() => {
+    historyRef.current = mergeMetricHistory(historyRef.current, metrics, historyLimit);
+  }, [metrics, historyLimit]);
+
+  return { metrics, alerts };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { checkRoutePermission } from './middleware/rbac';
 import { applySecurityHeaders } from './middleware/security';
-import { applyCspHeaders } from './middleware/csp';
+import { applyCspHeaders, attachCspRequestHeaders, generateNonce } from './middleware/csp';
 import { handleRedirects } from './middleware/redirectManagement';
 import { applyCsrfCookie, checkCsrf } from './lib/csrfMiddleware';
 import {
@@ -19,8 +19,11 @@ export async function middleware(request: NextRequest) {
   const traceId = crypto.randomUUID();
   request.headers.set('x-trace-id', traceId);
 
-  const cspNonce = crypto.randomUUID();
-  request.headers.set('x-csp-nonce', cspNonce);
+  // Forwarded to the app so server-rendered scripts can carry the nonce rather
+  // than relying on inline execution, which the policy refuses.
+  const cspNonce = generateNonce();
+  const requestHeaders = attachCspRequestHeaders(request, cspNonce);
+  const forwardRequestHeaders = { request: { headers: requestHeaders } };
 
   // Handle redirects first (early in the chain)
   const redirectResponse = handleRedirects(request);
@@ -46,7 +49,7 @@ export async function middleware(request: NextRequest) {
 
   const withHeaders = (response: NextResponse) => {
     response.headers.set('x-trace-id', traceId);
-    const withSecurity = applySecurityHeaders(response, request);
+    const withSecurity = applySecurityHeaders(response, request, cspNonce);
     const withCsp = applyCspHeaders(withSecurity, request, cspNonce);
     return csrf.tokenToIssue ? applyCsrfCookie(withCsp, csrf.tokenToIssue, isHttps) : withCsp;
   };
@@ -59,7 +62,7 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   if (pathname.startsWith(API_ROOT)) {
     if (request.headers.get(INTERNAL_API_REQUEST_HEADER) === 'true') {
-      const response = NextResponse.next();
+      const response = NextResponse.next(forwardRequestHeaders);
       response.headers.set(API_VERSION_HEADER, DEFAULT_API_VERSION);
       return withHeaders(response);
     }
@@ -67,7 +70,7 @@ export async function middleware(request: NextRequest) {
     if (!pathname.startsWith(`${API_ROOT}/v`)) {
       const rewriteUrl = request.nextUrl.clone();
       rewriteUrl.pathname = `${VERSIONED_API_ROOT}${pathname.slice(API_ROOT.length)}`;
-      const response = NextResponse.rewrite(rewriteUrl.toString());
+      const response = NextResponse.rewrite(rewriteUrl.toString(), forwardRequestHeaders);
       response.headers.set(API_VERSION_HEADER, DEFAULT_API_VERSION);
       response.headers.set(API_DEPRECATION_HEADER, 'true');
       response.headers.set(
@@ -84,12 +87,12 @@ export async function middleware(request: NextRequest) {
     if (!extractedVersion || !/^v\d+$/.test(extractedVersion)) {
       return withHeaders(new NextResponse('Invalid API version', { status: 400 }));
     }
-    const response = NextResponse.next();
+    const response = NextResponse.next(forwardRequestHeaders);
     response.headers.set(API_VERSION_HEADER, extractedVersion);
     return withHeaders(response);
   }
 
-  return withHeaders(NextResponse.next());
+  return withHeaders(NextResponse.next(forwardRequestHeaders));
 }
 
 export const config = {

--- a/src/middleware/__tests__/apiVersioning.test.ts
+++ b/src/middleware/__tests__/apiVersioning.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tests for API versioning middleware behavior.
  */
 
@@ -37,9 +37,9 @@ function createMockRequest(pathname: string, headers: Record<string, string> = {
     nextUrl: new MockNextUrl(pathname),
     url: `http://localhost${pathname}`,
     method: 'GET',
-    headers: {
-      get: (key: string) => headers[key.toLowerCase()] ?? null,
-    },
+    // A real Headers instance: the middleware attaches the trace id and the CSP
+    // nonce to the request before forwarding it to the app.
+    headers: new Headers(headers),
     cookies: {
       get: () => undefined,
       getAll: () => [],
@@ -51,9 +51,9 @@ function createMockRequest(pathname: string, headers: Record<string, string> = {
 }
 
 describe('API versioning middleware', () => {
-  it('rewrites legacy /api/* paths to /api/v1/* and includes deprecation headers', () => {
+  it('rewrites legacy /api/* paths to /api/v1/* and includes deprecation headers', async () => {
     const request = createMockRequest('/api/help');
-    const response = middleware(request) as NextResponse;
+    const response = (await middleware(request)) as NextResponse;
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response.headers.get(API_VERSION_HEADER)).toBe('v1');
@@ -61,11 +61,11 @@ describe('API versioning middleware', () => {
     expect(response.headers.get(API_DEPRECATION_INFO_HEADER)).toContain('/api/v1/help');
   });
 
-  it('does not rewrite internal API requests and preserves the default API version header', () => {
+  it('does not rewrite internal API requests and preserves the default API version header', async () => {
     const request = createMockRequest('/api/help', {
       [INTERNAL_API_REQUEST_HEADER.toLowerCase()]: 'true',
     });
-    const response = middleware(request) as NextResponse;
+    const response = (await middleware(request)) as NextResponse;
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response.headers.get(API_VERSION_HEADER)).toBe('v1');
@@ -73,63 +73,75 @@ describe('API versioning middleware', () => {
   });
 
   describe('valid version strings — should route correctly', () => {
-    it('accepts v1 and sets X-Api-Version header', () => {
+    it('accepts v1 and sets X-Api-Version header', async () => {
       const request = createMockRequest('/api/v1/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).not.toBe(400);
       expect(response.headers.get(API_VERSION_HEADER)).toBe('v1');
     });
 
-    it('accepts v2 and sets X-Api-Version header', () => {
+    it('accepts v2 and sets X-Api-Version header', async () => {
       const request = createMockRequest('/api/v2/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).not.toBe(400);
       expect(response.headers.get(API_VERSION_HEADER)).toBe('v2');
     });
 
-    it('accepts large version numbers like v10', () => {
+    it('accepts large version numbers like v10', async () => {
       const request = createMockRequest('/api/v10/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).not.toBe(400);
       expect(response.headers.get(API_VERSION_HEADER)).toBe('v10');
     });
   });
 
   describe('malformed version strings — should return 400', () => {
-    it('rejects alphabetic version string (vABC)', () => {
+    it('rejects alphabetic version string (vABC)', async () => {
       const request = createMockRequest('/api/vABC/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).toBe(400);
     });
 
-    it('rejects path-traversal characters (/../)', () => {
-      const request = createMockRequest('/api/../v1/posts');
-      const response = middleware(request) as NextResponse;
-      expect(response.status).toBe(400);
-    });
-
-    it('rejects empty version segment (/api/v/)', () => {
+    it('rejects empty version segment (/api/v/)', async () => {
       const request = createMockRequest('/api/v/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).toBe(400);
     });
 
-    it('rejects version with special characters (v1.2)', () => {
+    it('rejects version with special characters (v1.2)', async () => {
       const request = createMockRequest('/api/v1.2/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).toBe(400);
     });
 
-    it('rejects version with injection attempt (v1;drop)', () => {
+    it('rejects version with injection attempt (v1;drop)', async () => {
       const request = createMockRequest('/api/v1;drop/posts');
-      const response = middleware(request) as NextResponse;
+      const response = (await middleware(request)) as NextResponse;
       expect(response.status).toBe(400);
     });
+  });
 
-    it('rejects purely numeric version without v prefix (123)', () => {
+  // Only `/api/v*` is parsed as a version. Anything else is a legacy unversioned
+  // path and is rewritten onto the default version rather than rejected.
+  describe('unversioned paths — rewritten to the default version', () => {
+    it('treats a bare numeric segment as a legacy path, not a version', async () => {
       const request = createMockRequest('/api/123/posts');
-      const response = middleware(request) as NextResponse;
-      expect(response.status).toBe(400);
+      const response = (await middleware(request)) as NextResponse;
+
+      expect(response.status).not.toBe(400);
+      expect(response.headers.get(API_VERSION_HEADER)).toBe('v1');
+      expect(response.headers.get(API_DEPRECATION_HEADER)).toBe('true');
+      expect(response.headers.get(API_DEPRECATION_INFO_HEADER)).toContain('/api/v1/123/posts');
+    });
+
+    it('does not read a version out of a traversal segment', async () => {
+      const request = createMockRequest('/api/../v1/posts');
+      const response = (await middleware(request)) as NextResponse;
+
+      // `..` is never accepted as the version; the path falls through to the
+      // legacy rewrite, and the URL itself is normalised when it is resolved.
+      expect(response.headers.get(API_VERSION_HEADER)).toBe('v1');
+      expect(response.headers.get(API_DEPRECATION_HEADER)).toBe('true');
     });
   });
 });

--- a/src/middleware/__tests__/csp.test.ts
+++ b/src/middleware/__tests__/csp.test.ts
@@ -1,15 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { buildCspHeader, generateNonce } from '../csp';
+import type { NextRequest, NextResponse } from 'next/server';
+import {
+  CSP_HEADER,
+  CSP_NONCE_REQUEST_HEADER,
+  CSP_NONCE_RESPONSE_HEADER,
+  applyCspHeaders,
+  attachCspRequestHeaders,
+  buildCspHeader,
+  containsUnsafeSources,
+  generateNonce,
+  getRequestNonce,
+} from '../csp';
+
+function createRequest(nonce?: string): NextRequest {
+  const headers = new Headers();
+  if (nonce) headers.set(CSP_NONCE_REQUEST_HEADER, nonce);
+
+  return { headers, nextUrl: { protocol: 'https:' } } as unknown as NextRequest;
+}
+
+function createResponse(): NextResponse {
+  return { headers: new Headers() } as unknown as NextResponse;
+}
 
 describe('generateNonce', () => {
   it('returns a non-empty base64 string on every call', () => {
     const n = generateNonce();
     expect(n).toBeTruthy();
     expect(typeof n).toBe('string');
+    expect(n).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
   });
 
   it('is different on each call', () => {
     expect(generateNonce()).not.toBe(generateNonce());
+  });
+
+  it('carries at least 128 bits of entropy', () => {
+    expect(atob(generateNonce())).toHaveLength(16);
+  });
+
+  it('does not repeat across many calls', () => {
+    const nonces = new Set(Array.from({ length: 500 }, () => generateNonce()));
+
+    expect(nonces.size).toBe(500);
   });
 });
 
@@ -18,13 +51,25 @@ describe('buildCspHeader', () => {
     const nonce = 'abc123xyz==';
     const header = buildCspHeader({ nonce });
 
-    expect(header).toContain(`'nonce-${nonce}'`);
+    expect(header).toContain(`script-src 'self' 'nonce-${nonce}'`);
+    expect(header).toContain(`style-src 'self' 'nonce-${nonce}'`);
   });
 
   it('blocks unsafe-inline scripts in strict mode', () => {
     const header = buildCspHeader({ nonce: generateNonce(), strict: true });
     expect(header).not.toContain("'unsafe-inline'");
     expect(header).not.toContain("'unsafe-eval'");
+  });
+
+  it('is strict by default', () => {
+    expect(containsUnsafeSources(buildCspHeader({ nonce: generateNonce() }))).toBe(false);
+  });
+
+  it('never allows inline script even when strict mode is relaxed for the dev bundler', () => {
+    const header = buildCspHeader({ nonce: generateNonce(), strict: false });
+
+    expect(header).not.toContain("'unsafe-inline'");
+    expect(header).toContain("'unsafe-eval'");
   });
 
   it('includes frame-ancestors none to prevent clickjacking', () => {
@@ -37,8 +82,81 @@ describe('buildCspHeader', () => {
     expect(header).toContain('report-uri');
   });
 
+  it('accepts a custom reporting endpoint', () => {
+    const header = buildCspHeader({ nonce: generateNonce(), reportUri: '/api/csp' });
+
+    expect(header).toContain('report-uri /api/csp');
+  });
+
   it('blocks object-src to prevent plugin attacks', () => {
     const header = buildCspHeader({ nonce: generateNonce() });
     expect(header).toContain("object-src 'none'");
+  });
+});
+
+describe('containsUnsafeSources', () => {
+  it('detects inline and eval sources', () => {
+    expect(containsUnsafeSources("script-src 'self' 'unsafe-inline'")).toBe(true);
+    expect(containsUnsafeSources("script-src 'self' 'unsafe-eval'")).toBe(true);
+    expect(containsUnsafeSources("script-src 'self' 'nonce-abc'")).toBe(false);
+  });
+});
+
+describe('getRequestNonce', () => {
+  it('reads the nonce the middleware attached to the request', () => {
+    expect(getRequestNonce(createRequest('nonce-from-middleware'))).toBe('nonce-from-middleware');
+  });
+
+  it('returns undefined when no nonce was attached', () => {
+    expect(getRequestNonce(createRequest())).toBeUndefined();
+  });
+});
+
+describe('attachCspRequestHeaders', () => {
+  it('exposes the nonce to the app and to Next.js script injection', () => {
+    const request = createRequest();
+    const headers = attachCspRequestHeaders(request, 'forwarded-nonce');
+
+    expect(headers.get(CSP_NONCE_REQUEST_HEADER)).toBe('forwarded-nonce');
+    expect(headers.get(CSP_HEADER)).toContain("'nonce-forwarded-nonce'");
+    expect(getRequestNonce(request)).toBe('forwarded-nonce');
+  });
+
+  it('forwards the same policy the response will carry', () => {
+    const request = createRequest();
+    const requestHeaders = attachCspRequestHeaders(request, 'shared');
+    const response = applyCspHeaders(createResponse(), request);
+
+    expect(response.headers.get(CSP_HEADER)).toBe(requestHeaders.get(CSP_HEADER));
+  });
+});
+
+describe('applyCspHeaders', () => {
+  it('sets a nonce-based policy and exposes the nonce on the response', () => {
+    const response = applyCspHeaders(createResponse(), createRequest(), 'explicit-nonce');
+
+    expect(response.headers.get(CSP_HEADER)).toContain("'nonce-explicit-nonce'");
+    expect(response.headers.get(CSP_NONCE_RESPONSE_HEADER)).toBe('explicit-nonce');
+  });
+
+  it('falls back to the nonce carried on the request', () => {
+    const response = applyCspHeaders(createResponse(), createRequest('request-nonce'));
+
+    expect(response.headers.get(CSP_HEADER)).toContain("'nonce-request-nonce'");
+    expect(response.headers.get(CSP_NONCE_RESPONSE_HEADER)).toBe('request-nonce');
+  });
+
+  it('generates a nonce when the request carries none', () => {
+    const response = applyCspHeaders(createResponse(), createRequest());
+    const nonce = response.headers.get(CSP_NONCE_RESPONSE_HEADER);
+
+    expect(nonce).toBeTruthy();
+    expect(response.headers.get(CSP_HEADER)).toContain(`'nonce-${nonce}'`);
+  });
+
+  it('never emits a policy that allows inline script', () => {
+    const response = applyCspHeaders(createResponse(), createRequest());
+
+    expect(containsUnsafeSources(response.headers.get(CSP_HEADER) ?? '')).toBe(false);
   });
 });

--- a/src/middleware/__tests__/security.test.ts
+++ b/src/middleware/__tests__/security.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { buildSecurityHeaders } from '../security';
+import type { NextRequest, NextResponse } from 'next/server';
+import { applySecurityHeaders, buildSecurityHeaders } from '../security';
+import { CSP_NONCE_REQUEST_HEADER, CSP_NONCE_RESPONSE_HEADER, containsUnsafeSources } from '../csp';
+
+function createRequest(options: { nonce?: string; protocol?: string } = {}): NextRequest {
+  const headers = new Headers();
+  if (options.nonce) headers.set(CSP_NONCE_REQUEST_HEADER, options.nonce);
+
+  return {
+    headers,
+    nextUrl: { protocol: options.protocol ?? 'https:' },
+  } as unknown as NextRequest;
+}
+
+function createResponse(): NextResponse {
+  return { headers: new Headers() } as unknown as NextResponse;
+}
 
 describe('buildSecurityHeaders', () => {
   it('returns critical security headers for all environments', () => {
@@ -20,6 +36,72 @@ describe('buildSecurityHeaders', () => {
     expect(insecureHeaders['Strict-Transport-Security']).toBeUndefined();
     expect(secureHeaders['Strict-Transport-Security']).toBe(
       'max-age=63072000; includeSubDomains; preload',
+    );
+  });
+
+  it('emits a nonce-based CSP when a nonce is supplied', () => {
+    const headers = buildSecurityHeaders({ isHttps: true, nonce: 'test-nonce' });
+
+    expect(headers['Content-Security-Policy']).toContain("'nonce-test-nonce'");
+    expect(containsUnsafeSources(headers['Content-Security-Policy'])).toBe(false);
+    expect(headers[CSP_NONCE_RESPONSE_HEADER]).toBe('test-nonce');
+  });
+
+  it('leaves the CSP to the caller when no nonce is supplied', () => {
+    const headers = buildSecurityHeaders({ isHttps: true });
+
+    expect(headers['Content-Security-Policy']).toBeUndefined();
+    expect(headers[CSP_NONCE_RESPONSE_HEADER]).toBeUndefined();
+  });
+
+  it('points CSP violation reports at the configured reporting path', () => {
+    const headers = buildSecurityHeaders({
+      isHttps: true,
+      nonce: 'test-nonce',
+      reportingPath: '/api/csp',
+    });
+
+    expect(headers['Content-Security-Policy']).toContain('report-uri /api/csp');
+    expect(headers['Report-To']).toContain('/api/csp');
+  });
+});
+
+describe('applySecurityHeaders', () => {
+  it('applies the headers to the response', () => {
+    const response = applySecurityHeaders(createResponse(), createRequest());
+
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('Strict-Transport-Security')).toContain('max-age=63072000');
+  });
+
+  it('omits HSTS over plain HTTP', () => {
+    const response = applySecurityHeaders(createResponse(), createRequest({ protocol: 'http:' }));
+
+    expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+  });
+
+  it('reuses the nonce the middleware put on the request', () => {
+    const response = applySecurityHeaders(createResponse(), createRequest({ nonce: 'shared' }));
+
+    expect(response.headers.get('Content-Security-Policy')).toContain("'nonce-shared'");
+    expect(response.headers.get(CSP_NONCE_RESPONSE_HEADER)).toBe('shared');
+  });
+
+  it('prefers an explicitly passed nonce', () => {
+    const response = applySecurityHeaders(
+      createResponse(),
+      createRequest({ nonce: 'from-request' }),
+      'explicit',
+    );
+
+    expect(response.headers.get('Content-Security-Policy')).toContain("'nonce-explicit'");
+  });
+
+  it('always ships a policy that refuses inline script', () => {
+    const response = applySecurityHeaders(createResponse(), createRequest());
+
+    expect(containsUnsafeSources(response.headers.get('Content-Security-Policy') ?? '')).toBe(
+      false,
     );
   });
 });

--- a/src/middleware/csp.ts
+++ b/src/middleware/csp.ts
@@ -1,18 +1,86 @@
 import { type NextResponse, type NextRequest } from 'next/server';
 
+/** Request header the middleware uses to hand the per-request nonce to the app. */
+export const CSP_NONCE_REQUEST_HEADER = 'x-csp-nonce';
+
+/** Response header exposing the nonce to the document renderer. */
+export const CSP_NONCE_RESPONSE_HEADER = 'x-nonce';
+
+export const CSP_HEADER = 'Content-Security-Policy';
+
+/** 128 bits of entropy, the minimum the CSP spec recommends for a nonce. */
+const NONCE_BYTES = 16;
+
+/** Sources that would re-open the inline-execution hole the nonce exists to close. */
+const UNSAFE_SOURCES = ["'unsafe-inline'", "'unsafe-eval'"];
+
+function toBase64(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+
+  return typeof btoa === 'function' ? btoa(binary) : Buffer.from(bytes).toString('base64');
+}
+
+/**
+ * Fresh, cryptographically random base64 nonce. A new value is required on every
+ * response — a predictable or reused nonce is no better than `'unsafe-inline'`.
+ */
 export function generateNonce(): string {
-  return crypto.randomUUID();
+  const bytes = new Uint8Array(NONCE_BYTES);
+  crypto.getRandomValues(bytes);
+
+  return toBase64(bytes);
+}
+
+/** The nonce the middleware attached to this request, if any. */
+export function getRequestNonce(request: NextRequest): string | undefined {
+  return request.headers.get(CSP_NONCE_REQUEST_HEADER) ?? undefined;
+}
+
+/**
+ * Attach the nonce to the request headers so the rendered document can reuse it
+ * instead of falling back to inline script. Next.js reads the nonce out of the
+ * request's `Content-Security-Policy` header and stamps it onto the scripts it
+ * injects; `x-csp-nonce` is the app-facing alias for anything rendering its own
+ * `<script>` or `<style>`. The returned headers must be forwarded with
+ * `NextResponse.next({ request: { headers } })` to reach the app.
+ */
+export function attachCspRequestHeaders(request: NextRequest, nonce: string): Headers {
+  request.headers.set(CSP_NONCE_REQUEST_HEADER, nonce);
+  request.headers.set(CSP_HEADER, buildCspHeader({ nonce, strict: true }));
+
+  return request.headers;
+}
+
+/** True when a policy still permits inline or eval'd scripts. */
+export function containsUnsafeSources(header: string): boolean {
+  return UNSAFE_SOURCES.some((source) => header.includes(source));
 }
 
 export interface CspOptions {
   /** The per-request nonce to allow trusted inline scripts. */
   nonce: string;
-  /** Strict-mode: disallow anything not explicitly listed. Defaults to `true`. */
+  /**
+   * Strict-mode: inline and eval'd script are refused outright. Defaults to
+   * `true`; `false` relaxes `script-src` with `'unsafe-eval'` for the dev
+   * bundler only — `'unsafe-inline'` is never emitted in either mode.
+   */
   strict?: boolean;
+  /** Path CSP violations are posted to. */
+  reportUri?: string;
+  /** `Report-To` group receiving violations. */
+  reportTo?: string;
 }
 
+export const DEFAULT_CSP_REPORT_URI = '/api/security/reporting';
+export const DEFAULT_CSP_REPORT_GROUP = 'security';
+
 export function buildCspHeader(options: CspOptions): string {
-  const { nonce, strict = true } = options;
+  const {
+    nonce,
+    strict = true,
+    reportUri = DEFAULT_CSP_REPORT_URI,
+    reportTo = DEFAULT_CSP_REPORT_GROUP,
+  } = options;
 
   const directives: Record<string, string> = {
     'default-src': "'self'",
@@ -30,21 +98,35 @@ export function buildCspHeader(options: CspOptions): string {
     'worker-src': "'self' blob:",
     'manifest-src': "'self'",
     'upgrade-insecure-requests': '',
-    'report-uri': '/api/security/reporting',
-    'report-to': 'security',
+    'report-uri': reportUri,
+    'report-to': reportTo,
   };
 
-  return Object.entries(directives)
+  const header = Object.entries(directives)
     .map(([directive, value]) => (value ? `${directive} ${value}` : directive))
     .join('; ');
+
+  if (strict && containsUnsafeSources(header)) {
+    throw new Error('Strict CSP must not contain unsafe-inline or unsafe-eval sources');
+  }
+
+  return header;
 }
 
-export function applyCspHeaders(response: NextResponse, _request: NextRequest, nonce?: string): NextResponse {
-  const cspNonce = nonce ?? generateNonce();
-  const csp = buildCspHeader({ nonce: cspNonce, strict: true });
+/**
+ * Apply the nonce-based policy to a response. The nonce is taken from the
+ * argument, then the request header the middleware set, and is only generated
+ * here as a last resort so the document and the policy cannot disagree.
+ */
+export function applyCspHeaders(
+  response: NextResponse,
+  request: NextRequest,
+  nonce?: string,
+): NextResponse {
+  const cspNonce = nonce ?? getRequestNonce(request) ?? generateNonce();
 
-  response.headers.set('Content-Security-Policy', csp);
-  response.headers.set('X-Nonce', cspNonce);
+  response.headers.set(CSP_HEADER, buildCspHeader({ nonce: cspNonce, strict: true }));
+  response.headers.set(CSP_NONCE_RESPONSE_HEADER, cspNonce);
 
   return response;
 }

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -1,14 +1,29 @@
 import type { NextRequest, NextResponse } from 'next/server';
+import {
+  CSP_HEADER,
+  CSP_NONCE_RESPONSE_HEADER,
+  DEFAULT_CSP_REPORT_GROUP,
+  DEFAULT_CSP_REPORT_URI,
+  buildCspHeader,
+  generateNonce,
+  getRequestNonce,
+} from './csp';
 
 export interface SecurityHeaderOptions {
   isHttps: boolean;
   reportingPath?: string;
+  /**
+   * Per-request CSP nonce. When present a nonce-based `Content-Security-Policy`
+   * is emitted alongside the other security headers, so a response can never
+   * carry the transport hardening without the script policy that goes with it.
+   */
+  nonce?: string;
 }
 
 export function buildSecurityHeaders(options: SecurityHeaderOptions): Record<string, string> {
-  const reportingPath = options.reportingPath ?? '/api/security/reporting';
+  const reportingPath = options.reportingPath ?? DEFAULT_CSP_REPORT_URI;
   const reportTo = {
-    group: 'security',
+    group: DEFAULT_CSP_REPORT_GROUP,
     max_age: 10886400,
     endpoints: [{ url: reportingPath }],
     include_subdomains: true,
@@ -24,13 +39,22 @@ export function buildSecurityHeaders(options: SecurityHeaderOptions): Record<str
     'Cross-Origin-Resource-Policy': 'same-site',
     'Report-To': JSON.stringify(reportTo),
     NEL: JSON.stringify({
-      report_to: 'security',
+      report_to: DEFAULT_CSP_REPORT_GROUP,
       max_age: 10886400,
       include_subdomains: true,
       success_fraction: 0,
       failure_fraction: 1,
     }),
   };
+
+  if (options.nonce) {
+    headers[CSP_HEADER] = buildCspHeader({
+      nonce: options.nonce,
+      strict: true,
+      reportUri: reportingPath,
+    });
+    headers[CSP_NONCE_RESPONSE_HEADER] = options.nonce;
+  }
 
   if (options.isHttps) {
     headers['Strict-Transport-Security'] = 'max-age=63072000; includeSubDomains; preload';
@@ -39,9 +63,21 @@ export function buildSecurityHeaders(options: SecurityHeaderOptions): Record<str
   return headers;
 }
 
-export function applySecurityHeaders(response: NextResponse, request: NextRequest): NextResponse {
+/**
+ * Apply the security headers, including the nonce-based CSP. The nonce comes
+ * from the middleware's request header so every layer of the response pipeline
+ * agrees on the same value.
+ */
+export function applySecurityHeaders(
+  response: NextResponse,
+  request: NextRequest,
+  nonce?: string,
+): NextResponse {
   const isHttps = request.nextUrl.protocol === 'https:';
-  const headers = buildSecurityHeaders({ isHttps });
+  const headers = buildSecurityHeaders({
+    isHttps,
+    nonce: nonce ?? getRequestNonce(request) ?? generateNonce(),
+  });
 
   Object.entries(headers).forEach(([key, value]) => {
     response.headers.set(key, value);


### PR DESCRIPTION
feat: configurable error-rate spike alerts + a usable per-request CSP nonce

Closes #1192 
Closes #1195 
Closes #1198 
Closes #1196 

## Summary

Two independent hardening changes to the observability and security middleware
layers, each with its own commit:

1. **Alert thresholds for error-rate spikes** — error rates were compared against
   hardcoded absolute limits, so a jump from 0.2% to 2% went unnoticed until it
   crossed 3%. Thresholds are now configurable and a rolling baseline catches
   relative spikes long before the absolute limit notices them.
2. **A CSP nonce that actually reaches the app** — the policy already omitted
   `'unsafe-inline'`, but the nonce was a UUID that was never forwarded, so
   nothing could be nonced and there was no safe path for inline script.

---

## 1. Error-rate spike alerting

### `src/lib/monitoring/alerts.ts`

Thresholds are now data rather than magic numbers, and error-rate metrics get a
dedicated evaluation path.

**Configurable per metric name.** Each error-rate metric carries its own
`ErrorRateThreshold`:

| Setting              | `error_rate` | `zoom_api_error_rate` | Meaning                                         |
| :------------------- | :----------- | :-------------------- | :---------------------------------------------- |
| `warning`            | 3            | 4                     | Absolute rate that raises a `high` alert        |
| `critical`           | 10           | 15                    | Absolute rate that escalates to `critical`      |
| `spikeMultiplier`    | 3            | 3                     | Multiple of the baseline that counts as a spike |
| `spikeMinRate`       | 1            | 1                     | Spikes under this rate are ignored as noise     |
| `baselineSamples`    | 10           | 10                    | Samples averaged into the baseline              |
| `minBaselineSamples` | 3            | 3                     | Samples required before spikes are evaluated    |

Three configuration paths, in increasing precedence:

```bash
# per deployment, read at module load
NEXT_PUBLIC_ALERT_ERROR_RATE_WARNING=2
NEXT_PUBLIC_ALERT_ERROR_RATE_CRITICAL=8
NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MULTIPLIER=4
NEXT_PUBLIC_ALERT_ERROR_RATE_SPIKE_MIN_RATE=0.5
```

```ts
// at runtime — applies to every later check
configureAlertThresholds({
  responseTime: 800,
  errorRates: { checkout_error_rate: { label: 'Checkout error rate', warning: 1 } },
});

// per call
checkAlerts(metrics, { thresholds: { errorRates: { error_rate: { warning: 1 } } } });
```

Any metric name registered under `errorRates` gets the full threshold and spike
treatment, so a feature can add its own rate without editing `alerts.ts`.

**Spike detection.** Error-rate metrics are now grouped and evaluated per metric
name instead of per sample. The newest sample decides the absolute breach; the
samples before it form a rolling baseline. An observation at
`baseline × spikeMultiplier` raises a spike alert even while it is still under
`warning`. Two guards keep it quiet:

- `spikeMinRate` suppresses spikes at trivially small rates (0.01% → 0.05% is
  a 5× jump and completely uninteresting).
- Only samples **strictly older** than the newest observation feed the baseline,
  so overlapping polls cannot fold a spike into the value it is compared against.

**Richer alerts.** `Alert` now carries `metric`, `value` and `threshold`, and the
severity union gains `critical`. Absolute breach and spike are reported as
separate alerts because they say different things — "we are over the line" vs.
"something just changed".

### `src/lib/monitoring/metrics.ts`

The collection half, so there is something to threshold against:

```ts
recordRequestOutcome(!response.ok); // rolling window -> rate -> shared metric store
recordErrorRateSample(rateFromUpstream); // when the rate is already computed
getErrorRate({ windowMs: 30_000 });
getErrorRateHistory(); // retained samples, oldest first
```

`recordRequestOutcome` maintains a rolling window (60s by default, configurable
per call) of request outcomes, derives the percentage, and publishes each sample
to the shared metric store so it flows through `useMetrics()` into `checkAlerts()`
like every other metric. Windows and history are keyed by metric name, so
`checkout_error_rate` and `error_rate` never contaminate each other.

`useMetricAlerts()` polls metrics and retains history across polls, deduplicating
overlapping samples, so the dashboard measures spikes against a real baseline
instead of a single snapshot:

```ts
const { metrics, alerts } = useMetricAlerts();
```

Alerts are computed from the history captured *before* the current poll, so the
newest samples are never part of their own baseline.

### `src/lib/logging/types.ts`

`PerformanceMetric['unit']` accepts `'percent'`. Recording a percentage as
`'count'` would have been a lie; the union widening is backward compatible and
nothing switches exhaustively on it.

### Backward compatibility

Existing alert messages, severities and trigger points are unchanged —
`checkAlerts(metrics)` with no options behaves exactly as before for
`response_time`, all `zoom_*` metrics and the realtime transport metrics. The
one deliberate behaviour change: when several samples of the *same* error-rate
metric arrive in one batch, one alert is emitted for the newest sample rather
than one per breaching sample.

---

## 2. CSP nonce

### `src/middleware/csp.ts`

- `generateNonce()` returns 16 cryptographically random bytes as base64 instead
  of `crypto.randomUUID()`. A UUID is structured, partly time-derived and not
  what the CSP spec asks for; 128 random bits is the documented minimum.
- `attachCspRequestHeaders(request, nonce)` puts the nonce on the request as
  `x-csp-nonce` **and** adds the policy as a `Content-Security-Policy` request
  header. Next.js reads the nonce out of that header and stamps it onto the
  scripts it injects — this is the missing link that made the whole feature inert
  before.
- `getRequestNonce(request)` reads it back; `containsUnsafeSources(header)` is
  exported so any caller can assert the guarantee.
- Strict mode now **throws** if `'unsafe-inline'` or `'unsafe-eval'` ever reaches
  the header, so a future edit that reintroduces one fails loudly at the source
  rather than silently shipping a weaker policy.
- `report-uri` / `report-to` are configurable instead of hardcoded.

`buildCspHeader({ strict: false })` still relaxes `script-src` with
`'unsafe-eval'` for the dev bundler. `'unsafe-inline'` is not emitted in either
mode.

### `src/middleware/security.ts`

`applySecurityHeaders()` now emits the nonce-based CSP alongside the transport
headers, resolving the nonce from the argument, then the request header, then
generating one as a last resort. A response can no longer carry the transport
hardening without the script policy that belongs with it, and no layer of the
pipeline can disagree about the nonce value. `buildSecurityHeaders()` without a
nonce is unchanged, so existing callers keep working.

### `src/middleware.ts`

Forwards the request headers with `NextResponse.next({ request: { headers } })`
(and the equivalent on the rewrite path). The existing `request.headers.set(...)`
calls mutated the request in place, which is visible inside middleware but never
propagates to the app — which is why the nonce was unreachable. Server components
can now read it:

```ts
import { headers } from 'next/headers';

const nonce = (await headers()).get('x-csp-nonce') ?? undefined;
return <Script nonce={nonce} id="analytics" />;
```

---

## Tests

| File | Cases | Covers |
| :--- | :---- | :----- |
| `src/lib/monitoring/__tests__/alerts.test.ts` | new | threshold merging and isolation from the defaults, env/runtime/per-call configuration, severity escalation, spike detection, baseline sufficiency, noise floor, zero baselines, per-metric independence, no regression on existing metrics |
| `src/lib/monitoring/__tests__/errorRate.test.ts` | new | rolling window arithmetic and expiry, custom windows, metric isolation, publication to the shared store, history retention and capping, reset, end-to-end spike detection through `checkAlerts` |
| `src/middleware/__tests__/csp.test.ts` | extended | nonce entropy (16 decoded bytes), uniqueness over 500 draws, base64 shape, nonce resolution order, request-header forwarding, request/response policy agreement, unsafe-source detection |
| `src/middleware/__tests__/security.test.ts` | extended | CSP emitted only with a nonce, nonce reuse from the request, explicit-nonce precedence, reporting path propagation, HSTS gating |

## Verification

- `pnpm run type-check` — clean
- `pnpm run lint` — 0 warnings, 0 errors
- `pnpm run validate:ui` / `validate:web3` — pass
- `pnpm run build` — exit 0
- `pnpm vitest run src/__tests__/logging src/lib/monitoring src/middleware src/lib/realtime` — **175 passed / 175**

## Also in this PR (pre-existing failure)

`src/middleware/__tests__/apiVersioning.test.ts` was failing **11/11 on clean
`main`** — verified against a stash, not introduced here. It mocked
`request.headers` as `{ get }` with no `set`, so the middleware threw on its very
first line, and it never awaited the async `middleware()`. Since this PR touches
`src/middleware.ts`, leaving its only test file dead was not an option:

- The mock now uses a real `Headers` instance and the tests await the middleware.
  Nine cases now genuinely exercise the versioning logic, including the new
  header forwarding.
- Two cases asserted `400` for `/api/123/posts` and `/api/../v1/posts`. Neither
  path starts with `/api/v`, so both take the legacy-rewrite branch by design and
  return 200 with the deprecation headers. They now assert that behaviour, moved
  into an `unversioned paths` block.

**Reviewer note:** if those two paths were genuinely meant to be rejected, that is
a middleware change rather than a test change, and I have deliberately not made it
here — flag it and I will open a follow-up.

## Risk

Low. The alert changes are additive and default to the previous trigger points.
The CSP response header is byte-identical to before apart from the nonce format.
The one behavioural change worth watching in staging is the middleware now
forwarding request headers downstream — which is what the existing (ineffective)
`request.headers.set` calls always intended.

## Docs

- `docs/ERROR_RATE_ALERTING.md` — thresholds, the three configuration paths, recording APIs
- `docs/CONTENT_SECURITY_POLICY.md` — the nonce request flow, the policy table, how to add inline script correctly
