### PR TITLE
fix: Propagate trace IDs into audit log entries

### DIFF
--- a/src/lib/audit/__tests__/store.test.ts
+++ b/src/lib/audit/__tests__/store.test.ts
@@ -27,6 +27,16 @@ describe('audit store', () => {
     expect(entry.method).toBe('POST');
   });
 
+  it('propagates the trace id into the log entry', () => {
+    const entry = appendAuditLog({ ...baseInput, traceId: 'trace_abc123' });
+    expect(entry.traceId).toBe('trace_abc123');
+  });
+
+  it('omits trace id when not provided', () => {
+    const entry = appendAuditLog(baseInput);
+    expect(entry.traceId).toBeUndefined();
+  });
+
   it('returns filtered results by action', () => {
     appendAuditLog({ ...baseInput, action: 'delete', targetId: 'note_del' });
     const { entries } = queryAuditLogs({ action: 'delete' });

--- a/src/lib/audit/store.ts
+++ b/src/lib/audit/store.ts
@@ -20,6 +20,7 @@ export function appendAuditLog(input: CreateAuditLogInput): AuditLogEntry {
     userAgent: input.userAgent,
     statusCode: input.statusCode,
     timestamp: new Date().toISOString(),
+    traceId: input.traceId,
     metadata: input.metadata,
   };
 

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -12,6 +12,7 @@ export interface AuditLogEntry {
   userAgent: string;
   timestamp: string;
   statusCode: number;
+  traceId?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -25,6 +26,7 @@ export interface CreateAuditLogInput {
   ip: string;
   userAgent: string;
   statusCode: number;
+  traceId?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/middleware/__tests__/audit.test.ts
+++ b/src/middleware/__tests__/audit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { logAuditMutation } from '../audit';
+
+vi.mock('@/lib/audit', () => ({
+  appendAuditLog: vi.fn(),
+}));
+
+import { appendAuditLog } from '@/lib/audit';
+
+function createMockRequest(headers: Record<string, string> = {}): Request {
+  return {
+    url: 'http://localhost/api/notes',
+    method: 'POST',
+    headers: {
+      get: (key: string) => headers[key.toLowerCase()] ?? null,
+    },
+  } as unknown as Request;
+}
+
+describe('logAuditMutation', () => {
+  it('propagates the x-trace-id header into the audit entry', () => {
+    const request = createMockRequest({ 'x-trace-id': 'trace_xyz' });
+    logAuditMutation(request, {
+      action: 'create',
+      targetType: 'note',
+      targetId: 'note_1',
+      statusCode: 201,
+    });
+
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: 'trace_xyz' }),
+    );
+  });
+
+  it('omits trace id when header is absent', () => {
+    const request = createMockRequest();
+    logAuditMutation(request, {
+      action: 'create',
+      targetType: 'note',
+      targetId: 'note_1',
+      statusCode: 201,
+    });
+
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: undefined }),
+    );
+  });
+});

--- a/src/middleware/audit.ts
+++ b/src/middleware/audit.ts
@@ -50,6 +50,7 @@ export function logAuditMutation(request: Request, input: AuditMutationInput): v
     ip: getClientIp(request),
     userAgent: getRequestHeader(request, 'user-agent') || 'unknown',
     statusCode: input.statusCode,
+    traceId: getRequestHeader(request, 'x-trace-id') || undefined,
     metadata: input.metadata,
   });
 }


### PR DESCRIPTION
## Summary
Propagated trace IDs into audit log entries.

Changes:
- `src/lib/audit/types.ts`: Added optional `traceId?: string` to both `AuditLogEntry` and `CreateAuditLogInput` interfaces.
- `src/lib/audit/store.ts`: `appendAuditLog` now copies `input.traceId` into the stored entry.
- `src/middleware/audit.ts`: `logAuditMutation` reads the `x-trace-id` request header (set by the root middleware) and passes it to `appendAuditLog`.
- `src/lib/audit/__tests__/store.test.ts`: Added tests verifying traceId is propagated and omitted when absent.
- `src/middleware/__tests__/audit.test.ts`: New test file verifying the middleware reads the `x-trace-id` header and passes it through, and omits it when absent.

The traceId field is optional, so existing direct `appendAuditLog` callers (route handlers) remain unaffected and backward compatible.

## Changed files
- `src/lib/audit/__tests__/store.test.ts`
- `src/lib/audit/store.ts`
- `src/lib/audit/types.ts`
- `src/middleware/__tests__/audit.test.ts`
- `src/middleware/audit.ts`

## Test plan
Run the audit-related unit tests:
- `npx vitest run src/lib/audit/__tests__/store.test.ts`
- `npx vitest run src/middleware/__tests__/audit.test.ts`

Also run the full test suite to confirm no regressions: `npx vitest run`.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #1194
