### PR TITLE
fix: persist study group state in useEffect instead of useMemo

### DIFF
--- a/src/app/hooks/useStudyGroups.tsx
+++ b/src/app/hooks/useStudyGroups.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useNotificationStore } from '@/app/store/notificationStore';
 
@@ -614,8 +614,9 @@ export function useStudyGroups(currentUser?: { id: string; name: string }): UseS
   );
 
   // Persist when state changes (robust against batch updates via persistAll)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useMemo(() => persistAll(), [groups, messages, resources, challenges, certificates, persistAll]);
+  useEffect(() => {
+    persistAll();
+  }, [persistAll]);
 
   return {
     groups,


### PR DESCRIPTION
Summary
- Replaced the useMemo(() => persistAll(), ...) side-effect hack in useStudyGroups with a proper useEffect. persistAll is a useCallback already depending on all four state slices, so the effect runs exactly when state changes.
- Eliminates the react-hooks/exhaustive-deps disable and the risk of unexpected/double writes under Strict Mode and concurrent rendering.
- Removed the now-unused useMemo import.
Testing
- ESLint passes on the modified file.
- Existing per-action save() calls remain intact; the effect adds robust batch persistence as before.

closes #932
