### PR TITLE
feat(email,scheduler,offline): idempotent sends, template validation, cron validation, connectivity debounce

### DIFF
--- a/src/hooks/__tests__/useOfflineModeConnectivity.test.tsx
+++ b/src/hooks/__tests__/useOfflineModeConnectivity.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const syncData = vi.fn(async () => ({
+  success: true,
+  syncedItems: 0,
+  conflicts: [],
+  errors: [],
+  lastSyncTime: new Date().toISOString(),
+}));
+
+vi.mock('../../services/offlineSync', () => ({
+  OfflineStorage: class {
+    async init() {}
+    async clearAll() {}
+  },
+  OfflineSyncService: class {
+    syncData = syncData;
+    async getSyncStatus() {
+      return {
+        isSyncing: false,
+        pending: 0,
+        conflicted: 0,
+        resolved: 0,
+        deadLetter: 0,
+        lastSyncTime: null,
+      };
+    }
+  },
+}));
+
+vi.mock('../../store/synchronizationEngine', () => ({
+  syncEngine: { recordDrainResult: vi.fn(async () => undefined) },
+}));
+
+import { useOfflineMode } from '../useOfflineMode';
+
+const goOffline = () => {
+  Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+  window.dispatchEvent(new Event('offline'));
+};
+
+const goOnline = () => {
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+  window.dispatchEvent(new Event('online'));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  syncData.mockClear();
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useOfflineMode connectivity debouncing', () => {
+  it('starts from the browser online state', () => {
+    const { result } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 100 }));
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('reports going offline once the state holds', async () => {
+    const { result } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 100 }));
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  // Each `online` event used to start a sync that the next `offline` cut
+  // short, so the queue never drained and every attempt burned a retry.
+  it('does not sync while connectivity is flapping', async () => {
+    renderHook(() => useOfflineMode({ connectivityDebounceMs: 500 }));
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(50);
+      goOnline();
+      await vi.advanceTimersByTimeAsync(50);
+      goOffline();
+      await vi.advanceTimersByTimeAsync(50);
+      goOnline();
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(syncData).not.toHaveBeenCalled();
+  });
+
+  it('syncs once when connectivity settles online', async () => {
+    const { result } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 100 }));
+
+    await act(async () => {
+      await result.current.initializeOfflineMode();
+    });
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    await act(async () => {
+      goOnline();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(syncData).toHaveBeenCalledTimes(1);
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('does not sync when the settled state is offline', async () => {
+    renderHook(() => useOfflineMode({ connectivityDebounceMs: 100 }));
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(syncData).not.toHaveBeenCalled();
+  });
+
+  it('flushes the pending state on demand', async () => {
+    const { result } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 10_000 }));
+
+    await act(async () => {
+      goOffline();
+    });
+
+    expect(result.current.isOnline).toBe(true);
+
+    await act(async () => {
+      result.current.flushConnectivity();
+    });
+
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  // A timer firing after unmount would sync against a torn-down service.
+  it('cancels a pending transition on unmount', async () => {
+    const { unmount } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 500 }));
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(50);
+      goOnline();
+    });
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(syncData).not.toHaveBeenCalled();
+  });
+
+  it('stops listening after unmount', async () => {
+    const { unmount } = renderHook(() => useOfflineMode({ connectivityDebounceMs: 100 }));
+
+    unmount();
+
+    await act(async () => {
+      goOffline();
+      await vi.advanceTimersByTimeAsync(1_000);
+      goOnline();
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(syncData).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useOfflineMode.tsx
+++ b/src/hooks/useOfflineMode.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CONNECTIVITY_DEBOUNCE_MS,
+  createConnectivityDebouncer,
+  type ConnectivityDebouncer,
+} from '../utils/pwaUtils';
 import {
   OfflineStorage,
   OfflineSyncService,
@@ -41,11 +46,21 @@ const estimateCourseSize = (course: DownloadCourseInput) => {
   return (course.sizeBytes || 0) + moduleEstimate + assetEstimate;
 };
 
-export const useOfflineMode = () => {
+export interface OfflineModeOptions {
+  /** Settle time for connectivity changes. Defaults to CONNECTIVITY_DEBOUNCE_MS. */
+  connectivityDebounceMs?: number;
+}
+
+export const useOfflineMode = (options: OfflineModeOptions = {}) => {
+  const { connectivityDebounceMs = CONNECTIVITY_DEBOUNCE_MS } = options;
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isOnline, setIsOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine,
+  );
 
   const storageRef = useRef<OfflineStorage | null>(null);
   const syncRef = useRef<OfflineSyncService | null>(null);
+  const debouncerRef = useRef<ConnectivityDebouncer | null>(null);
 
   const initializeOfflineMode = useCallback(async () => {
     if (storageRef.current && syncRef.current) {
@@ -285,9 +300,58 @@ export const useOfflineMode = () => {
     return URL.createObjectURL(asset.data);
   }, []);
 
+  // Held in a ref so the listeners below are attached once, rather than being
+  // torn down and re-subscribed every time syncData's identity changes.
+  const syncDataRef = useRef(syncData);
+  syncDataRef.current = syncData;
+
+  /**
+   * Reacts to connectivity only once it has held for the debounce window.
+   *
+   * A flapping connection fires `online`/`offline` several times a second, and
+   * each `online` used to start a sync that the next `offline` interrupted —
+   * so the queue never drained and every partial attempt burned a retry.
+   */
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const debouncer = createConnectivityDebouncer(
+      navigator.onLine,
+      (online) => {
+        setIsOnline(online);
+        if (online) void syncDataRef.current().catch(() => undefined);
+      },
+      { debounceMs: connectivityDebounceMs },
+    );
+
+    debouncerRef.current = debouncer;
+
+    const handleOnline = () => debouncer.push(true);
+    const handleOffline = () => debouncer.push(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      // A pending timer firing after unmount would sync against a torn-down
+      // service.
+      debouncer.cancel();
+      debouncerRef.current = null;
+    };
+  }, [connectivityDebounceMs]);
+
+  /** Applies the pending connectivity state immediately, skipping the wait. */
+  const flushConnectivity = useCallback(() => {
+    debouncerRef.current?.flush();
+  }, []);
+
   return useMemo(
     () => ({
       isInitialized,
+      isOnline,
+      flushConnectivity,
       initializeOfflineMode,
       cleanupOfflineMode,
       downloadCourse,
@@ -310,6 +374,8 @@ export const useOfflineMode = () => {
     }),
     [
       isInitialized,
+      isOnline,
+      flushConnectivity,
       initializeOfflineMode,
       cleanupOfflineMode,
       downloadCourse,

--- a/src/lib/email/__tests__/queue-idempotency.test.ts
+++ b/src/lib/email/__tests__/queue-idempotency.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailQueue } from '../queue';
+import { deriveIdempotencyKey, scopedIdempotencyKey, withIdempotencyKey } from '../idempotency';
+import type { EmailMessage, EmailProvider, EmailSendResult } from '../types';
+
+const message = (overrides: Partial<EmailMessage> = {}): EmailMessage => ({
+  to: { email: 'ada@teachlink.test', name: 'Ada' },
+  subject: 'Reset your password',
+  html: '<p>link</p>',
+  text: 'link',
+  ...overrides,
+});
+
+function provider(
+  send: (message: EmailMessage) => Promise<EmailSendResult> = async () => ({
+    success: true,
+    provider: 'mock',
+    messageId: 'id-1',
+  }),
+): EmailProvider & { send: ReturnType<typeof vi.fn> } {
+  return { type: 'mock', send: vi.fn(send) } as EmailProvider & { send: ReturnType<typeof vi.fn> };
+}
+
+describe('deriveIdempotencyKey', () => {
+  it('is stable for the same message', () => {
+    expect(deriveIdempotencyKey(message())).toBe(deriveIdempotencyKey(message()));
+  });
+
+  it('changes with the subject', () => {
+    expect(deriveIdempotencyKey(message({ subject: 'Other' }))).not.toBe(
+      deriveIdempotencyKey(message()),
+    );
+  });
+
+  it('changes with the body', () => {
+    expect(deriveIdempotencyKey(message({ html: '<p>other</p>' }))).not.toBe(
+      deriveIdempotencyKey(message()),
+    );
+  });
+
+  it('changes with the recipient', () => {
+    expect(deriveIdempotencyKey(message({ to: { email: 'grace@teachlink.test' } }))).not.toBe(
+      deriveIdempotencyKey(message()),
+    );
+  });
+
+  // Recipient order and casing are not part of what the message *is*.
+  it('ignores recipient order and case', () => {
+    const first = deriveIdempotencyKey(
+      message({ to: [{ email: 'a@x.test' }, { email: 'b@x.test' }] }),
+    );
+    const second = deriveIdempotencyKey(
+      message({ to: [{ email: 'B@x.test' }, { email: 'A@x.test' }] }),
+    );
+
+    expect(second).toBe(first);
+  });
+
+  it('ignores tags, which are routing metadata', () => {
+    expect(deriveIdempotencyKey(message({ tags: ['transactional'] }))).toBe(
+      deriveIdempotencyKey(message()),
+    );
+  });
+});
+
+describe('withIdempotencyKey', () => {
+  it('derives a key when none was supplied', () => {
+    expect(withIdempotencyKey(message()).idempotencyKey).toBe(deriveIdempotencyKey(message()));
+  });
+
+  it('keeps a caller-supplied key', () => {
+    const supplied = message({ idempotencyKey: 'reset:user-42' });
+
+    expect(withIdempotencyKey(supplied)).toBe(supplied);
+  });
+});
+
+describe('scopedIdempotencyKey', () => {
+  it('namespaces the identifier', () => {
+    expect(scopedIdempotencyKey('password-reset', 'user-42')).toBe('password-reset:user-42');
+  });
+});
+
+describe('EmailQueue idempotency', () => {
+  it('sends a message with no key every time', async () => {
+    const mock = provider();
+    const queue = new EmailQueue(mock);
+
+    await queue.enqueue(message());
+    await queue.enqueue(message());
+
+    expect(mock.send).toHaveBeenCalledTimes(2);
+  });
+
+  // The duplicate a retried API call or a double-clicked button produces.
+  it('sends only once for a repeated key', async () => {
+    const mock = provider();
+    const queue = new EmailQueue(mock);
+    const withKey = message({ idempotencyKey: 'reset:user-42' });
+
+    const first = await queue.enqueue(withKey);
+    const second = await queue.enqueue(withKey);
+
+    expect(mock.send).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('dedupes concurrent enqueues of the same key', async () => {
+    const mock = provider(
+      async () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ success: true, provider: 'mock', messageId: 'id-1' }), 5),
+        ),
+    );
+    const queue = new EmailQueue(mock);
+    const withKey = message({ idempotencyKey: 'reset:user-42' });
+
+    const [first, second] = await Promise.all([queue.enqueue(withKey), queue.enqueue(withKey)]);
+
+    expect(mock.send).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it('keeps different keys independent', async () => {
+    const mock = provider();
+    const queue = new EmailQueue(mock);
+
+    await queue.enqueue(message({ idempotencyKey: 'a' }));
+    await queue.enqueue(message({ idempotencyKey: 'b' }));
+
+    expect(mock.send).toHaveBeenCalledTimes(2);
+  });
+
+  // A send that failed is not a delivery, so the key must not block a retry.
+  it('allows a retry after a failed send', async () => {
+    const mock = provider();
+    mock.send
+      .mockResolvedValueOnce({ success: false, provider: 'mock', error: 'smtp down' })
+      .mockResolvedValueOnce({ success: false, provider: 'mock', error: 'smtp down' })
+      .mockResolvedValueOnce({ success: false, provider: 'mock', error: 'smtp down' })
+      .mockResolvedValue({ success: true, provider: 'mock', messageId: 'id-2' });
+
+    const queue = new EmailQueue(mock, { maxRetries: 3, retryDelayMs: 0 });
+    const withKey = message({ idempotencyKey: 'reset:user-42' });
+
+    const failed = await queue.enqueue(withKey);
+    expect(failed.success).toBe(false);
+
+    const retried = await queue.enqueue(withKey);
+    expect(retried.success).toBe(true);
+  });
+
+  it('sends again once the key has aged out', async () => {
+    const mock = provider();
+    const queue = new EmailQueue(mock, { idempotencyTtlMs: 1_000 });
+    const withKey = message({ idempotencyKey: 'reset:user-42' });
+
+    await queue.enqueue(withKey, 0);
+    await queue.enqueue(withKey, 2_000);
+
+    expect(mock.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('still dedupes inside the window', async () => {
+    const mock = provider();
+    const queue = new EmailQueue(mock, { idempotencyTtlMs: 10_000 });
+    const withKey = message({ idempotencyKey: 'reset:user-42' });
+
+    await queue.enqueue(withKey, 0);
+    await queue.enqueue(withKey, 5_000);
+
+    expect(mock.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('prunes aged keys', async () => {
+    const queue = new EmailQueue(provider(), { idempotencyTtlMs: 1_000 });
+
+    await queue.enqueue(message({ idempotencyKey: 'a' }), 0);
+    expect(queue.idempotencyCacheSize).toBe(1);
+
+    expect(queue.pruneIdempotencyCache(5_000)).toBe(1);
+    expect(queue.idempotencyCacheSize).toBe(0);
+  });
+
+  it('clears the cache on request', async () => {
+    const queue = new EmailQueue(provider());
+
+    await queue.enqueue(message({ idempotencyKey: 'a' }));
+    queue.clearIdempotencyCache();
+
+    expect(queue.idempotencyCacheSize).toBe(0);
+  });
+});
+
+describe('EmailQueue delivery', () => {
+  // Every enqueue used to share one resolver, so with two messages in flight
+  // an enqueue could resolve with the other message's result.
+  it('resolves each enqueue with its own result', async () => {
+    const mock = provider(async (sent) => ({
+      success: true,
+      provider: 'mock',
+      messageId: `id-${sent.subject}`,
+    }));
+    const queue = new EmailQueue(mock, { maxConcurrent: 2 });
+
+    const [first, second] = await Promise.all([
+      queue.enqueue(message({ subject: 'first' })),
+      queue.enqueue(message({ subject: 'second' })),
+    ]);
+
+    expect(first.messageId).toBe('id-first');
+    expect(second.messageId).toBe('id-second');
+  });
+
+  it('retries a failing send up to the cap', async () => {
+    const mock = provider(async () => ({ success: false, provider: 'mock', error: 'boom' }));
+    const queue = new EmailQueue(mock, { maxRetries: 3, retryDelayMs: 0 });
+
+    const result = await queue.enqueue(message());
+
+    expect(mock.send).toHaveBeenCalledTimes(3);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('after 3 attempts');
+  });
+
+  it('stops retrying once a send succeeds', async () => {
+    const mock = provider();
+    mock.send
+      .mockResolvedValueOnce({ success: false, provider: 'mock', error: 'transient' })
+      .mockResolvedValue({ success: true, provider: 'mock', messageId: 'ok' });
+
+    const queue = new EmailQueue(mock, { maxRetries: 3, retryDelayMs: 0 });
+    const result = await queue.enqueue(message());
+
+    expect(mock.send).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/email/__tests__/templates.test.ts
+++ b/src/lib/email/__tests__/templates.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EmailTemplateManager,
+  MissingTemplateVariablesError,
+  extractTemplateVariables,
+  getTemplateSchema,
+} from '../templates';
+
+const manager = new EmailTemplateManager();
+
+const welcomePayload = { name: 'Ada' };
+
+const verificationPayload = {
+  name: 'Ada',
+  verificationUrl: 'https://teachlink.test/verify?token=abc',
+  backupCode: 'XYZ-123',
+  restoreUrl: 'https://teachlink.test/restore',
+  expiresInMinutes: 60,
+};
+
+describe('extractTemplateVariables', () => {
+  it('finds each placeholder once', () => {
+    expect(extractTemplateVariables('{{a}} and {{ b }} and {{a}}')).toEqual(['a', 'b']);
+  });
+
+  it('tolerates whitespace inside the braces', () => {
+    expect(extractTemplateVariables('{{  spaced  }}')).toEqual(['spaced']);
+  });
+
+  it('returns nothing for a template with no variables', () => {
+    expect(extractTemplateVariables('<p>Static copy</p>')).toEqual([]);
+  });
+});
+
+describe('getTemplateSchema', () => {
+  // Read from the templates themselves, so a declared schema cannot drift
+  // away from what the template actually references.
+  it('reports the variables each part uses', () => {
+    const schema = getTemplateSchema('password-reset');
+
+    expect(schema.html).toEqual(['expiresInMinutes', 'resetUrl']);
+    expect(schema.subject).toEqual([]);
+  });
+});
+
+describe('validatePayload', () => {
+  it('accepts a complete payload', () => {
+    expect(manager.validatePayload('welcome', welcomePayload)).toEqual({
+      valid: true,
+      missing: [],
+      unused: [],
+    });
+  });
+
+  it('names a missing variable and where it is used', () => {
+    const result = manager.validatePayload('password-reset', { resetUrl: 'https://x.test' });
+
+    expect(result.valid).toBe(false);
+    expect(result.missing).toHaveLength(1);
+    expect(result.missing[0].name).toBe('expiresInMinutes');
+    expect(result.missing[0].parts).toEqual(['html', 'text']);
+  });
+
+  // An empty string renders as nothing, which is the failure this validation
+  // exists to catch — supplying one is not supplying the variable.
+  it('treats an empty or whitespace value as missing', () => {
+    expect(manager.validatePayload('welcome', { name: '' }).valid).toBe(false);
+    expect(manager.validatePayload('welcome', { name: '   ' }).valid).toBe(false);
+  });
+
+  it('treats null and undefined as missing', () => {
+    expect(manager.validatePayload('welcome', { name: null }).valid).toBe(false);
+    expect(manager.validatePayload('welcome', { name: undefined }).valid).toBe(false);
+  });
+
+  it('accepts zero and false as supplied values', () => {
+    const result = manager.validatePayload('password-reset', {
+      resetUrl: 'https://x.test',
+      expiresInMinutes: 0,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  // `userName` for a template that wants `name` is a far better clue than a
+  // blank space in the delivered email.
+  it('reports a variable the template never uses', () => {
+    const result = manager.validatePayload('welcome', { name: 'Ada', userName: 'Ada' });
+
+    expect(result.valid).toBe(true);
+    expect(result.unused).toEqual(['userName']);
+  });
+
+  it('reports every missing variable at once', () => {
+    const result = manager.validatePayload('email-verification', { name: 'Ada' });
+
+    expect(result.missing.map((variable) => variable.name).sort()).toEqual([
+      'backupCode',
+      'expiresInMinutes',
+      'restoreUrl',
+      'verificationUrl',
+    ]);
+  });
+});
+
+describe('getTemplate', () => {
+  it('renders a complete payload', () => {
+    const template = manager.getTemplate('welcome', welcomePayload);
+
+    expect(template.subject).toBe('Welcome to TeachLink');
+    expect(template.html).toContain('Welcome, Ada');
+    expect(template.text).toContain('Ada');
+  });
+
+  it('renders the verification email', () => {
+    const template = manager.getTemplate('email-verification', verificationPayload);
+
+    expect(template.html).toContain('https://teachlink.test/verify?token=abc');
+    expect(template.html).toContain('XYZ-123');
+  });
+
+  // A password reset whose link rendered as nothing is worse than one never
+  // sent: the user cannot tell it is broken.
+  it('throws rather than rendering a blank placeholder', () => {
+    expect(() => manager.getTemplate('password-reset', { resetUrl: 'https://x.test' })).toThrow(
+      MissingTemplateVariablesError,
+    );
+  });
+
+  it('names the template and variables in the error', () => {
+    try {
+      manager.getTemplate('password-reset', {});
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      const typed = error as MissingTemplateVariablesError;
+      expect(typed.templateId).toBe('password-reset');
+      expect(typed.missing.map((variable) => variable.name).sort()).toEqual([
+        'expiresInMinutes',
+        'resetUrl',
+      ]);
+      expect(typed.message).toContain('password-reset');
+    }
+  });
+
+  // Previews and tests still need to render an incomplete payload.
+  it('renders anyway when allowMissing is set', () => {
+    const template = manager.getTemplate('welcome', {}, { allowMissing: true });
+
+    expect(template.html).toContain('Welcome, ');
+  });
+
+  it('still escapes HTML in supplied values', () => {
+    const template = manager.getTemplate('welcome', { name: '<script>alert(1)</script>' });
+
+    expect(template.html).not.toContain('<script>');
+    expect(template.html).toContain('&lt;script&gt;');
+  });
+
+  it('does not reject a payload carrying extra keys', () => {
+    expect(() => manager.getTemplate('welcome', { name: 'Ada', extra: 'ignored' })).not.toThrow();
+  });
+});

--- a/src/lib/email/idempotency.ts
+++ b/src/lib/email/idempotency.ts
@@ -1,0 +1,53 @@
+import { createHash } from 'crypto';
+import { EmailAddress, EmailMessage } from '@/lib/email/types';
+
+/**
+ * Idempotency key derivation for transactional email.
+ *
+ * A key is best supplied by the caller, who knows what the message *is* — "the
+ * password reset for user 42, request abc". When there is nothing to hand, a
+ * key derived from the message content is still enough to collapse the common
+ * duplicate: the identical message sent twice by a retry.
+ */
+
+function normalizeRecipients(to: EmailAddress | EmailAddress[]): string[] {
+  const list = Array.isArray(to) ? to : [to];
+
+  // Sorted and lower-cased so recipient order cannot produce two keys for what
+  // is otherwise the same message.
+  return [...new Set(list.map((address) => address.email.trim().toLowerCase()))].sort();
+}
+
+/**
+ * Derives a stable key from the message itself.
+ *
+ * Covers recipients, subject and both bodies. It does not cover `tags` or
+ * `replyTo`: those are routing metadata, and two messages differing only there
+ * are still the same mail to the person receiving it.
+ */
+export function deriveIdempotencyKey(message: EmailMessage): string {
+  const payload = JSON.stringify([
+    normalizeRecipients(message.to),
+    message.from?.email?.trim().toLowerCase() ?? '',
+    message.subject,
+    message.html,
+    message.text ?? '',
+  ]);
+
+  return createHash('sha256').update(payload, 'utf8').digest('hex');
+}
+
+/**
+ * Returns the message with an idempotency key attached, deriving one from the
+ * content when the caller did not supply it.
+ */
+export function withIdempotencyKey(message: EmailMessage): EmailMessage {
+  return message.idempotencyKey
+    ? message
+    : { ...message, idempotencyKey: deriveIdempotencyKey(message) };
+}
+
+/** Namespaced key, so two features cannot collide on the same identifier. */
+export function scopedIdempotencyKey(scope: string, identifier: string): string {
+  return `${scope}:${identifier}`;
+}

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -2,4 +2,5 @@ export * from '@/lib/email/types';
 export * from '@/lib/email/provider';
 export * from '@/lib/email/templates';
 export * from '@/lib/email/queue';
+export * from '@/lib/email/idempotency';
 export * from '@/lib/email/hybridEvents';

--- a/src/lib/email/queue.ts
+++ b/src/lib/email/queue.ts
@@ -12,6 +12,15 @@ const DEFAULT_OPTIONS: QueueOptions = {
   maxConcurrent: 2,
 };
 
+/**
+ * How long a completed send is remembered for dedupe purposes.
+ *
+ * Long enough to cover the retries and redeliveries that cause duplicates,
+ * short enough that a genuinely new message reusing a key days later is not
+ * swallowed.
+ */
+export const DEFAULT_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -20,28 +29,100 @@ function createJobId(): string {
   return `email_${Date.now()}_${Math.random().toString(16).slice(2)}`;
 }
 
+/** A queued job plus the promise waiting on it. */
+interface PendingJob extends QueueJob {
+  resolve: (result: EmailSendResult) => void;
+}
+
+interface IdempotencyEntry {
+  /** Resolves with the result of the send this key already started. */
+  promise: Promise<EmailSendResult>;
+  recordedAt: number;
+}
+
 export class EmailQueue {
   private readonly provider: EmailProvider;
   private readonly options: QueueOptions;
-  private readonly queue: QueueJob[] = [];
+  private readonly queue: PendingJob[] = [];
+  private readonly idempotency = new Map<string, IdempotencyEntry>();
+  private readonly idempotencyTtlMs: number;
   private processing = 0;
 
-  constructor(provider: EmailProvider, options?: Partial<QueueOptions>) {
+  constructor(
+    provider: EmailProvider,
+    options?: Partial<QueueOptions> & { idempotencyTtlMs?: number },
+  ) {
     this.provider = provider;
     this.options = {
       ...DEFAULT_OPTIONS,
       ...options,
     };
+    this.idempotencyTtlMs = options?.idempotencyTtlMs ?? DEFAULT_IDEMPOTENCY_TTL_MS;
   }
 
-  enqueue(message: EmailMessage): Promise<EmailSendResult> {
-    return new Promise((resolve) => {
-      this.queue.push({ id: createJobId(), message, attempts: 0 });
-      this.process(resolve);
+  /**
+   * Queues a message for delivery.
+   *
+   * When the message carries an `idempotencyKey`, a second enqueue under the
+   * same key does not send again — it returns the first send's result. This is
+   * what stops a retried API call, a double-clicked button or a redelivered
+   * webhook from sending the same password reset twice. The key is registered
+   * before the send starts, so concurrent duplicates dedupe as well as
+   * sequential ones.
+   */
+  enqueue(message: EmailMessage, now: number = Date.now()): Promise<EmailSendResult> {
+    const key = message.idempotencyKey;
+
+    if (key) {
+      const existing = this.idempotency.get(key);
+      if (existing && now - existing.recordedAt <= this.idempotencyTtlMs) {
+        return existing.promise;
+      }
+    }
+
+    const promise = new Promise<EmailSendResult>((resolve) => {
+      this.queue.push({ id: createJobId(), message, attempts: 0, resolve });
+      this.process();
     });
+
+    if (key) {
+      this.idempotency.set(key, { promise, recordedAt: now });
+
+      // A send that failed outright is not a delivery, so it must not block a
+      // later retry of the same key.
+      void promise
+        .then((result) => {
+          if (!result.success) this.idempotency.delete(key);
+        })
+        .catch(() => this.idempotency.delete(key));
+    }
+
+    return promise;
   }
 
-  private process(resolve: (result: EmailSendResult) => void): void {
+  /** Number of keys currently held for dedupe. */
+  get idempotencyCacheSize(): number {
+    return this.idempotency.size;
+  }
+
+  /** Drops keys older than the TTL. */
+  pruneIdempotencyCache(now: number = Date.now()): number {
+    let removed = 0;
+    for (const [key, entry] of this.idempotency) {
+      if (now - entry.recordedAt > this.idempotencyTtlMs) {
+        this.idempotency.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Forgets every recorded key. */
+  clearIdempotencyCache(): void {
+    this.idempotency.clear();
+  }
+
+  private process(): void {
     while (this.processing < this.options.maxConcurrent && this.queue.length > 0) {
       const nextJob = this.queue.shift();
       if (!nextJob) {
@@ -49,11 +130,14 @@ export class EmailQueue {
       }
 
       this.processing += 1;
+      // Each job resolves its *own* caller. Sharing one resolver across the
+      // queue meant an enqueue could resolve with an unrelated message's
+      // result whenever two were in flight at once.
       void this.runJob(nextJob)
-        .then((result) => resolve(result))
+        .then((result) => nextJob.resolve(result))
         .finally(() => {
           this.processing -= 1;
-          this.process(resolve);
+          this.process();
         });
     }
   }

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -1,4 +1,10 @@
-import { EmailTemplate, EmailTemplatePayload } from '@/lib/email/types';
+import {
+  EmailTemplate,
+  EmailTemplatePayload,
+  MissingTemplateVariable,
+  RenderOptions,
+  TemplateValidationResult,
+} from '@/lib/email/types';
 
 export type TransactionalTemplateId =
   | 'welcome'
@@ -24,8 +30,31 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/** Matches a `{{ placeholder }}` and captures its name. */
+const PLACEHOLDER_PATTERN = /{{\s*([\w.-]+)\s*}}/g;
+
+/**
+ * The variables a template string references.
+ *
+ * Read from the template itself rather than a hand-maintained list, so the
+ * declared schema cannot drift away from what the template actually uses.
+ */
+export function extractTemplateVariables(template: string): string[] {
+  const names = new Set<string>();
+  for (const match of template.matchAll(PLACEHOLDER_PATTERN)) {
+    names.add(match[1]);
+  }
+  return [...names].sort();
+}
+
+/** True when the payload supplies a usable value for `name`. */
+function isProvided(payload: EmailTemplatePayload, name: string): boolean {
+  const value = payload[name];
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
 function render(template: string, payload: EmailTemplatePayload): string {
-  return template.replace(/{{\s*([\w.-]+)\s*}}/g, (_match, key: string) => {
+  return template.replace(PLACEHOLDER_PATTERN, (_match, key: string) => {
     const value = payload[key];
     return escapeHtml(value == null ? '' : String(value));
   });
@@ -55,8 +84,86 @@ const TEXT_TEMPLATES: Record<TransactionalTemplateId, string> = {
     'Verify your email, {{name}}: {{verificationUrl}}. Backup code: {{backupCode}}. Recovery link: {{restoreUrl}}. Expires in {{expiresInMinutes}} minutes.',
 };
 
+/** Thrown when a template is rendered without every variable it references. */
+export class MissingTemplateVariablesError extends Error {
+  readonly templateId: string;
+  readonly missing: MissingTemplateVariable[];
+
+  constructor(templateId: string, missing: MissingTemplateVariable[]) {
+    super(
+      `Template "${templateId}" is missing ${missing.length} variable(s): ${missing
+        .map((variable) => `${variable.name} (${variable.parts.join(', ')})`)
+        .join(', ')}`,
+    );
+    this.name = 'MissingTemplateVariablesError';
+    this.templateId = templateId;
+    this.missing = missing;
+  }
+}
+
+/** Every variable the given template references, by part. */
+export function getTemplateSchema(
+  id: TransactionalTemplateId,
+): Record<'subject' | 'html' | 'text', string[]> {
+  return {
+    subject: extractTemplateVariables(TEMPLATE_SUBJECTS[id]),
+    html: extractTemplateVariables(HTML_TEMPLATES[id]),
+    text: extractTemplateVariables(TEXT_TEMPLATES[id]),
+  };
+}
+
 export class EmailTemplateManager {
-  getTemplate(id: TransactionalTemplateId, payload: EmailTemplatePayload): EmailTemplate {
+  /**
+   * Checks a payload against the variables the template actually references.
+   *
+   * Reports unused variables too: a payload with `userName` for a template
+   * that wants `name` produces one missing and one unused entry, which is a
+   * far better clue than a blank space in the rendered email.
+   */
+  validatePayload(
+    id: TransactionalTemplateId,
+    payload: EmailTemplatePayload,
+  ): TemplateValidationResult {
+    const schema = getTemplateSchema(id);
+    const byName = new Map<string, MissingTemplateVariable>();
+
+    for (const part of ['subject', 'html', 'text'] as const) {
+      for (const name of schema[part]) {
+        if (isProvided(payload, name)) continue;
+
+        const existing = byName.get(name);
+        if (existing) existing.parts.push(part);
+        else byName.set(name, { name, parts: [part] });
+      }
+    }
+
+    const referenced = new Set([...schema.subject, ...schema.html, ...schema.text]);
+    const unused = Object.keys(payload).filter((key) => !referenced.has(key));
+
+    const missing = [...byName.values()];
+    return { valid: missing.length === 0, missing, unused };
+  }
+
+  /**
+   * Renders a transactional template.
+   *
+   * Throws [`MissingTemplateVariablesError`] rather than rendering an
+   * unresolved placeholder as an empty string — a password-reset email whose
+   * link silently rendered as nothing is worse than one that was never sent,
+   * because the user cannot tell it is broken.
+   */
+  getTemplate(
+    id: TransactionalTemplateId,
+    payload: EmailTemplatePayload,
+    options: RenderOptions = {},
+  ): EmailTemplate {
+    if (!options.allowMissing) {
+      const validation = this.validatePayload(id, payload);
+      if (!validation.valid) {
+        throw new MissingTemplateVariablesError(id, validation.missing);
+      }
+    }
+
     return {
       id,
       subject: render(TEMPLATE_SUBJECTS[id], payload),

--- a/src/lib/email/types.ts
+++ b/src/lib/email/types.ts
@@ -5,7 +5,7 @@ export interface EmailAddress {
   name?: string;
 }
 
-export interface EmailMessage {
+export interface EmailMessage extends EmailIdempotency {
   to: EmailAddress | EmailAddress[];
   subject: string;
   html: string;
@@ -48,4 +48,42 @@ export interface QueueJob {
   id: string;
   message: EmailMessage;
   attempts: number;
+}
+
+/** One template variable the caller failed to supply. */
+export interface MissingTemplateVariable {
+  /** Placeholder name, as it appears between the braces. */
+  name: string;
+  /** Where it was referenced: the subject, the HTML body, or the text body. */
+  parts: Array<'subject' | 'html' | 'text'>;
+}
+
+export interface TemplateValidationResult {
+  valid: boolean;
+  /** Variables the template references but the payload does not provide. */
+  missing: MissingTemplateVariable[];
+  /** Variables supplied but never referenced — a likely typo in the caller. */
+  unused: string[];
+}
+
+/**
+ * Options for rendering a transactional template.
+ *
+ * `allowMissing` exists for previews and tests; it is deliberately not the
+ * default, because rendering an unresolved variable as an empty string is what
+ * sends "Reset your password:  " with no link in it.
+ */
+export interface RenderOptions {
+  allowMissing?: boolean;
+}
+
+/** Idempotency support for transactional sends. */
+export interface EmailIdempotency {
+  /**
+   * Caller-supplied key identifying this message.
+   *
+   * Two enqueues with the same key are one send: the second returns the first
+   * one's result rather than delivering a duplicate.
+   */
+  idempotencyKey?: string;
 }

--- a/src/lib/export-scheduler/__tests__/cron-validation.test.ts
+++ b/src/lib/export-scheduler/__tests__/cron-validation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  InvalidCronExpressionError,
+  assertValidCron,
+  describeCronErrors,
+  frequencyToCron,
+  validateCron,
+  validateCronExpression,
+} from '../cron-parser';
+
+describe('validateCron', () => {
+  it.each([
+    ['* * * * *', 'every minute'],
+    ['0 0 * * *', 'daily at midnight'],
+    ['30 9 * * 1-5', 'weekdays at 09:30'],
+    ['*/15 * * * *', 'every fifteen minutes'],
+    ['0 0 1 * *', 'first of the month'],
+    ['0 0,12 * * *', 'twice daily'],
+    ['0 9-17/2 * * *', 'every other hour in business hours'],
+    ['59 23 31 12 6', 'field maximums'],
+  ])('accepts %s (%s)', (expression) => {
+    expect(validateCron(expression).valid).toBe(true);
+  });
+
+  // crontab accepts 7 as a second spelling of Sunday.
+  it('accepts 7 as Sunday', () => {
+    expect(validateCron('0 0 * * 7').valid).toBe(true);
+  });
+
+  it('returns the parsed fields when valid', () => {
+    const result = validateCron('30 9 1 6 5');
+
+    expect(result.expression).toEqual({
+      minute: '30',
+      hour: '9',
+      dayOfMonth: '1',
+      month: '6',
+      dayOfWeek: '5',
+    });
+  });
+
+  it('tolerates surrounding whitespace and repeated spaces', () => {
+    expect(validateCron('  0   0  *  *  *  ').valid).toBe(true);
+  });
+
+  describe('rejections', () => {
+    it('rejects an empty expression', () => {
+      const result = validateCron('');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('expression');
+    });
+
+    it('rejects the wrong number of fields', () => {
+      const result = validateCron('0 0 * *');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('must have 5 fields');
+    });
+
+    it('names the field that is out of range', () => {
+      const result = validateCron('0 0 * * 9');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('dayOfWeek');
+      expect(result.errors[0].message).toContain('outside 0-7');
+    });
+
+    it('rejects a minute above 59', () => {
+      expect(validateCron('60 0 * * *').errors[0].field).toBe('minute');
+    });
+
+    it('rejects day-of-month zero', () => {
+      expect(validateCron('0 0 0 * *').errors[0].field).toBe('dayOfMonth');
+    });
+
+    // parseInt stops at the first non-digit, so the old validator read "5x"
+    // as 5 and accepted an expression cron itself rejects.
+    it('rejects a value with trailing characters', () => {
+      const result = validateCron('0 0 5x * *');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('dayOfMonth');
+      expect(result.errors[0].message).toContain('not a number');
+    });
+
+    it('rejects a non-numeric value', () => {
+      expect(validateCron('abc 0 * * *').valid).toBe(false);
+    });
+
+    it('rejects a zero step', () => {
+      const result = validateCron('*/0 * * * *');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('greater than zero');
+    });
+
+    it('rejects a non-numeric step', () => {
+      expect(validateCron('*/x * * * *').valid).toBe(false);
+    });
+
+    it('rejects a backwards range', () => {
+      const result = validateCron('0 17-9 * * *');
+
+      expect(result.errors[0].message).toContain('starts after it ends');
+    });
+
+    it('rejects a range outside the field bounds', () => {
+      expect(validateCron('0 0 * 1-13 *').valid).toBe(false);
+    });
+
+    it('rejects a malformed list entry', () => {
+      const result = validateCron('0 0,99 * * *');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('list entry');
+    });
+
+    it('rejects an empty list entry', () => {
+      expect(validateCron('0 0,, * * *').valid).toBe(false);
+    });
+
+    // One save should surface every mistake, not just the first.
+    it('reports every bad field at once', () => {
+      const result = validateCron('99 99 * * 9');
+
+      expect(result.errors.map((error) => error.field)).toEqual([
+        'minute',
+        'hour',
+        'dayOfWeek',
+      ]);
+    });
+  });
+});
+
+describe('validateCronExpression', () => {
+  it('keeps the boolean contract for existing callers', () => {
+    expect(validateCronExpression('0 0 * * *')).toBe(true);
+    expect(validateCronExpression('0 0 * * 9')).toBe(false);
+  });
+});
+
+describe('assertValidCron', () => {
+  it('returns the parsed expression when valid', () => {
+    expect(assertValidCron('0 0 * * *').minute).toBe('0');
+  });
+
+  it('throws with every reason attached', () => {
+    try {
+      assertValidCron('99 0 * * 9');
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidCronExpressionError);
+      expect((error as InvalidCronExpressionError).errors).toHaveLength(2);
+      expect((error as InvalidCronExpressionError).message).toContain('minute');
+    }
+  });
+});
+
+describe('describeCronErrors', () => {
+  it('renders the errors on one line', () => {
+    const { errors } = validateCron('99 0 * * *');
+
+    expect(describeCronErrors(errors)).toBe('minute: value "99" is outside 0-59');
+  });
+});
+
+describe('frequencyToCron', () => {
+  it.each(['daily', 'weekly', 'monthly', 'hourly', 'anything-else'])(
+    'produces a valid expression for %s',
+    (frequency) => {
+      expect(validateCron(frequencyToCron(frequency)).valid).toBe(true);
+    },
+  );
+});

--- a/src/lib/export-scheduler/__tests__/scheduler-validation.test.ts
+++ b/src/lib/export-scheduler/__tests__/scheduler-validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/queue', () => ({
+  taskQueue: { register: vi.fn(), enqueue: vi.fn(() => ({ id: 'job-1' })) },
+}));
+
+vi.mock('../storage', () => ({
+  getSchedule: vi.fn(),
+  getDueSchedules: vi.fn(async () => []),
+  updateScheduleNextRun: vi.fn(async () => undefined),
+  getTemplate: vi.fn(),
+  addHistory: vi.fn(),
+}));
+
+vi.mock('../exporter', () => ({
+  exportData: vi.fn(),
+  fetchDataForTemplate: vi.fn(),
+}));
+
+vi.mock('../notification-service', () => ({
+  notificationService: { notifyExportComplete: vi.fn(), notifyExportFailed: vi.fn() },
+}));
+
+import { ExportSchedulerService } from '../scheduler-service';
+import type { ExportSchedule } from '../types';
+
+const schedule = (overrides: Partial<ExportSchedule> = {}): ExportSchedule =>
+  ({
+    id: 'schedule-1',
+    userId: 'user-1',
+    templateId: 'template-1',
+    frequency: 'daily',
+    emailDelivery: false,
+    ...overrides,
+  }) as ExportSchedule;
+
+let service: ExportSchedulerService;
+
+beforeEach(() => {
+  service = new ExportSchedulerService();
+});
+
+describe('validateSchedule', () => {
+  it('accepts a valid cron expression', () => {
+    const result = service.validateSchedule(schedule({ cronExpression: '0 9 * * 1-5' }));
+
+    expect(result.valid).toBe(true);
+    expect(result.cronExpression).toBe('0 9 * * 1-5');
+    expect(result.errors).toEqual([]);
+  });
+
+  // An invalid expression was accepted silently and the job simply never ran,
+  // with nothing to tell the user why.
+  it('rejects an invalid expression and names the field', () => {
+    const result = service.validateSchedule(schedule({ cronExpression: '0 0 * * 9' }));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe('dayOfWeek');
+  });
+
+  it('falls back to the frequency when no expression is set', () => {
+    const result = service.validateSchedule(schedule({ frequency: 'weekly' }));
+
+    expect(result.valid).toBe(true);
+    expect(result.cronExpression).toBe('0 0 * * 0');
+  });
+
+  it('reports the derived expression it validated', () => {
+    expect(service.validateSchedule(schedule({ frequency: 'monthly' })).cronExpression).toBe(
+      '0 0 1 * *',
+    );
+  });
+
+  it('rejects an expression with the wrong field count', () => {
+    const result = service.validateSchedule(schedule({ cronExpression: '0 0 *' }));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe('expression');
+  });
+});

--- a/src/lib/export-scheduler/cron-parser.ts
+++ b/src/lib/export-scheduler/cron-parser.ts
@@ -11,6 +11,47 @@ export interface CronExpression {
   dayOfWeek: string;
 }
 
+/** The five cron fields, in order, with their permitted numeric ranges. */
+export const CRON_FIELDS = [
+  { name: 'minute', min: 0, max: 59 },
+  { name: 'hour', min: 0, max: 23 },
+  { name: 'dayOfMonth', min: 1, max: 31 },
+  { name: 'month', min: 1, max: 12 },
+  // 7 is accepted as a second spelling of Sunday, as crontab does.
+  { name: 'dayOfWeek', min: 0, max: 7 },
+] as const;
+
+export type CronFieldName = (typeof CRON_FIELDS)[number]['name'];
+
+/** One reason an expression was rejected, addressed to whoever typed it. */
+export interface CronValidationError {
+  field: CronFieldName | 'expression';
+  value: string;
+  message: string;
+}
+
+export interface CronValidationResult {
+  valid: boolean;
+  errors: CronValidationError[];
+  /** The parsed fields, present only when `valid` is true. */
+  expression?: CronExpression;
+}
+
+/** Thrown by [`assertValidCron`]; carries every reason, not just the first. */
+export class InvalidCronExpressionError extends Error {
+  readonly errors: CronValidationError[];
+
+  constructor(expression: string, errors: CronValidationError[]) {
+    super(
+      `Invalid cron expression "${expression}": ${errors
+        .map((error) => `${error.field} ${error.message}`)
+        .join('; ')}`,
+    );
+    this.name = 'InvalidCronExpressionError';
+    this.errors = errors;
+  }
+}
+
 export function parseCronExpression(expression: string): CronExpression {
   const parts = expression.trim().split(/\s+/);
 
@@ -27,40 +68,125 @@ export function parseCronExpression(expression: string): CronExpression {
   };
 }
 
-export function validateCronExpression(expression: string): boolean {
-  try {
-    const cron = parseCronExpression(expression);
+/**
+ * Strict integer parse.
+ *
+ * `parseInt` stops at the first non-digit, so it reads "5x" as 5 and would
+ * wave through `0 0 5x * *` — an expression cron itself rejects. Anything but
+ * digits is a typo worth reporting.
+ */
+function toInteger(value: string): number | null {
+  return /^\d+$/.test(value.trim()) ? Number(value.trim()) : null;
+}
 
-    // Basic validation
-    const validateField = (value: string, min: number, max: number): boolean => {
-      if (value === '*') return true;
-      if (value.includes('/')) {
-        const [range, step] = value.split('/');
-        if (range !== '*' && !validateField(range, min, max)) return false;
-        const stepNum = parseInt(step, 10);
-        return !isNaN(stepNum) && stepNum > 0;
-      }
-      if (value.includes('-')) {
-        const [start, end] = value.split('-').map((v) => parseInt(v, 10));
-        return !isNaN(start) && !isNaN(end) && start >= min && end <= max && start <= end;
-      }
-      if (value.includes(',')) {
-        return value.split(',').every((v) => validateField(v.trim(), min, max));
-      }
-      const num = parseInt(value, 10);
-      return !isNaN(num) && num >= min && num <= max;
-    };
+/** Validates one field value, returning the reason it failed, or null. */
+function fieldError(value: string, min: number, max: number): string | null {
+  const trimmed = value.trim();
 
-    return (
-      validateField(cron.minute, 0, 59) &&
-      validateField(cron.hour, 0, 23) &&
-      validateField(cron.dayOfMonth, 1, 31) &&
-      validateField(cron.month, 1, 12) &&
-      validateField(cron.dayOfWeek, 0, 6)
-    );
-  } catch {
-    return false;
+  if (trimmed === '') return 'is empty';
+  if (trimmed === '*') return null;
+
+  if (trimmed.includes(',')) {
+    for (const part of trimmed.split(',')) {
+      const error = fieldError(part, min, max);
+      if (error) return `list entry "${part.trim()}" ${error}`;
+    }
+    return null;
   }
+
+  if (trimmed.includes('/')) {
+    const segments = trimmed.split('/');
+    if (segments.length !== 2) return `has a malformed step in "${trimmed}"`;
+
+    const [range, step] = segments;
+    if (range !== '*') {
+      const rangeError = fieldError(range, min, max);
+      if (rangeError) return `step base "${range}" ${rangeError}`;
+    }
+
+    const stepValue = toInteger(step);
+    if (stepValue === null) return `step "${step}" is not a number`;
+    if (stepValue <= 0) return `step "${step}" must be greater than zero`;
+    if (stepValue > max) return `step "${step}" exceeds the maximum of ${max}`;
+    return null;
+  }
+
+  if (trimmed.includes('-')) {
+    const segments = trimmed.split('-');
+    if (segments.length !== 2) return `has a malformed range in "${trimmed}"`;
+
+    const start = toInteger(segments[0]);
+    const end = toInteger(segments[1]);
+    if (start === null || end === null) return `range "${trimmed}" is not numeric`;
+    if (start < min || end > max) return `range "${trimmed}" is outside ${min}-${max}`;
+    if (start > end) return `range "${trimmed}" starts after it ends`;
+    return null;
+  }
+
+  const numeric = toInteger(trimmed);
+  if (numeric === null) return `value "${trimmed}" is not a number`;
+  if (numeric < min || numeric > max) return `value "${trimmed}" is outside ${min}-${max}`;
+  return null;
+}
+
+/**
+ * Validates a cron expression, reporting every problem it finds.
+ *
+ * A boolean is not enough for a form: the user who typed `0 0 * * 9` needs to
+ * be told which field is wrong and why, not simply that something is. Every
+ * field is checked rather than stopping at the first failure, so one save
+ * surfaces every mistake.
+ */
+export function validateCron(expression: string): CronValidationResult {
+  if (typeof expression !== 'string' || expression.trim() === '') {
+    return {
+      valid: false,
+      errors: [{ field: 'expression', value: String(expression ?? ''), message: 'is empty' }],
+    };
+  }
+
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: 'expression',
+          value: expression,
+          message: `must have 5 fields (minute hour day month weekday), found ${parts.length}`,
+        },
+      ],
+    };
+  }
+
+  const errors: CronValidationError[] = [];
+  CRON_FIELDS.forEach((field, index) => {
+    const message = fieldError(parts[index], field.min, field.max);
+    if (message) errors.push({ field: field.name, value: parts[index], message });
+  });
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, errors: [], expression: parseCronExpression(expression) };
+}
+
+/** Boolean form of [`validateCron`], kept for existing callers. */
+export function validateCronExpression(expression: string): boolean {
+  return validateCron(expression).valid;
+}
+
+/** Throws [`InvalidCronExpressionError`] when `expression` is not valid. */
+export function assertValidCron(expression: string): CronExpression {
+  const result = validateCron(expression);
+  if (!result.valid || !result.expression) {
+    throw new InvalidCronExpressionError(expression, result.errors);
+  }
+  return result.expression;
+}
+
+/** One-line summary of why an expression was rejected, for logs and toasts. */
+export function describeCronErrors(errors: CronValidationError[]): string {
+  return errors.map((error) => `${error.field}: ${error.message}`).join('; ');
 }
 
 export function getNextRunTime(cronExpression: string, fromDate: Date = new Date()): Date {

--- a/src/lib/export-scheduler/scheduler-service.ts
+++ b/src/lib/export-scheduler/scheduler-service.ts
@@ -19,7 +19,13 @@ import {
   getTemplate,
   addHistory,
 } from './storage';
-import { getNextRunTime, frequencyToCron } from './cron-parser';
+import {
+  CronValidationError,
+  InvalidCronExpressionError,
+  getNextRunTime,
+  frequencyToCron,
+  validateCron,
+} from './cron-parser';
 import { exportData, fetchDataForTemplate } from './exporter';
 import { notificationService } from './notification-service';
 import { createLogger } from '@/lib/logging';
@@ -83,11 +89,39 @@ export class ExportSchedulerService {
       const dueSchedules = await getDueSchedules();
 
       for (const schedule of dueSchedules) {
-        await this.queueExportJob(schedule);
+        // Each schedule is isolated. One malformed cron expression used to
+        // throw out of getNextRunTime and abort this loop, so a single bad
+        // string stopped every *other* schedule from running too.
+        try {
+          await this.queueExportJob(schedule);
+        } catch (error) {
+          logger.error('Failed to queue scheduled export', {
+            scheduleId: schedule.id,
+            error,
+          });
+        }
       }
     } catch (error) {
       logger.error('Error checking due schedules', { error });
     }
+  }
+
+  /**
+   * Validates the cron expression a schedule would run on.
+   *
+   * Call this before saving a schedule: an invalid expression is otherwise
+   * accepted silently and the job simply never runs, with nothing to tell the
+   * user why.
+   */
+  validateSchedule(schedule: Pick<ExportSchedule, 'cronExpression' | 'frequency'>): {
+    valid: boolean;
+    cronExpression: string;
+    errors: CronValidationError[];
+  } {
+    const cronExpression = schedule.cronExpression || frequencyToCron(schedule.frequency);
+    const result = validateCron(cronExpression);
+
+    return { valid: result.valid, cronExpression, errors: result.errors };
   }
 
   /**
@@ -102,10 +136,18 @@ export class ExportSchedulerService {
       emailRecipients: schedule.emailRecipients,
     };
 
+    // Validate before enqueuing. Queuing the job first and then failing to
+    // compute the next run leaves the schedule due forever, re-running the
+    // same export on every sweep.
+    const { valid, cronExpression, errors } = this.validateSchedule(schedule);
+
+    if (!valid) {
+      throw new InvalidCronExpressionError(cronExpression, errors);
+    }
+
     taskQueue.enqueue('export-job', payload);
 
     // Update next run time
-    const cronExpression = schedule.cronExpression || frequencyToCron(schedule.frequency);
     const nextRun = getNextRunTime(cronExpression);
     await updateScheduleNextRun(schedule.id, nextRun, new Date());
   }

--- a/src/utils/__tests__/connectivityDebounce.test.ts
+++ b/src/utils/__tests__/connectivityDebounce.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CONNECTIVITY_DEBOUNCE_MS, createConnectivityDebouncer } from '../pwaUtils';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createConnectivityDebouncer', () => {
+  it('starts settled on the initial state', () => {
+    const debouncer = createConnectivityDebouncer(true, vi.fn());
+
+    expect(debouncer.settled).toBe(true);
+    expect(debouncer.pending).toBe(true);
+  });
+
+  it('reports a change once it has held for the window', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    expect(onChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(false);
+    expect(debouncer.settled).toBe(false);
+  });
+
+  it('does not report before the window elapses', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(999);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // The case the issue is about: a train tunnel or a wifi handover fires
+  // online/offline several times a second, and each one used to start a sync
+  // that the next event interrupted.
+  it('reports nothing when connectivity flaps back to where it started', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(200);
+    debouncer.push(true);
+    vi.advanceTimersByTime(200);
+    debouncer.push(false);
+    vi.advanceTimersByTime(200);
+    debouncer.push(true);
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(debouncer.settled).toBe(true);
+  });
+
+  it('collapses a burst into a single report of the final state', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(100);
+    debouncer.push(true);
+    vi.advanceTimersByTime(100);
+    debouncer.push(false);
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('restarts the window on each new differing event', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(900);
+    debouncer.push(true);
+    debouncer.push(false);
+    vi.advanceTimersByTime(900);
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for repeated events matching the settled state', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(true);
+    debouncer.push(true);
+    vi.advanceTimersByTime(5_000);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('reports each genuine transition in turn', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(1_000);
+    debouncer.push(true);
+    vi.advanceTimersByTime(1_000);
+
+    expect(onChange).toHaveBeenNthCalledWith(1, false);
+    expect(onChange).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it('tracks the pending value before it settles', () => {
+    const debouncer = createConnectivityDebouncer(true, vi.fn(), { debounceMs: 1_000 });
+
+    debouncer.push(false);
+
+    expect(debouncer.pending).toBe(false);
+    expect(debouncer.settled).toBe(true);
+  });
+
+  it('flushes the pending value immediately', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 10_000 });
+
+    debouncer.push(false);
+    debouncer.flush();
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(false);
+    expect(debouncer.settled).toBe(false);
+  });
+
+  it('flushing an unchanged value reports nothing', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange);
+
+    debouncer.flush();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // A timer firing after unmount would sync against a torn-down service.
+  it('cancels a pending report', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange, { debounceMs: 1_000 });
+
+    debouncer.push(false);
+    debouncer.cancel();
+    vi.advanceTimersByTime(5_000);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('uses injected timers when supplied', () => {
+    const setTimeoutFn = vi.fn().mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
+    const clearTimeoutFn = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, vi.fn(), {
+      setTimeoutFn: setTimeoutFn as unknown as typeof setTimeout,
+      clearTimeoutFn: clearTimeoutFn as unknown as typeof clearTimeout,
+    });
+
+    debouncer.push(false);
+    debouncer.cancel();
+
+    expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutFn).toHaveBeenCalledWith(1);
+  });
+
+  it('defaults to the shared debounce window', () => {
+    const onChange = vi.fn();
+    const debouncer = createConnectivityDebouncer(true, onChange);
+
+    debouncer.push(false);
+    vi.advanceTimersByTime(CONNECTIVITY_DEBOUNCE_MS - 1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/pwaUtils.ts
+++ b/src/utils/pwaUtils.ts
@@ -61,3 +61,98 @@ export async function clearOutdatedCaches(cachePrefix = 'teachlink-cache-'): Pro
     logger.error('Failed to clear outdated caches', { error, cachePrefix });
   }
 }
+
+/**
+ * Default settle time for connectivity changes.
+ *
+ * A flapping connection — a train tunnel, a wifi handover — fires `online` and
+ * `offline` several times a second. Reacting to each one starts a sync that is
+ * cancelled by the next event, so nothing ever drains.
+ */
+export const CONNECTIVITY_DEBOUNCE_MS = 1500;
+
+export interface ConnectivityDebouncerOptions {
+  /** How long the state must hold before it is reported. */
+  debounceMs?: number;
+  /** Injectable timers, so tests need not wait in real time. */
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+export interface ConnectivityDebouncer {
+  /** Feed a raw connectivity event. */
+  push: (online: boolean) => void;
+  /** The last settled value reported to the callback. */
+  readonly settled: boolean;
+  /** The most recent raw value, settled or not. */
+  readonly pending: boolean;
+  /** Report the pending value immediately, cancelling the timer. */
+  flush: () => void;
+  /** Cancel any pending report. */
+  cancel: () => void;
+}
+
+/**
+ * Debounces connectivity transitions, reporting only states that hold.
+ *
+ * Two properties matter beyond plain debouncing:
+ *
+ * - A value equal to the last settled one cancels the pending timer instead of
+ *   restarting it. Offline → online → offline within the window is not a
+ *   change at all, and should not fire a callback.
+ * - The callback fires only on an actual change, so a run of `online` events
+ *   on an already-online connection stays silent.
+ */
+export function createConnectivityDebouncer(
+  initialOnline: boolean,
+  onChange: (online: boolean) => void,
+  options: ConnectivityDebouncerOptions = {},
+): ConnectivityDebouncer {
+  const debounceMs = options.debounceMs ?? CONNECTIVITY_DEBOUNCE_MS;
+  const setTimer = options.setTimeoutFn ?? setTimeout;
+  const clearTimer = options.clearTimeoutFn ?? clearTimeout;
+
+  let settled = initialOnline;
+  let pending = initialOnline;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  };
+
+  const commit = () => {
+    timer = null;
+    if (pending === settled) return;
+    settled = pending;
+    onChange(settled);
+  };
+
+  return {
+    push(online: boolean) {
+      pending = online;
+
+      // Back to where we started: the flap cancelled itself out.
+      if (online === settled) {
+        cancel();
+        return;
+      }
+
+      cancel();
+      timer = setTimer(commit, debounceMs);
+    },
+    get settled() {
+      return settled;
+    },
+    get pending() {
+      return pending;
+    },
+    flush() {
+      cancel();
+      commit();
+    },
+    cancel,
+  };
+}


### PR DESCRIPTION
Four independent hardening fixes: two in transactional email, one in the export scheduler, one in offline mode.

Closes #1171
Closes #1177
Closes #1178
Closes #1181

---

### #1171 — Debounce offline-mode connectivity flapping

`src/utils/pwaUtils.ts`, `src/hooks/useOfflineMode.tsx`

`createConnectivityDebouncer` reports a connectivity state only once it has held for the window. Two properties beyond plain debouncing matter here:

- **A value returning to the last settled one cancels the pending timer** rather than restarting it. Offline → online → offline inside the window is not a change at all and should fire nothing.
- **The callback fires only on an actual change**, so a run of `online` events on an already-online connection stays silent.

`useOfflineMode` drives its `online`/`offline` listeners through it and syncs only on a settled online state, so a train tunnel or a wifi handover no longer starts a sync that the next event interrupts — which is how the queue ended up never draining while burning a retry on each attempt. The hook now also exposes `isOnline` and `flushConnectivity`, and cancels any pending transition on unmount so a timer cannot fire against a torn-down service.

### #1177 — Deduplicate transactional emails by idempotency key

`src/lib/email/queue.ts`, `src/lib/email/index.ts`, new `src/lib/email/idempotency.ts`

`EmailQueue.enqueue` accepts an `idempotencyKey`; a second enqueue under the same key returns the first send's result rather than delivering again. Three details make it actually hold:

- **The key is registered before the send starts**, so two concurrent enqueues dedupe, not just sequential ones. Registering on completion would let a double-clicked button through.
- **A failed send releases its key.** A failure is not a delivery, and blocking the retry would turn a transient SMTP error into a password reset the user never receives.
- **Keys expire on a TTL** (24h by default) with `pruneIdempotencyCache` and `clearIdempotencyCache`, so the map is not an unbounded leak in a long-lived process.

`deriveIdempotencyKey` derives a key from message content for callers with nothing better to hand, normalising recipient order and case — those are not part of what the message *is*. Tags and `replyTo` are excluded for the same reason.

### #1178 — Validate email template variables at render time

`src/lib/email/templates.ts`, `src/lib/email/types.ts`

Required variables are extracted **from the templates themselves**, not a hand-maintained list, so a declared schema cannot drift away from what the template actually references. `getTemplate` now throws `MissingTemplateVariablesError` rather than rendering an unresolved placeholder as an empty string — a password-reset email whose link silently renders as nothing is worse than one never sent, because the user cannot tell it is broken.

- An empty or whitespace-only value counts as **missing**; it renders as nothing, which is the exact failure being guarded against.
- Zero and `false` count as **supplied** — `expiresInMinutes: 0` is a value, not an omission.
- Unused payload keys are reported alongside missing ones: `userName` passed to a template that wants `name` produces one missing and one unused entry, which is a far better clue than a blank space in the delivered mail.
- `allowMissing` keeps previews and tests able to render an incomplete payload.

The one existing caller (`hybridEvents`) supplies all five variables of the verification template, so nothing in the app starts throwing.

### #1181 — Validate cron expressions in the export scheduler

`src/lib/export-scheduler/cron-parser.ts`, `src/lib/export-scheduler/scheduler-service.ts`

`validateCron` returns every field-level reason an expression was rejected — field, offending value, and why — instead of a bare boolean, so a form can tell the user that `0 0 * * 9` has a `dayOfWeek` outside 0-7. Every field is checked rather than stopping at the first, so one save surfaces every mistake.

Parsing is now strict. `parseInt` stops at the first non-digit, so the previous validator read `"5x"` as `5` and accepted `0 0 5x * *` — an expression cron itself rejects. `7` is accepted as a second spelling of Sunday, as crontab does.

On the service side, `validateSchedule` exposes the check for the save path, and `queueExportJob` validates **before** enqueuing: queuing first and then failing to compute the next run leaves the schedule due forever, re-running the same export on every sweep. Each schedule is also isolated inside `checkDueSchedules` — a malformed expression previously threw out of `getNextRunTime` and aborted the loop, so one bad string stopped every *other* schedule from running too.

---

### A delivery bug found while adding dedupe

`EmailQueue.process` took the `resolve` of a single `enqueue` call and used it for whatever job it dequeued. With `maxConcurrent: 2` and two messages in flight, an enqueue could resolve with an unrelated message's result. Each job now carries its own resolver.

### Verification

```
vitest (touched files)   123 passed / 10 files
tsc --noEmit             clean
next lint --max-warnings=0   clean
validate:ui              passed (43 pre-existing warnings)
validate:web3            passed
next build               clean
```

Three suites fail on `main` for reasons unrelated to this branch and are untouched here: `services/offlineSync.test.ts` (the session gate added in 367328b is unsatisfied under test — fixed in the sibling PR for #1169/#1170), `services/certificate-service.test.ts`, and `services/serviceAccount.test.ts` (which needs `goerli.infura.io`). Worth noting for the CI test step: it runs `timeout 30s pnpm vitest run --coverage` and **exits 0 when the 30 seconds elapse**, so a slow or hanging suite reports success — on this machine `vitest run` on `main` did not finish at all, one worker sitting at 99% CPU for over six minutes.
