### PR TITLE
fix: thread actual row index to col.render in Table

### DIFF
--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -43,6 +43,7 @@ export interface TableProps<T> {
 interface TableRowProps<T> {
   row: T;
   rowId: string;
+  index: number;
   columns: ColumnDef<T>[];
   onRowClick?: (row: T) => void;
   onRowDoubleTap?: (row: T) => void;
@@ -58,6 +59,7 @@ interface TableRowProps<T> {
 function TableRow<T>({
   row,
   rowId,
+  index,
   columns,
   onRowClick,
   onRowDoubleTap,
@@ -229,7 +231,7 @@ function TableRow<T>({
               style={style}
             >
               {col.render
-                ? col.render(row, 0)
+                ? col.render(row, index)
                 : (row[col.key as keyof T] as unknown as React.ReactNode)}
             </div>
           );
@@ -532,13 +534,14 @@ export function Table<T>({
                 No data available
               </div>
             ) : (
-              pageItems.map((row) => {
+              pageItems.map((row, index) => {
                 const id = getRowId(row);
                 return (
                   <MemoizedTableRow
                     key={id}
                     row={row}
                     rowId={id}
+                    index={page * pageSize + index}
                     columns={columns}
                     onRowClick={onRowClick}
                     onRowDoubleTap={onRowDoubleTap}


### PR DESCRIPTION
Closes #1048 

Fixes an issue in `src/components/ui/Table.tsx` where `col.render` was hardcoded to always receive `0` as the row index. 

The row index is now properly threaded from the `Table` component down through `TableRow` into the `render` function. The threaded index correctly accounts for pagination by calculating the absolute index (`page * pageSize + index`), ensuring any column logic relying on the row index (like numbering or striping) works as expected across all rows and pages.