### PR TITLE
feat: Detect refresh-token reuse after rotation in auth verification

### DIFF
--- a/src/lib/auth/__tests__/refreshToken.test.ts
+++ b/src/lib/auth/__tests__/refreshToken.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  verifyRefreshToken,
+  signRefreshToken,
+  updateRotationSequence,
+  getLatestRotationSequence,
+  clearRotationSequenceStore,
+} from '../jwt';
+
+const SECRET = 'test-jwt-secret';
+const USER_ROLE = 'STUDENT' as const;
+
+function base64url(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+async function signRefreshTokenWithSecret(payload: Record<string, unknown>): Promise<string> {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const unsigned = `${header}.${body}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(unsigned));
+  const signatureB64 = btoa(String.fromCharCode(...new Uint8Array(signature)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+  return `${unsigned}.${signatureB64}`;
+}
+
+describe('Refresh token reuse detection', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = SECRET;
+    process.env.JWT_CLOCK_SKEW_MS = '5000';
+    clearRotationSequenceStore();
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    delete process.env.JWT_CLOCK_SKEW_MS;
+  });
+
+  describe('verifyRefreshToken', () => {
+    it('returns null for missing token', async () => {
+      const result = await verifyRefreshToken(null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('missing');
+    });
+
+    it('returns null for malformed token', async () => {
+      const result = await verifyRefreshToken('not-a-jwt');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('malformed');
+    });
+
+    it('rejects tokens with invalid signature', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      // Tamper with the token
+      const parts = token.split('.');
+      const tamperedToken = `${parts[0]}.dGVzdA.${parts[2]}`;
+      const result = await verifyRefreshToken(tamperedToken);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('bad_signature');
+    });
+
+    it('accepts valid refresh token with correct rotation sequence', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(true);
+      expect(result.payload).toBeDefined();
+      expect(result.payload?.family).toBe('family-1');
+      expect(result.payload?.rotationSequence).toBe(0);
+    });
+
+    it('rejects refresh token with reused rotation sequence', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      
+      // First token with sequence 0
+      const token1 = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      // Simulate successful refresh by updating sequence to 1
+      updateRotationSequence('family-1', 1);
+
+      // Try to use the old token (reuse attempt)
+      const result = await verifyRefreshToken(token1);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('refresh_token_reuse_detected');
+    });
+
+    it('accepts refresh token with current rotation sequence', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      
+      // Set up sequence at 0
+      updateRotationSequence('family-1', 0);
+
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects refresh token without family claim', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('malformed');
+    });
+
+    it('rejects refresh token without rotationSequence claim', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('malformed');
+    });
+
+    it('rejects expired refresh token', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 3600,
+        exp: nowSeconds - 10,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('expired');
+    });
+
+    it('rejects refresh token with invalid role', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: 'INVALID_ROLE',
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('invalid_role');
+    });
+  });
+
+  describe('rotation sequence management', () => {
+    it('tracks rotation sequences per family', () => {
+      updateRotationSequence('family-1', 0);
+      updateRotationSequence('family-2', 5);
+
+      expect(getLatestRotationSequence('family-1')).toBe(0);
+      expect(getLatestRotationSequence('family-2')).toBe(5);
+    });
+
+    it('returns -1 for unknown families', () => {
+      expect(getLatestRotationSequence('unknown-family')).toBe(-1);
+    });
+
+    it('updates existing sequence', () => {
+      updateRotationSequence('family-1', 0);
+      updateRotationSequence('family-1', 1);
+      updateRotationSequence('family-1', 2);
+
+      expect(getLatestRotationSequence('family-1')).toBe(2);
+    });
+
+    it('clears all sequences', () => {
+      updateRotationSequence('family-1', 0);
+      updateRotationSequence('family-2', 5);
+
+      clearRotationSequenceStore();
+
+      expect(getLatestRotationSequence('family-1')).toBe(-1);
+      expect(getLatestRotationSequence('family-2')).toBe(-1);
+    });
+  });
+
+  describe('signRefreshToken', () => {
+    it('creates a valid refresh token', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = await signRefreshTokenWithSecret({
+        sub: 'user-1',
+        role: USER_ROLE,
+        family: 'family-1',
+        rotationSequence: 0,
+        iat: nowSeconds,
+        exp: nowSeconds + 30 * 24 * 60 * 60,
+      });
+
+      const result = await verifyRefreshToken(token);
+      expect(result.valid).toBe(true);
+      expect(result.payload?.sub).toBe('user-1');
+      expect(result.payload?.role).toBe(USER_ROLE);
+      expect(result.payload?.family).toBe('family-1');
+      expect(result.payload?.rotationSequence).toBe(0);
+    });
+  });
+});

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -12,6 +12,18 @@ export interface JWTPayload {
   nbf?: number;
 }
 
+/**
+ * Refresh token payload with rotation sequence tracking for reuse detection.
+ * Each time a refresh token is used, the sequence number advances.
+ * If a token with an older sequence is used, it indicates reuse.
+ */
+export interface RefreshTokenPayload extends JWTPayload {
+  /** Unique identifier for this refresh token family (user/session). */
+  family: string;
+  /** Rotation sequence number - increments with each token refresh. */
+  rotationSequence: number;
+}
+
 /** Distinct reasons a token can fail verification, for logging/monitoring. */
 export type TokenFailureReason =
   | 'missing'
@@ -20,7 +32,8 @@ export type TokenFailureReason =
   | 'bad_signature'
   | 'expired'
   | 'not_yet_valid'
-  | 'invalid_role';
+  | 'invalid_role'
+  | 'refresh_token_reuse_detected';
 
 export interface TokenVerification {
   valid: boolean;
@@ -202,4 +215,120 @@ export async function verifyTokenDetailed(
   } catch {
     return { valid: false, reason: 'malformed' };
   }
+}
+
+/**
+ * Store for tracking the latest rotation sequence per refresh token family.
+ * In production, this should be backed by Redis or a database.
+ * Maps: family ID -> latest rotation sequence number.
+ */
+const rotationSequenceStore = new Map<string, number>();
+
+/**
+ * Update the stored rotation sequence for a token family.
+ * Called after a successful token refresh to record the new sequence.
+ */
+export function updateRotationSequence(family: string, sequence: number): void {
+  rotationSequenceStore.set(family, sequence);
+}
+
+/**
+ * Get the latest known rotation sequence for a token family.
+ * Returns -1 if no sequence has been stored for this family.
+ */
+export function getLatestRotationSequence(family: string): number {
+  return rotationSequenceStore.get(family) ?? -1;
+}
+
+/**
+ * Clear all stored rotation sequences (useful for testing).
+ */
+export function clearRotationSequenceStore(): void {
+  rotationSequenceStore.clear();
+}
+
+/**
+ * Verify a refresh token with reuse detection.
+ * Rejects tokens whose rotation sequence has already been superseded.
+ */
+export async function verifyRefreshToken(
+  token: string | undefined | null,
+): Promise<{ valid: boolean; payload?: RefreshTokenPayload; reason?: TokenFailureReason }> {
+  if (!token) return { valid: false, reason: 'missing' };
+
+  const secret = process.env.JWT_SECRET;
+  if (!secret) return { valid: false, reason: 'no_secret' };
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return { valid: false, reason: 'malformed' };
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  try {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify'],
+    );
+
+    const signatureBytes = base64UrlDecode(signatureB64).buffer as ArrayBuffer;
+    const dataToVerify = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+    const isValid = await crypto.subtle.verify('HMAC', key, signatureBytes, dataToVerify);
+    if (!isValid) return { valid: false, reason: 'bad_signature' };
+
+    const payload = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(payloadB64)),
+    ) as RefreshTokenPayload;
+
+    const nowSeconds = Date.now() / 1000;
+    const clockSkewSeconds = getClockSkewSeconds();
+    if (payload.exp && nowSeconds > payload.exp + clockSkewSeconds) {
+      return { valid: false, payload, reason: 'expired' };
+    }
+    if (payload.nbf && nowSeconds < payload.nbf - clockSkewSeconds) {
+      return { valid: false, payload, reason: 'not_yet_valid' };
+    }
+
+    const validRoles: UserRole[] = [
+      UserRole.ADMIN,
+      UserRole.INSTRUCTOR,
+      UserRole.STUDENT,
+      UserRole.GUEST,
+    ];
+    if (!validRoles.includes(payload.role)) {
+      return { valid: false, payload, reason: 'invalid_role' };
+    }
+
+    if (!payload.family) {
+      return { valid: false, payload, reason: 'malformed' };
+    }
+
+    if (typeof payload.rotationSequence !== 'number') {
+      return { valid: false, payload, reason: 'malformed' };
+    }
+
+    const latestSequence = getLatestRotationSequence(payload.family);
+    if (latestSequence > payload.rotationSequence) {
+      return { valid: false, payload, reason: 'refresh_token_reuse_detected' };
+    }
+
+    return { valid: true, payload };
+  } catch {
+    return { valid: false, reason: 'malformed' };
+  }
+}
+
+/**
+ * Sign a new refresh token with rotation sequence tracking.
+ */
+export async function signRefreshToken(
+  payload: Omit<RefreshTokenPayload, 'iat' | 'exp'>,
+): Promise<string> {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('30d')
+    .sign(getSecret());
 }

--- a/src/lib/authMiddleware.ts
+++ b/src/lib/authMiddleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { User, UserRole } from '@/types/api';
-import { verifyToken } from '@/lib/auth/jwt';
+import { verifyToken, verifyRefreshToken, updateRotationSequence } from '@/lib/auth/jwt';
 import { checkIdentityRateLimit, resetIdentityRateLimit } from '@/lib/ratelimit';
 
 /**
@@ -33,6 +33,53 @@ export async function requireAuth(request: NextRequest): Promise<NextResponse | 
   }
 
   return null;
+}
+
+/**
+ * Verify a refresh token with reuse detection.
+ * Returns a 401 response if the token is invalid or reused, or the verified payload if valid.
+ * Usage: const result = await verifyRefreshTokenAuth(request);
+ */
+export async function verifyRefreshTokenAuth(
+  request: NextRequest,
+): Promise<{ payload: null; response: NextResponse } | { payload: import('@/lib/auth/jwt').RefreshTokenPayload; response: null }> {
+  const body = await request.json().catch(() => ({}));
+  const refreshToken = (body as { refreshToken?: string }).refreshToken;
+
+  if (!refreshToken) {
+    return {
+      payload: null,
+      response: NextResponse.json({ message: 'Refresh token required' }, { status: 400 }),
+    };
+  }
+
+  const verification = await verifyRefreshToken(refreshToken);
+
+  if (!verification.valid || !verification.payload) {
+    const status = verification.reason === 'refresh_token_reuse_detected' ? 401 : 401;
+    return {
+      payload: null,
+      response: NextResponse.json(
+        {
+          message:
+            verification.reason === 'refresh_token_reuse_detected'
+              ? 'Refresh token reuse detected. Please log in again.'
+              : 'Invalid refresh token',
+        },
+        { status },
+      ),
+    };
+  }
+
+  return { payload: verification.payload, response: null };
+}
+
+/**
+ * Update the rotation sequence after a successful token refresh.
+ * Should be called after issuing new tokens to record the new sequence.
+ */
+export function updateRefreshTokenSequence(family: string, newSequence: number): void {
+  updateRotationSequence(family, newSequence);
 }
 
 /**


### PR DESCRIPTION
## Changes

- Add RefreshTokenPayload interface with family and rotationSequence fields for tracking token rotation
- Add verifyRefreshToken function with reuse detection that rejects tokens whose rotation sequence has been superseded
- Add rotation sequence tracking store for persisting family-sequence mappings
- Add updateRotationSequence and getLatestRotationSequence utility functions
- Add signRefreshToken function for creating tokens with rotation tracking
- Add verifyRefreshTokenAuth middleware for refresh token verification with reuse detection
- Add comprehensive unit tests for reuse detection (15 tests)

## Security Improvement

This change prevents refresh token replay attacks. When a refresh token is used to obtain new tokens, the rotation sequence advances. If an attacker attempts to reuse an old refresh token (after the legitimate user has rotated it), the verification will reject it with a refresh_token_reuse_detected reason.

## Files Modified

- src/lib/auth/jwt.ts - Added refresh token types, verification, and signing functions
- src/lib/authMiddleware.ts - Added refresh token verification middleware
- src/lib/auth/__tests__/refreshToken.test.ts - New test file with 15 tests

## Testing

All 15 refresh token tests pass. Existing JWT tests (12 tests) continue to pass. TypeScript compilation and linting pass without errors.

closes #1151 